### PR TITLE
Fix Australian mobile phone number formats

### DIFF
--- a/lib/locales/en-au.yml
+++ b/lib/locales/en-au.yml
@@ -19,4 +19,4 @@ en-au:
       street_suffix: [Avenue, Boulevard, Circle, Circuit, Court, Crescent, Crest, Drive, Estate Dr, Grove, Hill, Island, Junction, Knoll, Lane, Loop, Mall, Manor, Meadow, Mews, Parade, Parkway, Pass, Place, Plaza, Ridge, Road, Run, Square, Station St, Street, Summit, Terrace, Track, Trail, View Rd, Way]
       default_country: [Australia]
     phone_number:
-      formats: ['0# #### ####', '+61 # #### ####', '04## #### ####', '+61 4## #### ####'] #iOS AUS phone formats
+      formats: ['0# #### ####', '+61 # #### ####', '04## ### ###', '+61 4## ### ###'] #iOS AUS phone formats


### PR DESCRIPTION
Australian mobile phone numbers have 10 digits not 12. When the country code is included you simply remove the 0 before the area code (4). Examples:

```
normal:                    0411 222 333
including country code: +61 411 222 333
```
