### PR TITLE
Fallback to :en locale without using I18n::Backend::Fallbacks

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -6,7 +6,6 @@ rescue LoadError
 end
 
 require 'i18n'
-I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 I18n.load_path += Dir[File.join(mydir, 'locales', '*.yml')]
 I18n.reload!
 
@@ -35,7 +34,12 @@ module Faker
       # Helper for the common approach of grabbing a translation with an array
       # of values and selecting one of them
       def fetch(key)
-        I18n.translate("faker.#{key}").rand
+        candidates = begin
+          I18n.translate("faker.#{key}", :throw => true)
+        rescue
+          I18n.translate("faker.#{key}", :locale => :en)
+        end
+        candidates.rand
       end
     end
   end

--- a/lib/faker/address.rb
+++ b/lib/faker/address.rb
@@ -43,7 +43,12 @@ module Faker
       # then you can call #country_code and it will act like #country
       def method_missing(m, *args, &block)
         # Use the alternate form of translate to get a nil rather than a "missing translation" string
-        if translation = I18n.translate(:faker)[:address][m]
+        translation = begin
+          I18n.translate(:faker, :throw => true)[:address][m]
+        rescue
+          I18n.translate(:faker, :locale => :en)[:address][m]
+        end
+        if translation
           translation.respond_to?(:rand) ? translation.rand : translation
         else
           super

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -2,7 +2,12 @@ module Faker
   # Based on Perl's Text::Lorem
   class Lorem < Base
     def self.words(num = 3)
-      I18n.translate('faker.lorem.words').shuffle[0, num]
+      candidates = begin
+        I18n.translate('faker.lorem.words', :throw => true)
+      rescue
+        I18n.translate('faker.lorem.words', :locale => :en)
+      end
+      candidates.shuffle[0, num]
     end
 
     def self.sentence(word_count = 4)


### PR DESCRIPTION
In my app where `I18n.locale = :ja`, I see a lot of "`translation missing:`" Strings when calling Faker.
It seems Faker uses `I18n::Backend::Fallbacks` but it doesn't work in my case.
Anyway, including `I18n::Backend::Fallbacks` to the global `I18n` constant should be avoided in this case because it may change the behavior of users' application.
With this patch, `I18n.t` invocations automatically falls back to `:en` locale, without relying on `I18n::Backend::Fallbacks`.
