### PR TITLE
refactored I18 enforce_available_locales method to support Rails 3.2.x

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -7,7 +7,7 @@ rescue LoadError
 end
 
 require 'i18n'
-I18n.enforce_available_locales = true
+defined? I18n.enforce_available_locales = true
 I18n.load_path += Dir[File.join(mydir, 'locales', '*.yml')]
 
 


### PR DESCRIPTION
Simply refactor to support older versions of Rails.
