### PR TITLE
changed IPv4 generator a bit

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -34,7 +34,7 @@ module Faker
       end
       
       def ip_v4_address
-        ary = (2..255).to_a
+        ary = (2..254).to_a
         [ary.rand,
         ary.rand,
         ary.rand,


### PR DESCRIPTION
255 number for an IP address has to be used with caution (at the end, it's the broadcast address for a subnetwork for example).
So the easiest is not to use it.
