### PR TITLE
Added international IBAN generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,13 @@ PATH
   specs:
     faker (1.3.0)
       i18n (~> 0.5)
+      iso-iban (~> 0.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    i18n (0.6.5)
+    i18n (0.6.9)
+    iso-iban (0.1.2)
     rake (10.1.0)
     test-unit (2.5.5)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Faker
 =====
-This gem is a port of Perl's Data::Faker library that generates fake data.  
+This gem is a port of Perl's Data::Faker library that generates fake data.
 
 It comes in very handy for taking screenshots (taking screenshots for my
 project, [Catch the Best](http://catchthebest.com/) was the original impetus
@@ -82,6 +82,11 @@ Faker::Business.credit_card_number #=> "1228-1221-1221-1431"
 Faker::Business.credit_card_expiry_date #=> <Date: 2015-11-11 ((2457338j,0s,0n),+0s,2299161j)>
 
 Faker::Business.credit_card_type #=> "visa"
+
+# Optional argument iso_country_code=nil
+Faker::Business.iban #=> "SE9520669868630320226589"
+
+Faker::Business.iban('CH') #=> "CH5869160ECu8YVVfIRQA"
 
 ```
 

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "faker"
 
   s.add_dependency('i18n', '~> 0.5')
+  s.add_dependency('iso-iban', '~> 0.1')
 
   s.files         = `git ls-files -- lib/*`.split("\n") + %w(History.txt License.txt README.md)
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/faker/business.rb
+++ b/lib/faker/business.rb
@@ -1,4 +1,5 @@
 require 'date'
+require 'iso/iban'
 
 module Faker
   class Business < Base
@@ -8,15 +9,20 @@ module Faker
       def credit_card_number
         fetch('business.credit_card_numbers')
       end
-      
+
       def credit_card_expiry_date
         Date.parse(fetch('business.credit_card_expiry_dates'))
       end
-      
+
       def credit_card_type
         fetch('business.credit_card_types')
       end
+
+      def iban(iso_country_code = nil)
+        iban = iso_country_code ? ISO::IBAN.random(iso_country_code) : ISO::IBAN.random
+        iban.compact
+      end
     end
-    
+
   end
 end


### PR DESCRIPTION
Generate an IBAN code.

Without define a country, it uses a random one
`Faker::Business.iban #=> "SE9520669868630320226589"`
With a specified 2-letter iso country code
`Faker::Business.iban('CH') #=> "CH5869160ECu8YVVfIRQA"`
