### PR TITLE
Upgraded i18n dependency and fixed options passed to translate

### DIFF
--- a/faker.gemspec
+++ b/faker.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |s|
   s.homepage    = "http://faker.rubyforge.org"
   s.summary     = %q{Easily generate fake data}
   s.description = %q{Faker, a port of Data::Faker from Perl, is used to easily generate fake data: names, addresses, phone numbers, etc.}
-  
+
   s.rubyforge_project = "faker"
 
-  s.add_dependency('i18n', '~> 0.4')
+  s.add_dependency('i18n', '~> 0.5')
 
   s.files         = `git ls-files -- lib/*`.split("\n") + %w(History.txt License.txt README.md)
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -66,9 +66,9 @@ module Faker
       def translate(*args)
         opts = args.last.is_a?(Hash) ? args.pop : {}
         opts[:locale] ||= Faker::Config.locale
-        opts[:throw] = true
+        opts[:raise] = true
         I18n.translate(*(args.push(opts)))
-      rescue
+      rescue I18n::MissingTranslationData => e
         # Super-simple fallback -- fallback to en if the
         # translation was missing.  If the translation isn't
         # in en either, then it will raise again.


### PR DESCRIPTION
Hey Stympy,

The argument for raising an error being passed to I18n.translate are no longer supported. The test was not catching the error because a different exception than TranslationMissing was being raised. We reduced the rescue to only respond to MissingTranslation exception, which would be saved by the :en translation. We updated the gemspec accordingly to reflect the new dependency on I18n version 0.5.0

The documentation for the exception option is here:
http://guides.rubyonrails.org/i18n.html#using-different-exception-handlers
