### PR TITLE
Faker::lorem.characters

### DIFF
--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -4,6 +4,10 @@ module Faker
     def self.words(num = 3)
       I18n.translate('faker.lorem.words').shuffle[0, num]
     end
+    
+    def self.characters(char_count = 255)
+      rand(36**char_count).to_s(36)
+    end
 
     def self.sentence(word_count = 4)
       words(word_count + rand(6)).join(' ').capitalize + '.'


### PR DESCRIPTION
added Faker::Lorem.characters(char_count = 255) helpful for validating lengths...

```
validates_length_of :title, :maximum => 100, :message => "is too long"

it "should be invalid if title is greater than 100 characters" do
    @obj = FactoryGirl.build(:obj, :title => Faker::lorem.characters(101))
    @obj.valid?.should be_false
    @obj.errors.full_messages.should include("Title is too long")
end
```

This is much better than :title => "some stupid long string that makes me write out 101 characters manually..."
