### PR TITLE
Add Bibles class with King James subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
   - [Faker::Verbs](doc/default/verbs.md)
   - [Faker::WorldCup](doc/default/world_cup.md)
 
+### Bibles
+  - [Faker::Bibles::KingJames](doc/bibles/king_james.md)
+
 ### Blockchain
   - [Faker::Blockchain::Bitcoin](doc/blockchain/bitcoin.md)
   - [Faker::Blockchain::Ethereum](doc/blockchain/ethereum.md)

--- a/doc/bibles/king_james.md
+++ b/doc/bibles/king_james.md
@@ -1,0 +1,25 @@
+# Faker::Bibles::KingJames
+
+```ruby
+# List of b
+Faker::Bibles::KingJames::BOOKS #=> ["genesis", "exodus", "leviticus", "numbers", "deuteronomy", "joshua", "judges", "ruth", "one_samuel", "two_samuel", "one_kings", "two_kings", "one_chronicles", "two_chronicles", "ezra", "nehemiah", "esther", "job", "psalms", "proverbs", "ecclesiastes", "song_of_solomon", "isaiah", "jeremiah", "lamentations", "ezekiel", "daniel", "hosea", "joel", "amos", "obadiah", "jonah", "micah", "nahum", "habakkuk", "zephaniah", "haggai", "zechariah", "malachi", "matthew", "mark", "luke", "john", "acts", "romans", "one_corinthians", "two_corinthians", "galatians", "ephesians", "philippians", "colossians", "one_thessalonians", "two_thessalonians", "one_timothy", "two_timothy", "titus", "philemon", "hebrews", "james", "one_peter", "two_peter", "one_john", "two_john", "three_john", "jude", "revelation"]
+
+# Random book name (generated from BOOKS)
+Faker::Bibles::KingJames.book #=> "two_thessalonians"
+
+# Random verse. Takes three optional arguments:
+#   prefix (bool): include/exclude prefix (default: true)
+#   emphasis (bool): include/exclude markdown-compatible emphasis (italicized in original publication) (default: false)
+#   books (string/array): which book(s) to use to select verse. (default: BOOKS)
+Faker::Bibles::KingJames.verse #=> "Jude 1:1 Jude, the servant of Jesus Christ, and brother of James, to them that are sanctified by God the Father, and preserved in Jesus Christ, and called:"
+
+
+# Random verse from a given book
+Faker::Bibles::KingJames.verse(books: 'genesis') #=> "Genesis 5:6 And Seth lived an hundred and five years, and begat Enos:"
+
+# Alias for random verse from a given book (replace verse with book name). Also takes prefix or emphasis args as shown above
+Faker::Bibles::KingJames.genesis #=> "Genesis 13:17 Arise, walk through the land in the length of it and in the breadth of it; for I will give it unto thee."
+
+# Random verse from array of books
+Faker::Bibles::KingJames.verse(books: %w[genesis exodus]) #=> "Exodus 34:2 And be ready in the morning, and come up in the morning unto mount Sinai, and present thyself there to me in the top of the mount."
+```

--- a/lib/faker/bibles/king_james.rb
+++ b/lib/faker/bibles/king_james.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Faker
+  class Bibles
+    class KingJames < Base
+      BOOKS = %w[genesis exodus leviticus numbers deuteronomy joshua judges ruth one_samuel two_samuel one_kings two_kings one_chronicles two_chronicles ezra nehemiah esther job psalms proverbs ecclesiastes song_of_solomon isaiah jeremiah lamentations ezekiel daniel hosea joel amos obadiah jonah micah nahum habakkuk zephaniah haggai zechariah malachi matthew mark luke john acts romans one_corinthians two_corinthians galatians ephesians philippians colossians one_thessalonians two_thessalonians one_timothy two_timothy titus philemon hebrews james one_peter two_peter one_john two_john three_john jude revelation].freeze
+      PREFIX_PATTERN = /^[[:alnum:] ]+?\d+?:\d+? /
+      flexible :king_james
+
+      class << self
+        def book
+          BOOKS.sample
+        end
+
+        def verse(prefix: true, emphasis: false, books: BOOKS)
+          books = [books] unless books.is_a? Array
+          validate_book_names(books)
+          format(fetch("king_james.#{books.sample}"), prefix, emphasis)
+        end
+
+        BOOKS.each do |book|
+          define_method(:"#{book}") do |prefix: true, emphasis: false|
+            verse(prefix: prefix, emphasis: emphasis, books: book)
+          end
+        end
+
+        private
+
+        def invalid_book_names?(arr)
+          (arr & BOOKS).size < arr.size
+        end
+
+        def validate_book_names(arr)
+          raise ArgumentError, "Given book names: #{arr.join(', ')}. Valid: #{BOOKS.join(', ')}" if invalid_book_names?(arr)
+        end
+
+        def format(string, prefix, emphasis)
+          string.gsub!(PREFIX_PATTERN, '') unless prefix
+          string.delete!('*') unless emphasis
+          string
+        end
+      end
+    end
+  end
+end

--- a/test/faker/bibles/test_king_james.rb
+++ b/test/faker/bibles/test_king_james.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerBiblesKingJames < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Bibles::KingJames
+  end
+
+  def test_book
+    assert @tester::BOOKS.include? @tester.book
+    # assert @tester.books.match(/\w+/)
+  end
+
+  def test_verse_with_no_arguments
+    assert @tester.verse.match(/\w+/)
+  end
+
+  def test_verse_without_prefix
+    refute @tester.verse(prefix: false).match(@tester::PREFIX_PATTERN)
+  end
+
+  def test_verse_without_emphasis
+    refute @tester.verse(emphasis: false).include?('*')
+  end
+
+  def test_verse_without_prefix_without_emphasis
+    result = @tester.verse(prefix: false, emphasis: false)
+    refute result.match(@tester::PREFIX_PATTERN)
+    refute result.include?('*')
+  end
+
+  Faker::Bibles::KingJames::BOOKS.each do |book|
+    define_method(:"test_#{book}_method_with_default_arguments") { @tester.method(book) }
+  end
+end


### PR DESCRIPTION
Issue# 
------
#1641

Description:
------
After viewing issue #1641, I thought I'd take a stab at adding a Bible class to Faker. In my branch, I initially included `Bible` as a subclass of `Books`, but I thought that making `Bibles` its own class might make it more extensible should anyone want to add other versions.

The yaml file is quite large but I've attempted to keep read times down by only accessing one book at a time.

I've included the King James English version, but there are several others that might eventually be included in the class. All tests and checks passing locally. 
