### PR TITLE
Use SecureRandom to generate bitcoin address

### DIFF
--- a/lib/faker/bitcoin.rb
+++ b/lib/faker/bitcoin.rb
@@ -1,11 +1,12 @@
 require 'digest'
+require 'securerandom'
 
 module Faker
   class Bitcoin < Base
     class << self
 
       def address
-        hash = rand(2**160).to_s(16)
+        hash = SecureRandom.hex(20)
         version = 0
         packed = version.chr + [hash].pack("H*")
         checksum = Digest::SHA2.digest(Digest::SHA2.digest(packed))[0..3]


### PR DESCRIPTION
My tests using Faker::Bitcoin are failing sometimes, because from time to time Faker::Bitcoin.address returns same bitcoin_address more that once.

Using secure random to generate bitcoin address fixes this problem.
