### PR TITLE
Make number of digits not incorrect anymore in Faker::Number.number

### DIFF
--- a/lib/faker/number.rb
+++ b/lib/faker/number.rb
@@ -2,7 +2,7 @@ module Faker
   class Number < Base
     class << self
       def number(digits)
-        rand(digits ** 10 - 1).to_s.center(digits, rand(9).to_s)
+        rand(10 ** digits - 1).to_s.center(digits, rand(9).to_s)
       end
 
       def digit
@@ -11,3 +11,4 @@ module Faker
     end
   end
 end
+


### PR DESCRIPTION
Fixes digit count in Faker::Number.number: 10 *\* x != x *\* 10
