### PR TITLE
Add Faker::Date.weekday_between

### DIFF
--- a/doc/default/date.md
+++ b/doc/default/date.md
@@ -20,4 +20,7 @@ Faker::Date.backward(days: 14) #=> "Fri, 19 Sep 2014"
 # Random birthday date (maximum age between 18 and 65)
 # Keyword arguments: min_age, max_age
 Faker::Date.birthday(min_age: 18, max_age: 65) #=> "Mar, 28 Mar 1986"
+
+# Random weekday between dates
+Faker::Date.weekday_between(:saturday, from: '2019-08-01', to: '2019-08-31') #=> "Sat, 17 Aug 2019"
 ```

--- a/lib/faker/default/date.rb
+++ b/lib/faker/default/date.rb
@@ -87,6 +87,20 @@ module Faker
         between(from: from, to: to).to_date
       end
 
+      def weekday_between(wday_name, from:, to:)
+        from = get_date_object(from)
+        to   = get_date_object(to)
+        wday = ::Date::DAYNAMES.index(wday_name.capitalize.to_s)
+
+        raise ArgumentError, "No such weekday \"#{wday_name}\"" if wday.nil?
+        raise ArgumentError, "Date interval does not contain any #{wday_name}" unless wday_present_on_interval?(wday, from, to)
+
+        loop do
+          date = Faker::Base.rand_in_range(from, to)
+          break date.to_date if wday == date.wday
+        end
+      end
+
       private
 
       def birthday_date(date, age)
@@ -106,6 +120,12 @@ module Faker
         date = ::Date.parse(date) if date.is_a?(::String)
         date = date.to_date if date.respond_to?(:to_date)
         date
+      end
+
+      def wday_present_on_interval?(wday, from, to)
+        return true if (from - to).abs >= 6
+
+        (from..to).to_a.map(&:wday).include?(wday)
       end
     end
   end

--- a/test/faker/default/test_faker_date.rb
+++ b/test/faker/default/test_faker_date.rb
@@ -169,7 +169,7 @@ class TestFakerDate < Test::Unit::TestCase
     end
   end
 
-  def test_weekday_between_on_exluding_interval
+  def test_weekday_between_on_excluding_interval
     from = Date.parse('2020-11-19')
     to   = Date.parse('2020-11-22')
 

--- a/test/faker/default/test_faker_date.rb
+++ b/test/faker/default/test_faker_date.rb
@@ -144,4 +144,43 @@ class TestFakerDate < Test::Unit::TestCase
       assert birthday < birthdate_max, "Expect < \"#{birthdate_max}\", but got #{birthday}"
     end
   end
+
+  def test_weekday_between
+    from = Date.parse('2020-01-01')
+    to   = Date.parse('2020-12-31')
+
+    100.times do
+      wday = Date::DAYNAMES.sample
+
+      random_date = @tester.weekday_between(wday, from: from, to: to)
+      assert_not_nil random_date
+      assert random_date.wday == Date::DAYNAMES.index(wday), "Expected == \"#{wday}\", but got #{random_date.wday}"
+    end
+  end
+
+  def test_weekday_between_with_wrong_name
+    from = Date.parse('2020-01-01')
+    to   = Date.parse('2020-12-31')
+
+    wday = 'Sundy'
+
+    assert_raise ArgumentError, 'No such weekday "Sundy"' do
+      @tester.weekday_between(wday, from: from, to: to)
+    end
+  end
+
+  def test_weekday_between_on_exluding_interval
+    from = Date.parse('2020-11-19')
+    to   = Date.parse('2020-11-22')
+
+    assert_raise ArgumentError do
+      @tester.weekday_between(:friday, from, to)
+    end
+    assert_raise ArgumentError do
+      @tester.weekday_between(:saturday, from, to)
+    end
+    assert_raise ArgumentError do
+      @tester.weekday_between(:sunday, from, to)
+    end
+  end
 end


### PR DESCRIPTION
Sometimes it's good to be able to randomly generate specified weekdays if you have a weekday dependent behaviour such as timetables, schedules, price policies etc.

...or if you searching for a day to visit your grandma using `irb` console
Get me random Saturday please:
```ruby
Faker::Date.weekday_between(:saturday, '2018-11-01', '2018-12-31')
 => #<Date: 2018-12-08 ((2458461j,0s,0n),+0s,2299161j)>
```