### PR TITLE
Not necessary to call I18n.reload! after setting load path, since it's called by the ActiveSupport i18n_railtie.

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -7,7 +7,6 @@ end
 
 require 'i18n'
 I18n.load_path += Dir[File.join(mydir, 'locales', '*.yml')]
-I18n.reload!
 
 
 module Faker


### PR DESCRIPTION
I have 200 gems in my app, many of them which use I18n and I don't see any others calling `I18n.reload!` after setting load path
