### PR TITLE
Fix uk_county to return a country

### DIFF
--- a/lib/faker/address.rb
+++ b/lib/faker/address.rb
@@ -45,7 +45,7 @@ module Faker
       alias_method :us_state, :state
       alias_method :us_state_abbr, :state_abbr
       alias_method :uk_postcode, :zip_code
-      def uk_county; county; end
+      def uk_county; country; end
 
     end
   end


### PR DESCRIPTION
The Faker::Address.uk_county calls an undefined county variable. It seems like it should actually return a countRy, not a county.
