### PR TITLE
Added a company logo generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Faker::Company.bs #=> "empower one-to-one web-readiness"
 
 Faker::Company.duns_number #=> "08-341-3736"
 
+# Get a random company logo url in GIF format.
+Faker::Company.logo #=> "http://www.biz-logo.com/examples/007.gif"
+
 ```
 
 

--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -24,6 +24,12 @@ module Faker
       def duns_number
         ('%09d' % rand(10 ** 9)).gsub(/(\d\d)(\d\d\d)(\d\d\d\d)/, '\\1-\\2-\\3')
       end
+
+      # Get a random company logo url in GIF format.
+      def logo
+        rand_num = Random.rand(76) + 1
+        "http://www.biz-logo.com/examples/#{ rand_num < 10 ? "00" : "0" }#{rand_num}.gif"
+      end
     end
 
   end

--- a/test/test_faker_company.rb
+++ b/test/test_faker_company.rb
@@ -8,4 +8,11 @@ class TestFakerCompany < Test::Unit::TestCase
   def test_duns_number
     assert @tester.duns_number.match(/\d\d-\d\d\d-\d\d\d\d/)
   end
+
+  require "open-uri"
+  def test_logo
+    open("#{ @tester.logo }") do |f|
+	  assert f.readline.include?("GIF")
+	end
+  end
 end


### PR DESCRIPTION
Based on a need in one of my projects, I thought a great Faker feature would be the ability to get random logo URLs for companies. Logos are in GIF format. I've implemented `Faker::Company.logo`, wrote (passing) tests, and updated README... all while abiding by contribution guidelines of course :)
