### PR TITLE
Fixes power reversal bug in Faker::Number

### DIFF
--- a/lib/faker/number.rb
+++ b/lib/faker/number.rb
@@ -2,7 +2,7 @@ module Faker
   class Number < Base
     class << self
       def number(digits)
-        rand(digits ** 10 - 1).to_s.center(digits, rand(9).to_s)
+        rand(10 ** digits - 1).to_s.center(digits, rand(9).to_s)
       end
 
       def digit

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -5,11 +5,14 @@ class TestFakerNumber < Test::Unit::TestCase
   def setup
     @tester = Faker::Number
   end
-  
+
   def test_number
-    assert @tester.number(10).match(/[0-9]{10}/)
+    10.times do |digits|
+      digits += 1
+      assert @tester.number(digits).match(/^[0-9]{#{digits}}$/)
+    end
   end
-  
+
   def test_digit
     assert @tester.digit.match(/[0-9]{1}/)
   end


### PR DESCRIPTION
Faker::Number#number returns incorrect values; the issue is that the power calculation to get a range for `rand` has the base and exponent reversed.
