### PR TITLE
Fix documentation on Faker::Ethereum (#1004)

### DIFF
--- a/doc/unreleased/blockchain/ethereum.md
+++ b/doc/unreleased/blockchain/ethereum.md
@@ -3,5 +3,5 @@
 Available since version 1.9.0.
 
 ```ruby
-Faker::Blockchain::Ethereum.address #=> "c38bbc8e93c09f6ed3fe39b5135da91ad1a99d397ef16948606cdcbd14929f9d"
+Faker::Blockchain::Ethereum.address #=> "0xd392b0c0500700d02d27ab30805ec80ddd3320ff"
 ```

--- a/doc/v1.9.1/ethereum.md
+++ b/doc/v1.9.1/ethereum.md
@@ -3,5 +3,5 @@
 Available since version 1.9.0.
 
 ```ruby
-Faker::Ethereum.address #=> "c38bbc8e93c09f6ed3fe39b5135da91ad1a99d397ef16948606cdcbd14929f9d"
+Faker::Ethereum.address #=> "0xd392b0c0500700d02d27ab30805ec80ddd3320ff"
 ```

--- a/doc/v1.9.2/blockchain/ethereum.md
+++ b/doc/v1.9.2/blockchain/ethereum.md
@@ -3,5 +3,5 @@
 Available since version 1.9.0.
 
 ```ruby
-Faker::Blockchain::Ethereum.address #=> "c38bbc8e93c09f6ed3fe39b5135da91ad1a99d397ef16948606cdcbd14929f9d"
+Faker::Blockchain::Ethereum.address #=> "0xd392b0c0500700d02d27ab30805ec80ddd3320ff"
 ```


### PR DESCRIPTION
The eth address in the example result is invalid.

```js
> web3.utils.isAddress("c38bbc8e93c09f6ed3fe39b5135da91ad1a99d397ef16948606cdcbd14929f9d")
false
> web3.utils.isAddress("0xd392b0c0500700d02d27ab30805ec80ddd3320ff")
true
```

```ruby
irb(main):002:0> Faker::Ethereum.address
=> "0xd392b0c0500700d02d27ab30805ec80ddd3320ff"
```