### PR TITLE
safe_email

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -10,6 +10,10 @@ module Faker
         [ user_name(name), fetch('internet.free_email') ].join('@')
       end
       
+      def safe_email(name = nil)
+        [user_name(name), 'example.'+ %w[org com net].shuffle.first].join('@')
+      end
+      
       def user_name(name = nil)
         return name.scan(/\w+/).shuffle.join(%w(. _).sample).downcase if name
         

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -14,6 +14,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
   end
   
+  def test_safe_email
+    assert @tester.safe_email.match(/.+@example.(com|net|org)/)
+  end
+  
   def test_user_name
     assert @tester.user_name.match(/[a-z]+((_|\.)[a-z]+)?/)
   end


### PR DESCRIPTION
Hi,
I have added safe_email method to Internet class which generate email from @example.{com, net, org} domain. 
Idea behind that is too ensure safe emails to be generate, so that no user will be sent email by mistake. According to RFC 2606 'example' domain will never be used, so emails from that domain also.
