### PR TITLE
Added latitude and longitude to address class 

### DIFF
--- a/lib/faker/address.rb
+++ b/lib/faker/address.rb
@@ -38,6 +38,14 @@ module Faker
       def state;         fetch('address.state');         end
       def country;       fetch('address.country');       end
 
+      def latitude
+        ((rand * 180) - 90).to_s
+      end
+
+      def longitude
+        ((rand * 360) - 180).to_s
+      end
+
       # You can add whatever you want to the locale file, and it will get 
       # caught here... e.g., create a country_code array in your locale, 
       # then you can call #country_code and it will act like #country


### PR DESCRIPTION
ruby-1.8.7-p302 > Faker::Address.latitude
 => "-60.4210881261435" 
ruby-1.8.7-p302 > Faker::Address.longitude
 => "16.7014001662163" 

I decided to get this to produce a string, rather than a float, as everything else in Faker produces a string. It's easy to convert anyway.
