### PR TITLE
Upgrade i18n

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     faker (2.1.0)
-      i18n (>= 0.7)
+      i18n (>= 0.8)
 
 GEM
   remote: https://rubygems.org/

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary     = 'Easily generate fake data'
   spec.description = 'Faker, a port of Data::Faker from Perl, is used to easily generate fake data: names, addresses, phone numbers, etc.'
-  spec.homepage    = 'https://github.com/stympy/faker'
+  spec.homepage    = 'https://github.com/faker-ruby/faker'
   spec.license     = 'MIT'
 
   spec.files         = Dir['lib/**/*'] + %w[History.md License.txt CHANGELOG.md README.md]
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3'
 
-  spec.metadata['changelog_uri'] = 'https://github.com/stympy/faker/blob/master/CHANGELOG.md'
-  spec.metadata['source_code_uri'] = 'https://github.com/stympy/faker'
-  spec.metadata['bug_tracker_uri'] = 'https://github.com/stympy/faker/issues'
+  spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/master/CHANGELOG.md'
+  spec.metadata['source_code_uri'] = 'https://github.com/faker-ruby/faker'
+  spec.metadata['bug_tracker_uri'] = 'https://github.com/faker-ruby/faker/issues'
 
   spec.add_dependency('i18n', '>= 0.8')
 

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/stympy/faker'
   spec.metadata['bug_tracker_uri'] = 'https://github.com/stympy/faker/issues'
 
-  spec.add_dependency('i18n', '>= 0.7')
+  spec.add_dependency('i18n', '>= 0.8')
 
   spec.add_development_dependency('minitest', '5.11.3')
   spec.add_development_dependency('pry', '0.12.2')


### PR DESCRIPTION
Issue# 
------
Through `bundler-audit`, I see that the `i18` has fix a security vulnerability, that has been fixed in the 0.8 version 

Description:
------
i18n Gem for Ruby lib/i18n/core_ext/hash.rb Hash#slice() Function Hash Handling DoS

This address CVE-2014-10077

For more information:
  * https://github.com/ruby-i18n/i18n/pull/289
