### PR TITLE
update Config.locale example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Faker::PhoneNumber.cell_phone #=> "(186)285-7925"
 
 # NOTE NOTE NOTE NOTE
 # For the 'US only' methods below, first you must do the following:
-Faker::Config.locale = 'en-us'
+Faker::Config.locale = 'en-US'
 
 # US only
 Faker::PhoneNumber.area_code #=> "201"


### PR DESCRIPTION
The current example in the README is invalid. The actual local file is en-US, not en-us. So when en-us is used, an I18n::InvalidLocale error is thrown.
