### PR TITLE
Adding Faker::Avatar.image to README to expose it better

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,22 @@ Faker::Name.title #=> "Legacy Creative Director"
 
 ```
 
+###Faker::Avatar
+----------------
+
+```ruby
+
+Faker::Avatar.image #=> "http://robohash.org/sitsequiquia.png?size=300x300"
+
+Faker::Avatar.image("my-own-slug") #=> "http://robohash.org/my-own-slug.png?size=300x300"
+
+Faker::Avatar.image("my-own-slug", "50x50") #=> "http://robohash.org/my-own-slug.png?size=50x50"
+
+Faker::Avatar.image("my-own-slug", "50x50", "jpg") #=> "http://robohash.org/my-own-slug.jpg?size=50x50"
+
+Faker::Avatar.image("my-own-slug", "50x50", "bmp") #=> "http://robohash.org/my-own-slug.bmp?size=50x50"
+```
+
 ###Faker::Number
 ----------------
 


### PR DESCRIPTION
It was not obvious to me that Faker has 'Faker::Avatar.image' available to generate urls with nice faked avatars. I had to look into the source code of the gem to find out about it. I bet other people will benefit from seeing it right in the README. 
