### PR TITLE
Update issue url in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Issue#
 
 Example:
 
-https://github.com/stympy/faker/issues/XXX
+https://github.com/faker-ruby/faker/issues/XXX
 
 OR
 


### PR DESCRIPTION
Hi, everyone 👋

Just a minor update in PULL_REQUEST_TEMPLATE.md.
I think it looks better for contributors who don't know #1645 

from 

> https://github.com/stympy/faker/issues/XXX

to 

> https://github.com/faker-ruby/faker/issues/XXX

