### PR TITLE
Don't recommend installing gem with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ development.
 Installing
 ----------
 ```bash
-sudo gem install faker
+gem install faker
 ```
 
 Usage


### PR DESCRIPTION
Since gems can execute arbitrary code, installing with sudo [can get dangerous](https://github.com/wmorgan/killergem) if anyone manages to hijack this gem or one if it's dependencies on RubyGems.

If a user _wants_ to install with sudo, they certainly can, and then they are assuming all the risk by being explicit. But it should not be recommended.

See also: http://masanjin.net/blog/sudo-gem-install-considered-harmful
