### PR TITLE
Allow Internet.user_name to take separators as parameter

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -14,15 +14,15 @@ module Faker
         [user_name(name), 'example.'+ %w[org com net].shuffle.first].join('@')
       end
       
-      def user_name(name = nil)
-        return name.scan(/\w+/).shuffle.join(%w(. _).sample).downcase if name
+      def user_name(name = nil, separators = %w(. _))
+        return name.scan(/\w+/).shuffle.join(separators.sample).downcase if name
         
         fix_umlauts([ 
           Proc.new { Name.first_name.gsub(/\W/, '').downcase },
           Proc.new { 
             [ Name.first_name, Name.last_name ].map {|n| 
               n.gsub(/\W/, '')
-            }.join(%w(. _).sample).downcase }
+            }.join(separators.sample).downcase }
         ].sample.call)
       end
       


### PR DESCRIPTION
Allow separators to be specified as a parameter for the username. In case your usernames have to adhere to certain constraints.
