### PR TITLE
Fixed loading locales

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -17,7 +17,7 @@ module Faker
     class << self
       attr_writer :locale
       def locale
-        @locale || I18n.locale
+        @locale || I18n.locale.downcase
       end
     end
   end


### PR DESCRIPTION
I'm from Brazil, and Rails returns :"pt-BR" when I ask `I18n.locale`. However in faker's code, all the locales are downcased (e.g :"pt-br"). That was causing my locale in faker to not be loaded correctly (and I guess other people that have an "-" in the locale suffer from that too.

By adding the `downcase` method fixes that issue.

All the tests are still passing. 
