### PR TITLE
improve on uk-postcode regex

### DIFF
--- a/lib/locales/en-gb.yml
+++ b/lib/locales/en-gb.yml
@@ -1,7 +1,7 @@
 en-gb:
   faker:
     address:
-      postcode: /[A-PR-UWYZ0-9][A-HK-Y0-9][AEHMNPRTVXY0-9]?[ABEHMNPRVWXY0-9]? {1,2}[0-9][ABD-HJLN-UW-Z]{2}/
+      postcode: /[A-PR-UWYZ][A-HK-Y]?[0-9][ABEHMNPRVWXY0-9]?\s{1,2}[0-9][ABD-HJLN-UW-Z]{2}/
       county: [Avon, Bedfordshire, Berkshire, Borders, Buckinghamshire, Cambridgeshire, Central, Cheshire, Cleveland, Clwyd, Cornwall, County Antrim, County Armagh, County Down, County Fermanagh, County Londonderry, County Tyrone, Cumbria, Derbyshire, Devon, Dorset, Dumfries and Galloway, Durham, Dyfed, East Sussex, Essex, Fife, Gloucestershire, Grampian, Greater Manchester, Gwent, Gwynedd County, Hampshire, Herefordshire, Hertfordshire, Highlands and Islands, Humberside, Isle of Wight, Kent, Lancashire, Leicestershire, Lincolnshire, Lothian, Merseyside, Mid Glamorgan, Norfolk, North Yorkshire, Northamptonshire, Northumberland, Nottinghamshire, Oxfordshire, Powys, Rutland, Shropshire, Somerset, South Glamorgan, South Yorkshire, Staffordshire, Strathclyde, Suffolk, Surrey, Tayside, Tyne and Wear, Warwickshire, West Glamorgan, West Midlands, West Sussex, West Yorkshire, Wiltshire, Worcestershire]
       uk_country: [England, Scotland, Wales, Northern Ireland]
       default_country: [England, Scotland, Wales, Northern Ireland]


### PR DESCRIPTION
the previous uk postcode regex would generate invalid postcode like
12AB 12AB
ABAB 12AB
...

so just slightly improved it, so it should generate better uk postcode
