### PR TITLE
Return a value based on the arguments of max and min length

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -223,6 +223,10 @@ module Faker
         @unique ||= UniqueGenerator.new(self, max_retries)
       end
 
+      def limit(min = 0, max = 100, max_retries = 10_000)
+        @limit ||= LimitGenerator.new(self, min, max, max_retries)
+      end
+
       def sample(list)
         list.respond_to?(:sample) ? list.sample(random: Faker::Config.random) : list
       end

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -223,8 +223,8 @@ module Faker
         @unique ||= UniqueGenerator.new(self, max_retries)
       end
 
-      def limit(min = 0, max = 100, max_retries = 10_000)
-        @limit ||= LimitGenerator.new(self, min, max, max_retries)
+      def limit(min = 0, max = 10, max_retries = 10_000)
+        LimitGenerator.new(self, min, max, max_retries)
       end
 
       def sample(list)

--- a/lib/helpers/limit_generator.rb
+++ b/lib/helpers/limit_generator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Faker
+    class LimitGenerator
+      def initialize(generator, max, min, max_retries)
+        @generator = generator
+        @max = max
+        @min = min
+        @max_retries = max_retries
+        @previous_results = Hash.new { |hash, key| hash[key] = Set.new }
+      end
+  
+      # rubocop:disable Style/MethodMissingSuper
+      def method_missing(name, *arguments)
+        self.class.marked_unique.add(self)
+  
+        @max_retries.times do
+          result = @generator.public_send(name, *arguments)
+  
+          next if result.length < @min || result.length > @max
+
+          return result
+        end
+  
+        raise RetryLimitExceeded, "Retry limit exceeded for #{name}"
+      end
+      # rubocop:enable Style/MethodMissingSuper
+  
+      def respond_to_missing?(method_name, include_private = false)
+        method_name.to_s.start_with?('faker_') || super
+      end
+  
+      RetryLimitExceeded = Class.new(StandardError)
+    end
+  end
+  

--- a/lib/helpers/limit_generator.rb
+++ b/lib/helpers/limit_generator.rb
@@ -1,36 +1,32 @@
 # frozen_string_literal: true
 
 module Faker
-    class LimitGenerator
-      def initialize(generator, max, min, max_retries)
-        @generator = generator
-        @max = max
-        @min = min
-        @max_retries = max_retries
-        @previous_results = Hash.new { |hash, key| hash[key] = Set.new }
-      end
-  
-      # rubocop:disable Style/MethodMissingSuper
-      def method_missing(name, *arguments)
-        self.class.marked_unique.add(self)
-  
-        @max_retries.times do
-          result = @generator.public_send(name, *arguments)
-  
-          next if result.length < @min || result.length > @max
-
-          return result
-        end
-  
-        raise RetryLimitExceeded, "Retry limit exceeded for #{name}"
-      end
-      # rubocop:enable Style/MethodMissingSuper
-  
-      def respond_to_missing?(method_name, include_private = false)
-        method_name.to_s.start_with?('faker_') || super
-      end
-  
-      RetryLimitExceeded = Class.new(StandardError)
+  class LimitGenerator
+    def initialize(generator, min, max, max_retries)
+      @generator = generator
+      @min = min
+      @max = max
+      @max_retries = max_retries
     end
+
+    # rubocop:disable Style/MethodMissingSuper
+    def method_missing(name, *arguments)
+      @max_retries.times do
+        result = @generator.public_send(name, *arguments)
+
+        next if result.length < @min || result.length > @max
+
+        return result
+      end
+
+      raise RetryLimitExceeded, "Retry limit exceeded for #{name}"
+    end
+    # rubocop:enable Style/MethodMissingSuper
+
+    def respond_to_missing?(method_name, include_private = false)
+      method_name.to_s.start_with?('faker_') || super
+    end
+
+    RetryLimitExceeded = Class.new(StandardError)
   end
-  
+end

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -123,4 +123,13 @@ class TestFaker < Test::Unit::TestCase
 
     assert_equal(unique_numbers.uniq, unique_numbers)
   end
+
+  def test_limit
+    10.times do
+      assert_operator Faker::Name.limit.name.length, :<=, 10
+      assert_operator Faker::Name.limit.name.length, :>=, 0
+      assert_operator Faker::Name.limit(10, 20).name.length, :<=, 20
+      assert_operator Faker::Name.limit(10, 20).name.length, :>=, 10
+    end
+  end
 end


### PR DESCRIPTION
This PR is focused on resolving https://github.com/stympy/faker/issues/469.

It introduces `limit` method which you can limit the length of the value returned.

You can use it like that: `Faker::Name.limit(10, 20).name`

It just gives support for string returns.