### PR TITLE
Correct the locale code for Norwegian Bokmål.

### DIFF
--- a/lib/locales/nb-no.yml
+++ b/lib/locales/nb-no.yml
@@ -1,5 +1,5 @@
 # coding: utf-8
-no-nb:
+nb-no:
   faker:
     address:
       city_root: ["Fet", "Gjes", "Høy", "Inn", "Fager", "Lille", "Lo", "Mal", "Nord", "Nær", "Sand", "Sme", "Stav", "Stor", "Tand", "Ut", "Vest"]


### PR DESCRIPTION
Norway has two written languages (nn and nb), so one would assume that
the locale is no (Norway) with a modifier to specify which written
language.

Unfortunately, this is incorrect. The written languages have two
separate origins, so they each have a locale code, and the modifier is
the country.

This is in contrast to English, which is considered a single language
with regional modifiers (UK, AU, US, etc).
