### PR TITLE
Add a rut (rol unico tributario) generator

### DIFF
--- a/lib/faker/code.rb
+++ b/lib/faker/code.rb
@@ -7,6 +7,12 @@ module Faker
         base == 13 ? generate_base13_isbn : generate_base10_isbn
       end
 
+      def rut
+        value = Number.number(8)
+        vd = rut_verificator_digit(value)
+        value << "-#{vd}"
+      end
+
     private
 
       def generate_base10_isbn
@@ -25,6 +31,11 @@ module Faker
         values.split(//).each_with_index.inject(0) do |sum, (value, index)|
           sum + block.call(value, index)
         end
+      end
+
+      def rut_verificator_digit(rut)
+        total = rut.to_s.rjust(8, '0').split(//).zip(%w(3 2 7 6 5 4 3 2)).collect{|a, b| a.to_i * b.to_i}.inject(:+)
+        (11 - total % 11).to_s.gsub(/10/, 'k').gsub(/11/, '0')
       end
     end
   end

--- a/test/test_faker_code.rb
+++ b/test/test_faker_code.rb
@@ -12,4 +12,8 @@ class TestFakerCode < Test::Unit::TestCase
   def test_default_isbn13_regexp
     assert @tester.isbn(13).match(/^\d{12}-\d$/)
   end
+
+  def test_rut
+    assert @tester.rut.match(/^\d{1,8}-(\d|k)$/)
+  end
 end


### PR DESCRIPTION
In Chile we have an unique ID called RUT (Rol Único Tributario). It's something like: 

```
14635292-8
```

I don't know if I should add it to the documentation or some kind of locale. At least it would be useful to us :P.
