### PR TITLE
Add warn for positional arguments when using Faker 2.0

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -43,6 +43,8 @@ module Faker
     Letters = ULetters + Array('a'..'z')
 
     class << self
+      NOT_GIVEN = Object.new
+
       ## by default numerify results do not start with a zero
       def numerify(number_string, leading_zero: false)
         return number_string.gsub(/#/) { rand(10).to_s } if leading_zero
@@ -244,6 +246,24 @@ module Faker
         yield
       ensure
         I18n.enforce_available_locales = old_enforce_available_locales
+      end
+
+      private
+
+      # Workaround for emulating `warn '...', uplevel: 1` in Ruby 2.4 or lower.
+      def warn_with_uplevel(message, uplevel: 1)
+        at = parse_caller(caller[uplevel]).join(':')
+        warn "#{at}: #{message}"
+      end
+
+      def parse_caller(at)
+        # rubocop:disable Style/GuardClause
+        if /^(.+?):(\d+)(?::in `.*')?/ =~ at
+          file = Regexp.last_match(1)
+          line = Regexp.last_match(2).to_i
+          [file, line]
+        end
+        # rubocop:enable Style/GuardClause
       end
     end
   end

--- a/lib/faker/books/dune.rb
+++ b/lib/faker/books/dune.rb
@@ -19,7 +19,12 @@ module Faker
           fetch('dune.planets')
         end
 
-        def quote(character: nil)
+        def quote(legacy_character = NOT_GIVEN, character: nil)
+          if legacy_character != NOT_GIVEN
+            warn_with_uplevel 'Passing `character` with the 1st argument of `Dune.quote` is deprecated. Use keyword argument like `Dune.quote(character: ...)` instead.', uplevel: 1
+            character = legacy_character
+          end
+
           quoted_characters = translate('faker.dune.quotes').keys
 
           if character.nil?
@@ -36,7 +41,12 @@ module Faker
           fetch('dune.quotes.' + character)
         end
 
-        def saying(source: nil)
+        def saying(legacy_source = NOT_GIVEN, source: nil)
+          if legacy_source != NOT_GIVEN
+            warn_with_uplevel 'Passing `source` with the 1st argument of `Dune.saying` is deprecated. Use keyword argument like `Dune.saying(source: ...)` instead.', uplevel: 1
+            source = legacy_source
+          end
+
           sourced_sayings = translate('faker.dune.sayings').keys
 
           if source.nil?

--- a/lib/faker/books/lovecraft.rb
+++ b/lib/faker/books/lovecraft.rb
@@ -8,7 +8,12 @@ module Faker
           fetch('lovecraft.location')
         end
 
-        def fhtagn(number: 1)
+        def fhtagn(legacy_number = NOT_GIVEN, number: 1)
+          if legacy_number != NOT_GIVEN
+            warn_with_uplevel 'Passing `number` with the 1st argument of `Lovecraft.fhtagn` is deprecated. Use keyword argument like `Lovecraft.fhtagn(number: ...)` instead.', uplevel: 1
+            number = legacy_number
+          end
+
           Array.new(number) { fetch('lovecraft.fhtagn') }.join('. ')
         end
 
@@ -20,7 +25,16 @@ module Faker
           fetch('lovecraft.tome')
         end
 
-        def sentence(word_count: 4, random_words_to_add: 6)
+        def sentence(legacy_word_count = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, random_words_to_add: 6)
+          if legacy_word_count != NOT_GIVEN
+            warn_with_uplevel 'Passing `word_count` with the 1st argument of `Lovecraft.sentence` is deprecated. Use keyword argument like `Lovecraft.sentence(word_count: ...)` instead.', uplevel: 1
+            word_count = legacy_word_count
+          end
+          if legacy_random_words_to_add != NOT_GIVEN
+            warn_with_uplevel 'Passing `random_words_to_add` with the 2nd argument of `Lovecraft.sentence` is deprecated. Use keyword argument like `Lovecraft.sentence(random_words_to_add: ...)` instead.', uplevel: 1
+            random_words_to_add = legacy_random_words_to_add
+          end
+
           words(number: word_count + rand(random_words_to_add.to_i).to_i, spaces_allowed: true).join(' ').capitalize + '.'
         end
 
@@ -29,7 +43,16 @@ module Faker
           random_word =~ /\s/ ? word : random_word
         end
 
-        def words(number: 3, spaces_allowed: false)
+        def words(legacy_number = NOT_GIVEN, legacy_spaces_allowed = NOT_GIVEN, number: 3, spaces_allowed: false)
+          if legacy_number != NOT_GIVEN
+            warn_with_uplevel 'Passing `number` with the 1st argument of `Lovecraft.words` is deprecated. Use keyword argument like `Lovecraft.words(number: ...)` instead.', uplevel: 1
+            number = legacy_number
+          end
+          if legacy_spaces_allowed != NOT_GIVEN
+            warn_with_uplevel 'Passing `spaces_allowed` with the 2nd argument of `Lovecraft.words` is deprecated. Use keyword argument like `Lovecraft.words(spaces_allowed: ...)` instead.', uplevel: 1
+            spaces_allowed = legacy_spaces_allowed
+          end
+
           resolved_num = resolve(number)
           word_list = translate('faker.lovecraft.words')
           word_list *= ((resolved_num / word_list.length) + 1)
@@ -40,7 +63,12 @@ module Faker
           words.each_with_index { |w, i| words[i] = word if w =~ /\s/ }
         end
 
-        def sentences(number: 3)
+        def sentences(legacy_number = NOT_GIVEN, number: 3)
+          if legacy_number != NOT_GIVEN
+            warn_with_uplevel 'Passing `number` with the 1st argument of `Lovecraft.sentences` is deprecated. Use keyword argument like `Lovecraft.sentences(number: ...)` instead.', uplevel: 1
+            number = legacy_number
+          end
+
           [].tap do |sentences|
             1.upto(resolve(number)) do
               sentences << sentence(word_count: 3)
@@ -48,11 +76,25 @@ module Faker
           end
         end
 
-        def paragraph(sentence_count: 3, random_sentences_to_add: 3)
+        def paragraph(legacy_sentence_count = NOT_GIVEN, legacy_random_sentences_to_add = NOT_GIVEN, sentence_count: 3, random_sentences_to_add: 3)
+          if legacy_sentence_count != NOT_GIVEN
+            warn_with_uplevel 'Passing `sentence_count` with the 1st argument of `Lovecraft.paragraph` is deprecated. Use keyword argument like `Lovecraft.paragraph(sentence_count: ...)` instead.', uplevel: 1
+            sentence_count = legacy_sentence_count
+          end
+          if legacy_random_sentences_to_add != NOT_GIVEN
+            warn_with_uplevel 'Passing `random_sentences_to_add` with the 2nd argument of `Lovecraft.paragraph` is deprecated. Use keyword argument like `Lovecraft.paragraph(random_sentences_to_add: ...)` instead.', uplevel: 1
+            random_sentences_to_add = legacy_random_sentences_to_add
+          end
+
           sentences(number: resolve(sentence_count) + rand(random_sentences_to_add.to_i).to_i).join(' ')
         end
 
-        def paragraphs(number: 3)
+        def paragraphs(legacy_number = NOT_GIVEN, number: 3)
+          if legacy_number != NOT_GIVEN
+            warn_with_uplevel 'Passing `number` with the 1st argument of `Lovecraft.paragraphs` is deprecated. Use keyword argument like `Lovecraft.paragraphs(number: ...)` instead.', uplevel: 1
+            number = legacy_number
+          end
+
           [].tap do |paragraphs|
             1.upto(resolve(number)) do
               paragraphs << paragraph(sentence_count: 3)
@@ -60,7 +102,12 @@ module Faker
           end
         end
 
-        def paragraph_by_chars(characters: 256)
+        def paragraph_by_chars(legacy_characters = NOT_GIVEN, characters: 256)
+          if legacy_characters != NOT_GIVEN
+            warn_with_uplevel 'Passing `characters` with the 1st argument of `Lovecraft.paragraph_by_chars` is deprecated. Use keyword argument like `Lovecraft.paragraph_by_chars(characters: ...)` instead.', uplevel: 1
+            characters = legacy_characters
+          end
+
           paragraph = paragraph(sentence_count: 3)
 
           paragraph += ' ' + paragraph(sentence_count: 3) while paragraph.length < characters

--- a/lib/faker/default/address.rb
+++ b/lib/faker/default/address.rb
@@ -5,7 +5,12 @@ module Faker
     flexible :address
 
     class << self
-      def city(options: {})
+      def city(legacy_options = NOT_GIVEN, options: {})
+        if legacy_options != NOT_GIVEN
+          warn_with_uplevel 'Passing `options` with the 1st argument of `Address.city` is deprecated. Use keyword argument like `Address.city(options: ...)` instead.', uplevel: 1
+          options = legacy_options
+        end
+
         parse(options[:with_state] ? 'address.city_with_state' : 'address.city')
       end
 
@@ -13,7 +18,12 @@ module Faker
         parse('address.street_name')
       end
 
-      def street_address(include_secondary: false)
+      def street_address(legacy_include_secondary = NOT_GIVEN, include_secondary: false)
+        if legacy_include_secondary != NOT_GIVEN
+          warn_with_uplevel 'Passing `include_secondary` with the 1st argument of `Address.street_address` is deprecated. Use keyword argument like `Address.street_address(include_secondary: ...)` instead.', uplevel: 1
+          include_secondary = legacy_include_secondary
+        end
+
         numerify(parse('address.street_address') + (include_secondary ? ' ' + secondary_address : ''))
       end
 
@@ -29,7 +39,12 @@ module Faker
         parse('address.community')
       end
 
-      def zip_code(state_abbreviation: '')
+      def zip_code(legacy_state_abbreviation = NOT_GIVEN, state_abbreviation: '')
+        if legacy_state_abbreviation != NOT_GIVEN
+          warn_with_uplevel 'Passing `state_abbreviation` with the 1st argument of `Address.zip_code` is deprecated. Use keyword argument like `Address.zip_code(state_abbreviation: ...)` instead.', uplevel: 1
+          state_abbreviation = legacy_state_abbreviation
+        end
+
         if state_abbreviation.empty?
           letterified_string = letterify(fetch('address.postcode'))
           return numerify(letterified_string, leading_zero: true)
@@ -71,11 +86,21 @@ module Faker
         fetch('address.country')
       end
 
-      def country_by_code(code: 'US')
+      def country_by_code(legacy_code = NOT_GIVEN, code: 'US')
+        if legacy_code != NOT_GIVEN
+          warn_with_uplevel 'Passing `code` with the 1st argument of `Address.country_by_code` is deprecated. Use keyword argument like `Address.country_by_code(code: ...)` instead.', uplevel: 1
+          code = legacy_code
+        end
+
         fetch('address.country_by_code.' + code)
       end
 
-      def country_name_to_code(name: 'united_states')
+      def country_name_to_code(legacy_name = NOT_GIVEN, name: 'united_states')
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Address.country_name_to_code` is deprecated. Use keyword argument like `Address.country_name_to_code(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+
         fetch('address.country_by_name.' + name)
       end
 

--- a/lib/faker/default/alphanumeric.rb
+++ b/lib/faker/default/alphanumeric.rb
@@ -6,14 +6,24 @@ module Faker
       ALPHABET = ('a'..'z').to_a
       ALPHANUMS = ALPHABET + (0..9).to_a
 
-      def alpha(number: 32)
+      def alpha(legacy_number = NOT_GIVEN, number: 32)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Alphanumeric.alpha` is deprecated. Use keyword argument like `Alphanumeric.alpha(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+
         char_count = resolve(number)
         return '' if char_count.to_i < 1
 
         Array.new(char_count) { sample(ALPHABET) }.join
       end
 
-      def alphanumeric(number: 32)
+      def alphanumeric(legacy_number = NOT_GIVEN, number: 32)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Alphanumeric.alphanumeric` is deprecated. Use keyword argument like `Alphanumeric.alphanumeric(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+
         char_count = resolve(number)
         return '' if char_count.to_i < 1
 

--- a/lib/faker/default/app.rb
+++ b/lib/faker/default/app.rb
@@ -15,7 +15,22 @@ module Faker
         parse('app.author')
       end
 
-      def semantic_version(major: 0..9, minor: 0..9, patch: 1..9)
+      # rubocop:disable Metrics/ParameterLists
+      def semantic_version(legacy_major = NOT_GIVEN, legacy_minor = NOT_GIVEN, legacy_patch = NOT_GIVEN, major: 0..9, minor: 0..9, patch: 1..9)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_major != NOT_GIVEN
+          warn_with_uplevel 'Passing `major` with the 1st argument of `App.semantic_version` is deprecated. Use keyword argument like `App.semantic_version(major: ...)` instead.', uplevel: 1
+          major = legacy_major
+        end
+        if legacy_minor != NOT_GIVEN
+          warn_with_uplevel 'Passing `minor` with the 2nd argument of `App.semantic_version` is deprecated. Use keyword argument like `App.semantic_version(minor: ...)` instead.', uplevel: 1
+          minor = legacy_minor
+        end
+        if legacy_patch != NOT_GIVEN
+          warn_with_uplevel 'Passing `patch` with the 3rd argument of `App.semantic_version` is deprecated. Use keyword argument like `App.semantic_version(patch: ...)` instead.', uplevel: 1
+          patch = legacy_patch
+        end
+
         [major, minor, patch].map { |chunk| sample(Array(chunk)) }.join('.')
       end
     end

--- a/lib/faker/default/avatar.rb
+++ b/lib/faker/default/avatar.rb
@@ -5,7 +5,30 @@ module Faker
     class << self
       SUPPORTED_FORMATS = %w[png jpg bmp].freeze
 
-      def image(slug: nil, size: '300x300', format: 'png', set: 'set1', bgset: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def image(legacy_slug = NOT_GIVEN, legacy_size = NOT_GIVEN, legacy_format = NOT_GIVEN, legacy_set = NOT_GIVEN, legacy_bgset = NOT_GIVEN, slug: nil, size: '300x300', format: 'png', set: 'set1', bgset: nil)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_slug != NOT_GIVEN
+          warn_with_uplevel 'Passing `slug` with the 1st argument of `Avatar.image` is deprecated. Use keyword argument like `Avatar.image(slug: ...)` instead.', uplevel: 1
+          slug = legacy_slug
+        end
+        if legacy_size != NOT_GIVEN
+          warn_with_uplevel 'Passing `size` with the 2nd argument of `Avatar.image` is deprecated. Use keyword argument like `Avatar.image(size: ...)` instead.', uplevel: 1
+          size = legacy_size
+        end
+        if legacy_format != NOT_GIVEN
+          warn_with_uplevel 'Passing `format` with the 3rd argument of `Avatar.image` is deprecated. Use keyword argument like `Avatar.image(format: ...)` instead.', uplevel: 1
+          format = legacy_format
+        end
+        if legacy_set != NOT_GIVEN
+          warn_with_uplevel 'Passing `set` with the 4th argument of `Avatar.image` is deprecated. Use keyword argument like `Avatar.image(set: ...)` instead.', uplevel: 1
+          set = legacy_set
+        end
+        if legacy_bgset != NOT_GIVEN
+          warn_with_uplevel 'Passing `bgset` with the 5th argument of `Avatar.image` is deprecated. Use keyword argument like `Avatar.image(bgset: ...)` instead.', uplevel: 1
+          bgset = legacy_bgset
+        end
+
         raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
 

--- a/lib/faker/default/bank.rb
+++ b/lib/faker/default/bank.rb
@@ -5,7 +5,12 @@ module Faker
     flexible :bank
 
     class << self
-      def account_number(digits: 10)
+      def account_number(legacy_digits = NOT_GIVEN, digits: 10)
+        if legacy_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `digits` with the 1st argument of `Bank.account_number` is deprecated. Use keyword argument like `Bank.account_number(digits: ...)` instead.', uplevel: 1
+          digits = legacy_digits
+        end
+
         output = ''
 
         output += rand.to_s[2..-1] while output.length < digits
@@ -13,10 +18,15 @@ module Faker
         output[0...digits]
       end
 
-      def iban(country_code: 'GB')
+      def iban(legacy_country_code = NOT_GIVEN, country_code: 'GB')
         # Each country has it's own format for bank accounts
         # Many of them use letters in certain parts of the account
         # Using regex patterns we can create virtually any type of bank account
+        if legacy_country_code != NOT_GIVEN
+          warn_with_uplevel 'Passing `country_code` with the 1st argument of `Bank.iban` is deprecated. Use keyword argument like `Bank.iban(country_code: ...)` instead.', uplevel: 1
+          country_code = legacy_country_code
+        end
+
         begin
           pattern = fetch("bank.iban_details.#{country_code.downcase}.bban_pattern")
         rescue I18n::MissingTranslationData

--- a/lib/faker/default/boolean.rb
+++ b/lib/faker/default/boolean.rb
@@ -3,7 +3,12 @@
 module Faker
   class Boolean < Base
     class << self
-      def boolean(true_ratio: 0.5)
+      def boolean(legacy_true_ratio = NOT_GIVEN, true_ratio: 0.5)
+        if legacy_true_ratio != NOT_GIVEN
+          warn_with_uplevel 'Passing `true_ratio` with the 1st argument of `Boolean.boolean` is deprecated. Use keyword argument like `Boolean.boolean(true_ratio: ...)` instead.', uplevel: 1
+          true_ratio = legacy_true_ratio
+        end
+
         (rand < true_ratio)
       end
     end

--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -6,7 +6,16 @@ module Faker
       @last_rut = nil
 
       # Fixed param added for testing a specific RUT and check digit combination.
-      def rut(min_rut: 1, fixed: false)
+      def rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 1, fixed: false)
+        if legacy_min_rut != NOT_GIVEN
+          warn_with_uplevel 'Passing `min_rut` with the 1st argument of `ChileRut.rut` is deprecated. Use keyword argument like `ChileRut.rut(min_rut: ...)` instead.', uplevel: 1
+          min_rut = legacy_min_rut
+        end
+        if legacy_fixed != NOT_GIVEN
+          warn_with_uplevel 'Passing `fixed` with the 2nd argument of `ChileRut.rut` is deprecated. Use keyword argument like `ChileRut.rut(fixed: ...)` instead.', uplevel: 1
+          fixed = legacy_fixed
+        end
+
         @last_rut = fixed ? min_rut : rand_in_range(min_rut, 99_999_999)
       end
 
@@ -34,7 +43,16 @@ module Faker
         dv
       end
 
-      def full_rut(min_rut: 0, fixed: false)
+      def full_rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
+        if legacy_min_rut != NOT_GIVEN
+          warn_with_uplevel 'Passing `min_rut` with the 1st argument of `ChileRut.full_rut` is deprecated. Use keyword argument like `ChileRut.full_rut(min_rut: ...)` instead.', uplevel: 1
+          min_rut = legacy_min_rut
+        end
+        if legacy_fixed != NOT_GIVEN
+          warn_with_uplevel 'Passing `fixed` with the 2nd argument of `ChileRut.full_rut` is deprecated. Use keyword argument like `ChileRut.full_rut(fixed: ...)` instead.', uplevel: 1
+          fixed = legacy_fixed
+        end
+
         "#{rut(min_rut: min_rut, fixed: fixed)}-#{dv}"
       end
 

--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -12,13 +12,23 @@ module Faker
 
       # By default generates 10 sign isbn code in format 123456789-X
       # You can pass 13 to generate new 13 sign code
-      def isbn(base: 10)
+      def isbn(legacy_base = NOT_GIVEN, base: 10)
+        if legacy_base != NOT_GIVEN
+          warn_with_uplevel 'Passing `base` with the 1st argument of `Code.isbn` is deprecated. Use keyword argument like `Code.isbn(base: ...)` instead.', uplevel: 1
+          base = legacy_base
+        end
+
         base == 13 ? generate_base13_isbn : generate_base10_isbn
       end
 
       # By default generates 13 sign ean code in format 1234567890123
       # You can pass 8 to generate ean8 code
-      def ean(base: 13)
+      def ean(legacy_base = NOT_GIVEN, base: 13)
+        if legacy_base != NOT_GIVEN
+          warn_with_uplevel 'Passing `base` with the 1st argument of `Code.ean` is deprecated. Use keyword argument like `Code.ean(base: ...)` instead.', uplevel: 1
+          base = legacy_base
+        end
+
         base == 8 ? generate_base8_ean : generate_base13_ean
       end
 
@@ -30,7 +40,16 @@ module Faker
 
       # By default generates a Singaporean NRIC ID for someone
       # who is born between the age of 18 and 65.
-      def nric(min_age: 18, max_age: 65)
+      def nric(legacy_min_age = NOT_GIVEN, legacy_max_age = NOT_GIVEN, min_age: 18, max_age: 65)
+        if legacy_min_age != NOT_GIVEN
+          warn_with_uplevel 'Passing `min_age` with the 1st argument of `Code.nric` is deprecated. Use keyword argument like `Code.nric(min_age: ...)` instead.', uplevel: 1
+          min_age = legacy_min_age
+        end
+        if legacy_max_age != NOT_GIVEN
+          warn_with_uplevel 'Passing `max_age` with the 2nd argument of `Code.nric` is deprecated. Use keyword argument like `Code.nric(max_age: ...)` instead.', uplevel: 1
+          max_age = legacy_max_age
+        end
+
         birthyear = Date.birthday(min_age: min_age, max_age: max_age).year
         prefix = birthyear < 2000 ? 'S' : 'T'
         values = birthyear.to_s[-2..-1]

--- a/lib/faker/default/commerce.rb
+++ b/lib/faker/default/commerce.rb
@@ -7,7 +7,12 @@ module Faker
         fetch('color.name')
       end
 
-      def promotion_code(digits: 6)
+      def promotion_code(legacy_digits = NOT_GIVEN, digits: 6)
+        if legacy_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `digits` with the 1st argument of `Commerce.promotion_code` is deprecated. Use keyword argument like `Commerce.promotion_code(digits: ...)` instead.', uplevel: 1
+          digits = legacy_digits
+        end
+
         [
           fetch('commerce.promotion_code.adjective'),
           fetch('commerce.promotion_code.noun'),
@@ -15,7 +20,16 @@ module Faker
         ].join
       end
 
-      def department(max: 3, fixed_amount: false)
+      def department(legacy_max = NOT_GIVEN, legacy_fixed_amount = NOT_GIVEN, max: 3, fixed_amount: false)
+        if legacy_max != NOT_GIVEN
+          warn_with_uplevel 'Passing `max` with the 1st argument of `Commerce.department` is deprecated. Use keyword argument like `Commerce.department(max: ...)` instead.', uplevel: 1
+          max = legacy_max
+        end
+        if legacy_fixed_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `fixed_amount` with the 2nd argument of `Commerce.department` is deprecated. Use keyword argument like `Commerce.department(fixed_amount: ...)` instead.', uplevel: 1
+          fixed_amount = legacy_fixed_amount
+        end
+
         num = max if fixed_amount
         num ||= 1 + rand(max)
 
@@ -34,7 +48,16 @@ module Faker
         fetch('commerce.product_name.material')
       end
 
-      def price(range: 0..100.0, as_string: false)
+      def price(legacy_range = NOT_GIVEN, legacy_as_string = NOT_GIVEN, range: 0..100.0, as_string: false)
+        if legacy_range != NOT_GIVEN
+          warn_with_uplevel 'Passing `range` with the 1st argument of `Commerce.price` is deprecated. Use keyword argument like `Commerce.price(range: ...)` instead.', uplevel: 1
+          range = legacy_range
+        end
+        if legacy_as_string != NOT_GIVEN
+          warn_with_uplevel 'Passing `as_string` with the 2nd argument of `Commerce.price` is deprecated. Use keyword argument like `Commerce.price(as_string: ...)` instead.', uplevel: 1
+          as_string = legacy_as_string
+        end
+
         price = (rand(range) * 100).floor / 100.0
         if as_string
           price_parts = price.to_s.split('.')

--- a/lib/faker/default/company.rb
+++ b/lib/faker/default/company.rb
@@ -126,7 +126,12 @@ module Faker
       end
 
       # Get a random Polish register of national economy number. More info https://pl.wikipedia.org/wiki/REGON
-      def polish_register_of_national_economy(length: 9)
+      def polish_register_of_national_economy(legacy_length = NOT_GIVEN, length: 9)
+        if legacy_length != NOT_GIVEN
+          warn_with_uplevel 'Passing `length` with the 1st argument of `Company.polish_register_of_national_economy` is deprecated. Use keyword argument like `Company.polish_register_of_national_economy(length: ...)` instead.', uplevel: 1
+          length = legacy_length
+        end
+
         raise ArgumentError, 'Length should be 9 or 14' unless [9, 14].include? length
 
         random_digits = []
@@ -153,7 +158,12 @@ module Faker
         regexify(/IT\d{2,4}\/\d{2,10}/)
       end
 
-      def brazilian_company_number(formatted: false)
+      def brazilian_company_number(legacy_formatted = NOT_GIVEN, formatted: false)
+        if legacy_formatted != NOT_GIVEN
+          warn_with_uplevel 'Passing `formatted` with the 1st argument of `Company.brazilian_company_number` is deprecated. Use keyword argument like `Company.brazilian_company_number(formatted: ...)` instead.', uplevel: 1
+          formatted = legacy_formatted
+        end
+
         digits = Array.new(8) { Faker::Number.digit.to_i } + [0, 0, 0, Faker::Number.non_zero_digit.to_i]
 
         factors = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 6].cycle

--- a/lib/faker/default/crypto_coin.rb
+++ b/lib/faker/default/crypto_coin.rb
@@ -7,15 +7,30 @@ module Faker
       ACRONYM = 1
       URL_LOGO = 2
 
-      def coin_name(coin: coin_array)
+      def coin_name(legacy_coin = NOT_GIVEN, coin: coin_array)
+        if legacy_coin != NOT_GIVEN
+          warn_with_uplevel 'Passing `coin` with the 1st argument of `CryptoCoin.coin_name` is deprecated. Use keyword argument like `CryptoCoin.coin_name(coin: ...)` instead.', uplevel: 1
+          coin = legacy_coin
+        end
+
         coin[COIN_NAME]
       end
 
-      def acronym(coin: coin_array)
+      def acronym(legacy_coin = NOT_GIVEN, coin: coin_array)
+        if legacy_coin != NOT_GIVEN
+          warn_with_uplevel 'Passing `coin` with the 1st argument of `CryptoCoin.acronym` is deprecated. Use keyword argument like `CryptoCoin.acronym(coin: ...)` instead.', uplevel: 1
+          coin = legacy_coin
+        end
+
         coin[ACRONYM]
       end
 
-      def url_logo(coin: coin_array)
+      def url_logo(legacy_coin = NOT_GIVEN, coin: coin_array)
+        if legacy_coin != NOT_GIVEN
+          warn_with_uplevel 'Passing `coin` with the 1st argument of `CryptoCoin.url_logo` is deprecated. Use keyword argument like `CryptoCoin.url_logo(coin: ...)` instead.', uplevel: 1
+          coin = legacy_coin
+        end
+
         coin[URL_LOGO]
       end
 

--- a/lib/faker/default/date.rb
+++ b/lib/faker/default/date.rb
@@ -3,14 +3,38 @@
 module Faker
   class Date < Base
     class << self
-      def between(from:, to:)
+      def between(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from:, to:)
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Date.between` is deprecated. Use keyword argument like `Date.between(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Date.between` is deprecated. Use keyword argument like `Date.between(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+
         from = get_date_object(from)
         to   = get_date_object(to)
 
         Faker::Base.rand_in_range(from, to)
       end
 
-      def between_except(from:, to:, excepted:)
+      # rubocop:disable Metrics/ParameterLists
+      def between_except(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, legacy_excepted = NOT_GIVEN, from:, to:, excepted:)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Date.between_except` is deprecated. Use keyword argument like `Date.between_except(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Date.between_except` is deprecated. Use keyword argument like `Date.between_except(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+        if legacy_excepted != NOT_GIVEN
+          warn_with_uplevel 'Passing `excepted` with the 3rd argument of `Date.between_except` is deprecated. Use keyword argument like `Date.between_except(excepted: ...)` instead.', uplevel: 1
+          excepted = legacy_excepted
+        end
+
         raise ArgumentError, 'From date, to date and excepted date must not be the same' if from == to && to == excepted
 
         excepted = get_date_object(excepted)
@@ -21,21 +45,40 @@ module Faker
         end
       end
 
-      def forward(days: 365)
+      def forward(legacy_days = NOT_GIVEN, days: 365)
+        if legacy_days != NOT_GIVEN
+          warn_with_uplevel 'Passing `days` with the 1st argument of `Date.forward` is deprecated. Use keyword argument like `Date.forward(days: ...)` instead.', uplevel: 1
+          days = legacy_days
+        end
+
         from = ::Date.today + 1
         to   = ::Date.today + days
 
         between(from: from, to: to).to_date
       end
 
-      def backward(days: 365)
+      def backward(legacy_days = NOT_GIVEN, days: 365)
+        if legacy_days != NOT_GIVEN
+          warn_with_uplevel 'Passing `days` with the 1st argument of `Date.backward` is deprecated. Use keyword argument like `Date.backward(days: ...)` instead.', uplevel: 1
+          days = legacy_days
+        end
+
         from = ::Date.today - days
         to   = ::Date.today - 1
 
         between(from: from, to: to).to_date
       end
 
-      def birthday(min_age: 18, max_age: 65)
+      def birthday(legacy_min_age = NOT_GIVEN, legacy_max_age = NOT_GIVEN, min_age: 18, max_age: 65)
+        if legacy_min_age != NOT_GIVEN
+          warn_with_uplevel 'Passing `min_age` with the 1st argument of `Date.birthday` is deprecated. Use keyword argument like `Date.birthday(min_age: ...)` instead.', uplevel: 1
+          min_age = legacy_min_age
+        end
+        if legacy_max_age != NOT_GIVEN
+          warn_with_uplevel 'Passing `max_age` with the 2nd argument of `Date.birthday` is deprecated. Use keyword argument like `Date.birthday(max_age: ...)` instead.', uplevel: 1
+          max_age = legacy_max_age
+        end
+
         t = ::Date.today
 
         from = birthday_date(t, max_age)

--- a/lib/faker/default/demographic.rb
+++ b/lib/faker/default/demographic.rb
@@ -23,7 +23,12 @@ module Faker
         fetch('demographic.sex')
       end
 
-      def height(unit: :metric)
+      def height(legacy_unit = NOT_GIVEN, unit: :metric)
+        if legacy_unit != NOT_GIVEN
+          warn_with_uplevel 'Passing `unit` with the 1st argument of `Demographic.height` is deprecated. Use keyword argument like `Demographic.height(unit: ...)` instead.', uplevel: 1
+          unit = legacy_unit
+        end
+
         case unit
         when :imperial
           inches = rand_in_range(57, 86)

--- a/lib/faker/default/driving_licence.rb
+++ b/lib/faker/default/driving_licence.rb
@@ -6,10 +6,26 @@ module Faker
     NI_CHANCE = 0.03 # NI Pop is about 3% of total UK population
 
     class << self
-      def british_driving_licence(last_name: Faker::Name.last_name,
-                                  initials: Faker::Name.initials,
-                                  gender: random_gender,
-                                  date_of_birth: Faker::Date.birthday(min_age: 18, max_age: 65))
+      # rubocop:disable Metrics/ParameterLists
+      def british_driving_licence(legacy_last_name = NOT_GIVEN, legacy_initials = NOT_GIVEN, legacy_gender = NOT_GIVEN, legacy_date_of_birth = NOT_GIVEN, last_name: Faker::Name.last_name, initials: Faker::Name.initials, gender: random_gender, date_of_birth: Faker::Date.birthday(min_age: 18, max_age: 65))
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_last_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `last_name` with the 1st argument of `DrivingLicence.british_driving_licence` is deprecated. Use keyword argument like `DrivingLicence.british_driving_licence(last_name: ...)` instead.', uplevel: 1
+          last_name = legacy_last_name
+        end
+        if legacy_initials != NOT_GIVEN
+          warn_with_uplevel 'Passing `initials` with the 2nd argument of `DrivingLicence.british_driving_licence` is deprecated. Use keyword argument like `DrivingLicence.british_driving_licence(initials: ...)` instead.', uplevel: 1
+          initials = legacy_initials
+        end
+        if legacy_gender != NOT_GIVEN
+          warn_with_uplevel 'Passing `gender` with the 3rd argument of `DrivingLicence.british_driving_licence` is deprecated. Use keyword argument like `DrivingLicence.british_driving_licence(gender: ...)` instead.', uplevel: 1
+          gender = legacy_gender
+        end
+        if legacy_date_of_birth != NOT_GIVEN
+          warn_with_uplevel 'Passing `date_of_birth` with the 4th argument of `DrivingLicence.british_driving_licence` is deprecated. Use keyword argument like `DrivingLicence.british_driving_licence(date_of_birth: ...)` instead.', uplevel: 1
+          date_of_birth = legacy_date_of_birth
+        end
+
         [
           gb_licence_padding(last_name, 5),
           gb_licence_year(date_of_birth, gender),

--- a/lib/faker/default/file.rb
+++ b/lib/faker/default/file.rb
@@ -3,7 +3,22 @@
 module Faker
   class File < Base
     class << self
-      def dir(segment_count: 3, root: nil, directory_separator: '/')
+      # rubocop:disable Metrics/ParameterLists
+      def dir(legacy_segment_count = NOT_GIVEN, legacy_root = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, segment_count: 3, root: nil, directory_separator: '/')
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_segment_count != NOT_GIVEN
+          warn_with_uplevel 'Passing `segment_count` with the 1st argument of `File.dir` is deprecated. Use keyword argument like `File.dir(segment_count: ...)` instead.', uplevel: 1
+          segment_count = legacy_segment_count
+        end
+        if legacy_root != NOT_GIVEN
+          warn_with_uplevel 'Passing `root` with the 2nd argument of `File.dir` is deprecated. Use keyword argument like `File.dir(root: ...)` instead.', uplevel: 1
+          root = legacy_root
+        end
+        if legacy_directory_separator != NOT_GIVEN
+          warn_with_uplevel 'Passing `directory_separator` with the 3rd argument of `File.dir` is deprecated. Use keyword argument like `File.dir(directory_separator: ...)` instead.', uplevel: 1
+          directory_separator = legacy_directory_separator
+        end
+
         Array
           .new(segment_count) { Faker::Internet.slug }
           .unshift(root)
@@ -20,7 +35,26 @@ module Faker
         fetch('file.mime_type')
       end
 
-      def file_name(dir: nil, name: nil, ext: nil, directory_separator: '/')
+      # rubocop:disable Metrics/ParameterLists
+      def file_name(legacy_dir = NOT_GIVEN, legacy_name = NOT_GIVEN, legacy_ext = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, dir: nil, name: nil, ext: nil, directory_separator: '/')
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_dir != NOT_GIVEN
+          warn_with_uplevel 'Passing `dir` with the 1st argument of `File.file_name` is deprecated. Use keyword argument like `File.file_name(dir: ...)` instead.', uplevel: 1
+          dir = legacy_dir
+        end
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 2nd argument of `File.file_name` is deprecated. Use keyword argument like `File.file_name(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+        if legacy_ext != NOT_GIVEN
+          warn_with_uplevel 'Passing `ext` with the 3rd argument of `File.file_name` is deprecated. Use keyword argument like `File.file_name(ext: ...)` instead.', uplevel: 1
+          ext = legacy_ext
+        end
+        if legacy_directory_separator != NOT_GIVEN
+          warn_with_uplevel 'Passing `directory_separator` with the 4th argument of `File.file_name` is deprecated. Use keyword argument like `File.file_name(directory_separator: ...)` instead.', uplevel: 1
+          directory_separator = legacy_directory_separator
+        end
+
         dir ||= dir(segment_count: 1)
         name ||= Faker::Lorem.word.downcase
         ext ||= extension

--- a/lib/faker/default/fillmurray.rb
+++ b/lib/faker/default/fillmurray.rb
@@ -3,7 +3,22 @@
 module Faker
   class Fillmurray < Base
     class << self
-      def image(grayscale: false, width: 200, height: 200)
+      # rubocop:disable Metrics/ParameterLists
+      def image(legacy_grayscale = NOT_GIVEN, legacy_width = NOT_GIVEN, legacy_height = NOT_GIVEN, grayscale: false, width: 200, height: 200)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_grayscale != NOT_GIVEN
+          warn_with_uplevel 'Passing `grayscale` with the 1st argument of `Fillmurray.image` is deprecated. Use keyword argument like `Fillmurray.image(grayscale: ...)` instead.', uplevel: 1
+          grayscale = legacy_grayscale
+        end
+        if legacy_width != NOT_GIVEN
+          warn_with_uplevel 'Passing `width` with the 2nd argument of `Fillmurray.image` is deprecated. Use keyword argument like `Fillmurray.image(width: ...)` instead.', uplevel: 1
+          width = legacy_width
+        end
+        if legacy_height != NOT_GIVEN
+          warn_with_uplevel 'Passing `height` with the 3rd argument of `Fillmurray.image` is deprecated. Use keyword argument like `Fillmurray.image(height: ...)` instead.', uplevel: 1
+          height = legacy_height
+        end
+
         raise ArgumentError, 'Width should be a number' unless width.to_s =~ /^\d+$/
         raise ArgumentError, 'Height should be a number' unless height.to_s =~ /^\d+$/
         raise ArgumentError, 'Grayscale should be a boolean' unless [true, false].include?(grayscale)

--- a/lib/faker/default/finance.rb
+++ b/lib/faker/default/finance.rb
@@ -26,7 +26,12 @@ module Faker
         template.gsub('L', luhn_digit.to_s)
       end
 
-      def vat_number(country: 'BR')
+      def vat_number(legacy_country = NOT_GIVEN, country: 'BR')
+        if legacy_country != NOT_GIVEN
+          warn_with_uplevel 'Passing `country` with the 1st argument of `Finance.vat_number` is deprecated. Use keyword argument like `Finance.vat_number(country: ...)` instead.', uplevel: 1
+          country = legacy_country
+        end
+
         numerify(fetch("finance.vat_number.#{country}"))
       rescue I18n::MissingTranslationData
         raise ArgumentError, "Could not find vat number for #{country}"

--- a/lib/faker/default/hipster.rb
+++ b/lib/faker/default/hipster.rb
@@ -8,7 +8,22 @@ module Faker
         random_word =~ /\s/ ? word : random_word
       end
 
-      def words(number: 3, supplemental: false, spaces_allowed: false)
+      # rubocop:disable Metrics/ParameterLists
+      def words(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_spaces_allowed = NOT_GIVEN, number: 3, supplemental: false, spaces_allowed: false)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Hipster.words` is deprecated. Use keyword argument like `Hipster.words(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Hipster.words` is deprecated. Use keyword argument like `Hipster.words(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+        if legacy_spaces_allowed != NOT_GIVEN
+          warn_with_uplevel 'Passing `spaces_allowed` with the 3rd argument of `Hipster.words` is deprecated. Use keyword argument like `Hipster.words(spaces_allowed: ...)` instead.', uplevel: 1
+          spaces_allowed = legacy_spaces_allowed
+        end
+
         resolved_num = resolve(number)
         word_list = (
           translate('faker.hipster.words') +
@@ -22,11 +37,35 @@ module Faker
         words.each_with_index { |w, i| words[i] = word if w =~ /\s/ }
       end
 
-      def sentence(word_count: 4, supplemental: false, random_words_to_add: 6)
+      # rubocop:disable Metrics/ParameterLists
+      def sentence(legacy_word_count = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, supplemental: false, random_words_to_add: 6)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_word_count != NOT_GIVEN
+          warn_with_uplevel 'Passing `word_count` with the 1st argument of `Hipster.sentence` is deprecated. Use keyword argument like `Hipster.sentence(word_count: ...)` instead.', uplevel: 1
+          word_count = legacy_word_count
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Hipster.sentence` is deprecated. Use keyword argument like `Hipster.sentence(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+        if legacy_random_words_to_add != NOT_GIVEN
+          warn_with_uplevel 'Passing `random_words_to_add` with the 3rd argument of `Hipster.sentence` is deprecated. Use keyword argument like `Hipster.sentence(random_words_to_add: ...)` instead.', uplevel: 1
+          random_words_to_add = legacy_random_words_to_add
+        end
+
         words(number: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental, spaces_allowed: true).join(' ').capitalize + '.'
       end
 
-      def sentences(number: 3, supplemental: false)
+      def sentences(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 3, supplemental: false)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Hipster.sentences` is deprecated. Use keyword argument like `Hipster.sentences(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Hipster.sentences` is deprecated. Use keyword argument like `Hipster.sentences(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         [].tap do |sentences|
           1.upto(resolve(number)) do
             sentences << sentence(word_count: 3, supplemental: supplemental)
@@ -34,11 +73,35 @@ module Faker
         end
       end
 
-      def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 3)
+      # rubocop:disable Metrics/ParameterLists
+      def paragraph(legacy_sentence_count = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_random_sentences_to_add = NOT_GIVEN, sentence_count: 3, supplemental: false, random_sentences_to_add: 3)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_sentence_count != NOT_GIVEN
+          warn_with_uplevel 'Passing `sentence_count` with the 1st argument of `Hipster.paragraph` is deprecated. Use keyword argument like `Hipster.paragraph(sentence_count: ...)` instead.', uplevel: 1
+          sentence_count = legacy_sentence_count
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Hipster.paragraph` is deprecated. Use keyword argument like `Hipster.paragraph(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+        if legacy_random_sentences_to_add != NOT_GIVEN
+          warn_with_uplevel 'Passing `random_sentences_to_add` with the 3rd argument of `Hipster.paragraph` is deprecated. Use keyword argument like `Hipster.paragraph(random_sentences_to_add: ...)` instead.', uplevel: 1
+          random_sentences_to_add = legacy_random_sentences_to_add
+        end
+
         sentences(number: resolve(sentence_count) + rand(random_sentences_to_add.to_i).to_i, supplemental: supplemental).join(' ')
       end
 
-      def paragraphs(number: 3, supplemental: false)
+      def paragraphs(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 3, supplemental: false)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Hipster.paragraphs` is deprecated. Use keyword argument like `Hipster.paragraphs(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Hipster.paragraphs` is deprecated. Use keyword argument like `Hipster.paragraphs(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         [].tap do |paragraphs|
           1.upto(resolve(number)) do
             paragraphs << paragraph(sentence_count: 3, supplemental: supplemental)
@@ -46,7 +109,16 @@ module Faker
         end
       end
 
-      def paragraph_by_chars(characters: 256, supplemental: false)
+      def paragraph_by_chars(legacy_characters = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, characters: 256, supplemental: false)
+        if legacy_characters != NOT_GIVEN
+          warn_with_uplevel 'Passing `characters` with the 1st argument of `Hipster.paragraph_by_chars` is deprecated. Use keyword argument like `Hipster.paragraph_by_chars(characters: ...)` instead.', uplevel: 1
+          characters = legacy_characters
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Hipster.paragraph_by_chars` is deprecated. Use keyword argument like `Hipster.paragraph_by_chars(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         paragraph = paragraph(sentence_count: 3, supplemental: supplemental)
 
         paragraph += ' ' + paragraph(sentence_count: 3, supplemental: supplemental) while paragraph.length < characters

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -78,7 +78,12 @@ module Faker
         [id_number, south_african_id_checksum_digit(id_number)].join
       end
 
-      def brazilian_citizen_number(formatted: false)
+      def brazilian_citizen_number(legacy_formatted = NOT_GIVEN, formatted: false)
+        if legacy_formatted != NOT_GIVEN
+          warn_with_uplevel 'Passing `formatted` with the 1st argument of `IDNumber.brazilian_citizen_number` is deprecated. Use keyword argument like `IDNumber.brazilian_citizen_number(formatted: ...)` instead.', uplevel: 1
+          formatted = legacy_formatted
+        end
+
         digits = Faker::Number.leading_zero_number(digits: 9) until digits&.match(/(\d)((?!\1)\d)+/)
         first_digit = brazilian_citizen_number_checksum_digit(digits)
         second_digit = brazilian_citizen_number_checksum_digit(digits + first_digit)
@@ -88,7 +93,12 @@ module Faker
 
       alias brazilian_cpf brazilian_citizen_number
 
-      def brazilian_id(formatted: false)
+      def brazilian_id(legacy_formatted = NOT_GIVEN, formatted: false)
+        if legacy_formatted != NOT_GIVEN
+          warn_with_uplevel 'Passing `formatted` with the 1st argument of `IDNumber.brazilian_id` is deprecated. Use keyword argument like `IDNumber.brazilian_id(formatted: ...)` instead.', uplevel: 1
+          formatted = legacy_formatted
+        end
+
         digits = Faker::Number.between(to: BRAZILIAN_ID_FROM, from: BRAZILIAN_ID_TO).to_s
         check_digit = brazilian_id_checksum_digit(digits)
         number = [digits, check_digit].join

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -3,7 +3,16 @@
 module Faker
   class Internet < Base
     class << self
-      def email(name: nil, separators: nil)
+      def email(legacy_name = NOT_GIVEN, legacy_separators = NOT_GIVEN, name: nil, separators: nil)
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Internet.email` is deprecated. Use keyword argument like `Internet.email(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+        if legacy_separators != NOT_GIVEN
+          warn_with_uplevel 'Passing `separators` with the 2nd argument of `Internet.email` is deprecated. Use keyword argument like `Internet.email(separators: ...)` instead.', uplevel: 1
+          separators = legacy_separators
+        end
+
         if separators
           [username(specifier: name, separators: separators), domain_name].join('@')
         else
@@ -11,15 +20,34 @@ module Faker
         end
       end
 
-      def free_email(name: nil)
+      def free_email(legacy_name = NOT_GIVEN, name: nil)
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Internet.free_email` is deprecated. Use keyword argument like `Internet.free_email(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+
         [username(specifier: name), fetch('internet.free_email')].join('@')
       end
 
-      def safe_email(name: nil)
+      def safe_email(legacy_name = NOT_GIVEN, name: nil)
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Internet.safe_email` is deprecated. Use keyword argument like `Internet.safe_email(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+
         [username(specifier: name), 'example.' + sample(%w[org com net])].join('@')
       end
 
-      def username(specifier: nil, separators: %w[. _])
+      def username(legacy_specifier = NOT_GIVEN, legacy_separators = NOT_GIVEN, specifier: nil, separators: %w[. _])
+        if legacy_specifier != NOT_GIVEN
+          warn_with_uplevel 'Passing `specifier` with the 1st argument of `Internet.username` is deprecated. Use keyword argument like `Internet.username(specifier: ...)` instead.', uplevel: 1
+          specifier = legacy_specifier
+        end
+        if legacy_separators != NOT_GIVEN
+          warn_with_uplevel 'Passing `separators` with the 2nd argument of `Internet.username` is deprecated. Use keyword argument like `Internet.username(separators: ...)` instead.', uplevel: 1
+          separators = legacy_separators
+        end
+
         with_locale(:en) do
           return shuffle(specifier.scan(/[[:word:]]+/)).join(sample(separators)).downcase if specifier.respond_to?(:scan)
 
@@ -55,7 +83,26 @@ module Faker
         end
       end
 
-      def password(min_length: 8, max_length: 16, mix_case: true, special_characters: false)
+      # rubocop:disable Metrics/ParameterLists
+      def password(legacy_min_length = NOT_GIVEN, legacy_max_length = NOT_GIVEN, legacy_mix_case = NOT_GIVEN, legacy_special_characters = NOT_GIVEN, min_length: 8, max_length: 16, mix_case: true, special_characters: false)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_min_length != NOT_GIVEN
+          warn_with_uplevel 'Passing `min_length` with the 1st argument of `Internet.password` is deprecated. Use keyword argument like `Internet.password(min_length: ...)` instead.', uplevel: 1
+          min_length = legacy_min_length
+        end
+        if legacy_max_length != NOT_GIVEN
+          warn_with_uplevel 'Passing `max_length` with the 2nd argument of `Internet.password` is deprecated. Use keyword argument like `Internet.password(max_length: ...)` instead.', uplevel: 1
+          max_length = legacy_max_length
+        end
+        if legacy_mix_case != NOT_GIVEN
+          warn_with_uplevel 'Passing `mix_case` with the 3rd argument of `Internet.password` is deprecated. Use keyword argument like `Internet.password(mix_case: ...)` instead.', uplevel: 1
+          mix_case = legacy_mix_case
+        end
+        if legacy_special_characters != NOT_GIVEN
+          warn_with_uplevel 'Passing `special_characters` with the 4th argument of `Internet.password` is deprecated. Use keyword argument like `Internet.password(special_characters: ...)` instead.', uplevel: 1
+          special_characters = legacy_special_characters
+        end
+
         temp = Lorem.characters(number: min_length)
         diff_length = max_length - min_length
 
@@ -80,7 +127,12 @@ module Faker
         temp
       end
 
-      def domain_name(subdomain: false)
+      def domain_name(legacy_subdomain = NOT_GIVEN, subdomain: false)
+        if legacy_subdomain != NOT_GIVEN
+          warn_with_uplevel 'Passing `subdomain` with the 1st argument of `Internet.domain_name` is deprecated. Use keyword argument like `Internet.domain_name(subdomain: ...)` instead.', uplevel: 1
+          subdomain = legacy_subdomain
+        end
+
         with_locale(:en) do
           domain_elements = [Char.prepare(domain_word), domain_suffix]
           domain_elements.unshift(Char.prepare(domain_word)) if subdomain
@@ -88,7 +140,12 @@ module Faker
         end
       end
 
-      def fix_umlauts(string: '')
+      def fix_umlauts(legacy_string = NOT_GIVEN, string: '')
+        if legacy_string != NOT_GIVEN
+          warn_with_uplevel 'Passing `string` with the 1st argument of `Internet.fix_umlauts` is deprecated. Use keyword argument like `Internet.fix_umlauts(string: ...)` instead.', uplevel: 1
+          string = legacy_string
+        end
+
         Char.fix_umlauts(string)
       end
 
@@ -100,7 +157,12 @@ module Faker
         fetch('internet.domain_suffix')
       end
 
-      def mac_address(prefix: '')
+      def mac_address(legacy_prefix = NOT_GIVEN, prefix: '')
+        if legacy_prefix != NOT_GIVEN
+          warn_with_uplevel 'Passing `prefix` with the 1st argument of `Internet.mac_address` is deprecated. Use keyword argument like `Internet.mac_address(prefix: ...)` instead.', uplevel: 1
+          prefix = legacy_prefix
+        end
+
         prefix_digits = prefix.split(':').map { |d| d.to_i(16) }
         address_digits = Array.new((6 - prefix_digits.size)) { rand(256) }
         (prefix_digits + address_digits).map { |d| format('%02x', d) }.join(':')
@@ -174,11 +236,35 @@ module Faker
         "#{ip_v6_address}/#{rand(1..127)}"
       end
 
-      def url(host: domain_name, path: "/#{username}", scheme: 'http')
+      # rubocop:disable Metrics/ParameterLists
+      def url(legacy_host = NOT_GIVEN, legacy_path = NOT_GIVEN, legacy_scheme = NOT_GIVEN, host: domain_name, path: "/#{username}", scheme: 'http')
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_host != NOT_GIVEN
+          warn_with_uplevel 'Passing `host` with the 1st argument of `Internet.url` is deprecated. Use keyword argument like `Internet.url(host: ...)` instead.', uplevel: 1
+          host = legacy_host
+        end
+        if legacy_path != NOT_GIVEN
+          warn_with_uplevel 'Passing `path` with the 2nd argument of `Internet.url` is deprecated. Use keyword argument like `Internet.url(path: ...)` instead.', uplevel: 1
+          path = legacy_path
+        end
+        if legacy_scheme != NOT_GIVEN
+          warn_with_uplevel 'Passing `scheme` with the 3rd argument of `Internet.url` is deprecated. Use keyword argument like `Internet.url(scheme: ...)` instead.', uplevel: 1
+          scheme = legacy_scheme
+        end
+
         "#{scheme}://#{host}#{path}"
       end
 
-      def slug(words: nil, glue: nil)
+      def slug(legacy_words = NOT_GIVEN, legacy_glue = NOT_GIVEN, words: nil, glue: nil)
+        if legacy_words != NOT_GIVEN
+          warn_with_uplevel 'Passing `words` with the 1st argument of `Internet.slug` is deprecated. Use keyword argument like `Internet.slug(words: ...)` instead.', uplevel: 1
+          words = legacy_words
+        end
+        if legacy_glue != NOT_GIVEN
+          warn_with_uplevel 'Passing `glue` with the 2nd argument of `Internet.slug` is deprecated. Use keyword argument like `Internet.slug(glue: ...)` instead.', uplevel: 1
+          glue = legacy_glue
+        end
+
         glue ||= sample(%w[- _])
         (words || Faker::Lorem.words(number: 2).join(' ')).delete(',.').gsub(' ', glue).downcase
       end
@@ -187,7 +273,12 @@ module Faker
         shuffle(rand(16**64).to_s(16).rjust(64, '0').chars.to_a).join
       end
 
-      def user_agent(vendor: nil)
+      def user_agent(legacy_vendor = NOT_GIVEN, vendor: nil)
+        if legacy_vendor != NOT_GIVEN
+          warn_with_uplevel 'Passing `vendor` with the 1st argument of `Internet.user_agent` is deprecated. Use keyword argument like `Internet.user_agent(vendor: ...)` instead.', uplevel: 1
+          vendor = legacy_vendor
+        end
+
         agent_hash = translate('faker.internet.user_agent')
         agents = vendor.respond_to?(:to_sym) && agent_hash[vendor.to_sym] || agent_hash[sample(agent_hash.keys)]
         sample(agents)

--- a/lib/faker/default/invoice.rb
+++ b/lib/faker/default/invoice.rb
@@ -6,13 +6,27 @@ module Faker
 
     class << self
       # Generate random amount between values with 2 decimals
-      def amount_between(from: 0, to: 0)
+      def amount_between(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from: 0, to: 0)
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Invoice.amount_between` is deprecated. Use keyword argument like `Invoice.amount_between(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Invoice.amount_between` is deprecated. Use keyword argument like `Invoice.amount_between(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+
         Faker::Base.rand_in_range(from, to).round(2)
       end
 
       # International bank slip reference https://en.wikipedia.org/wiki/Creditor_Reference
       # ref is optional so that we can create unit tests
-      def creditor_reference(ref: '')
+      def creditor_reference(legacy_ref = NOT_GIVEN, ref: '')
+        if legacy_ref != NOT_GIVEN
+          warn_with_uplevel 'Passing `ref` with the 1st argument of `Invoice.creditor_reference` is deprecated. Use keyword argument like `Invoice.creditor_reference(ref: ...)` instead.', uplevel: 1
+          ref = legacy_ref
+        end
+
         ref = reference if ref.empty?
 
         'RF' + iban_checksum('RF', ref) + ref
@@ -20,7 +34,12 @@ module Faker
 
       # Payment references have some rules in certain countries
       # ref is optional so that we can create unit tests
-      def reference(ref: '')
+      def reference(legacy_ref = NOT_GIVEN, ref: '')
+        if legacy_ref != NOT_GIVEN
+          warn_with_uplevel 'Passing `ref` with the 1st argument of `Invoice.reference` is deprecated. Use keyword argument like `Invoice.reference(ref: ...)` instead.', uplevel: 1
+          ref = legacy_ref
+        end
+
         pattern = fetch('invoice.reference.pattern')
 
         ref = Base.regexify(/#{pattern}/) if ref.empty?

--- a/lib/faker/default/json.rb
+++ b/lib/faker/default/json.rb
@@ -3,7 +3,16 @@ module Faker
     require 'json'
 
     class << self
-      def shallow_json(width: 3, options: { key: 'Name.first_name', value: 'Name.first_name' })
+      def shallow_json(legacy_width = NOT_GIVEN, legacy_options = NOT_GIVEN, width: 3, options: { key: 'Name.first_name', value: 'Name.first_name' })
+        if legacy_width != NOT_GIVEN
+          warn_with_uplevel 'Passing `width` with the 1st argument of `Json.shallow_json` is deprecated. Use keyword argument like `Json.shallow_json(width: ...)` instead.', uplevel: 1
+          width = legacy_width
+        end
+        if legacy_options != NOT_GIVEN
+          warn_with_uplevel 'Passing `options` with the 2nd argument of `Json.shallow_json` is deprecated. Use keyword argument like `Json.shallow_json(options: ...)` instead.', uplevel: 1
+          options = legacy_options
+        end
+
         options[:key] = 'Faker::' + options[:key]
         options[:value] = 'Faker::' + options[:value]
 
@@ -11,7 +20,22 @@ module Faker
         JSON.generate(hash)
       end
 
-      def add_depth_to_json(json: shallow_json, width: 3, options: { key: 'Name.first_name', value: 'Name.first_name' })
+      # rubocop:disable Metrics/ParameterLists
+      def add_depth_to_json(legacy_json = NOT_GIVEN, legacy_width = NOT_GIVEN, legacy_options = NOT_GIVEN, json: shallow_json, width: 3, options: { key: 'Name.first_name', value: 'Name.first_name' })
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_json != NOT_GIVEN
+          warn_with_uplevel 'Passing `json` with the 1st argument of `Json.add_depth_to_json` is deprecated. Use keyword argument like `Json.add_depth_to_json(json: ...)` instead.', uplevel: 1
+          json = legacy_json
+        end
+        if legacy_width != NOT_GIVEN
+          warn_with_uplevel 'Passing `width` with the 2nd argument of `Json.add_depth_to_json` is deprecated. Use keyword argument like `Json.add_depth_to_json(width: ...)` instead.', uplevel: 1
+          width = legacy_width
+        end
+        if legacy_options != NOT_GIVEN
+          warn_with_uplevel 'Passing `options` with the 3rd argument of `Json.add_depth_to_json` is deprecated. Use keyword argument like `Json.add_depth_to_json(options: ...)` instead.', uplevel: 1
+          options = legacy_options
+        end
+
         options[:key] = 'Faker::' + options[:key]
         options[:value] = 'Faker::' + options[:value]
 

--- a/lib/faker/default/lorem.rb
+++ b/lib/faker/default/lorem.rb
@@ -8,7 +8,16 @@ module Faker
         sample(translate('faker.lorem.words'))
       end
 
-      def words(number: 3, supplemental: false)
+      def words(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 3, supplemental: false)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Lorem.words` is deprecated. Use keyword argument like `Lorem.words(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.words` is deprecated. Use keyword argument like `Lorem.words(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         resolved_num = resolve(number)
         word_list = (
           translate('faker.lorem.words') +
@@ -22,7 +31,12 @@ module Faker
         sample(Types::CHARACTERS)
       end
 
-      def characters(number: 255)
+      def characters(legacy_number = NOT_GIVEN, number: 255)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Lorem.characters` is deprecated. Use keyword argument like `Lorem.characters(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+
         Alphanumeric.alphanumeric(number: number)
       end
 
@@ -30,23 +44,80 @@ module Faker
         sample(translate('faker.lorem.multibyte')).pack('C*').force_encoding('utf-8')
       end
 
-      def sentence(word_count: 4, supplemental: false, random_words_to_add: 0)
+      # rubocop:disable Metrics/ParameterLists
+      def sentence(legacy_word_count = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, supplemental: false, random_words_to_add: 0)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_word_count != NOT_GIVEN
+          warn_with_uplevel 'Passing `word_count` with the 1st argument of `Lorem.sentence` is deprecated. Use keyword argument like `Lorem.sentence(word_count: ...)` instead.', uplevel: 1
+          word_count = legacy_word_count
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.sentence` is deprecated. Use keyword argument like `Lorem.sentence(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+        if legacy_random_words_to_add != NOT_GIVEN
+          warn_with_uplevel 'Passing `random_words_to_add` with the 3rd argument of `Lorem.sentence` is deprecated. Use keyword argument like `Lorem.sentence(random_words_to_add: ...)` instead.', uplevel: 1
+          random_words_to_add = legacy_random_words_to_add
+        end
+
         words(number: word_count + rand(random_words_to_add.to_i), supplemental: supplemental).join(' ').capitalize + locale_period
       end
 
-      def sentences(number: 3, supplemental: false)
+      def sentences(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 3, supplemental: false)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Lorem.sentences` is deprecated. Use keyword argument like `Lorem.sentences(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.sentences` is deprecated. Use keyword argument like `Lorem.sentences(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         1.upto(resolve(number)).collect { sentence(word_count: 3, supplemental: supplemental) }
       end
 
-      def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 0)
+      # rubocop:disable Metrics/ParameterLists
+      def paragraph(legacy_sentence_count = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_random_sentences_to_add = NOT_GIVEN, sentence_count: 3, supplemental: false, random_sentences_to_add: 0)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_sentence_count != NOT_GIVEN
+          warn_with_uplevel 'Passing `sentence_count` with the 1st argument of `Lorem.paragraph` is deprecated. Use keyword argument like `Lorem.paragraph(sentence_count: ...)` instead.', uplevel: 1
+          sentence_count = legacy_sentence_count
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.paragraph` is deprecated. Use keyword argument like `Lorem.paragraph(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+        if legacy_random_sentences_to_add != NOT_GIVEN
+          warn_with_uplevel 'Passing `random_sentences_to_add` with the 3rd argument of `Lorem.paragraph` is deprecated. Use keyword argument like `Lorem.paragraph(random_sentences_to_add: ...)` instead.', uplevel: 1
+          random_sentences_to_add = legacy_random_sentences_to_add
+        end
+
         sentences(number: resolve(sentence_count) + rand(random_sentences_to_add.to_i), supplemental: supplemental).join(locale_space)
       end
 
-      def paragraphs(number: 3, supplemental: false)
+      def paragraphs(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 3, supplemental: false)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Lorem.paragraphs` is deprecated. Use keyword argument like `Lorem.paragraphs(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.paragraphs` is deprecated. Use keyword argument like `Lorem.paragraphs(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         1.upto(resolve(number)).collect { paragraph(sentence_count: 3, supplemental: supplemental) }
       end
 
-      def paragraph_by_chars(number: 256, supplemental: false)
+      def paragraph_by_chars(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 256, supplemental: false)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Lorem.paragraph_by_chars` is deprecated. Use keyword argument like `Lorem.paragraph_by_chars(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.paragraph_by_chars` is deprecated. Use keyword argument like `Lorem.paragraph_by_chars(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         paragraph = paragraph(sentence_count: 3, supplemental: supplemental)
 
         paragraph += ' ' + paragraph(sentence_count: 3, supplemental: supplemental) while paragraph.length < number
@@ -54,11 +125,35 @@ module Faker
         paragraph[0...number - 1] + '.'
       end
 
-      def question(word_count: 4, supplemental: false, random_words_to_add: 0)
+      # rubocop:disable Metrics/ParameterLists
+      def question(legacy_word_count = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, supplemental: false, random_words_to_add: 0)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_word_count != NOT_GIVEN
+          warn_with_uplevel 'Passing `word_count` with the 1st argument of `Lorem.question` is deprecated. Use keyword argument like `Lorem.question(word_count: ...)` instead.', uplevel: 1
+          word_count = legacy_word_count
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.question` is deprecated. Use keyword argument like `Lorem.question(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+        if legacy_random_words_to_add != NOT_GIVEN
+          warn_with_uplevel 'Passing `random_words_to_add` with the 3rd argument of `Lorem.question` is deprecated. Use keyword argument like `Lorem.question(random_words_to_add: ...)` instead.', uplevel: 1
+          random_words_to_add = legacy_random_words_to_add
+        end
+
         words(number: word_count + rand(random_words_to_add), supplemental: supplemental).join(' ').capitalize + locale_question_mark
       end
 
-      def questions(number: 3, supplemental: false)
+      def questions(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 3, supplemental: false)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Lorem.questions` is deprecated. Use keyword argument like `Lorem.questions(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_supplemental != NOT_GIVEN
+          warn_with_uplevel 'Passing `supplemental` with the 2nd argument of `Lorem.questions` is deprecated. Use keyword argument like `Lorem.questions(supplemental: ...)` instead.', uplevel: 1
+          supplemental = legacy_supplemental
+        end
+
         1.upto(resolve(number)).collect { question(word_count: 3, supplemental: supplemental) }
       end
 

--- a/lib/faker/default/lorem_flickr.rb
+++ b/lib/faker/default/lorem_flickr.rb
@@ -5,23 +5,87 @@ module Faker
     class << self
       SUPPORTED_COLORIZATIONS = %w[red green blue].freeze
 
-      def image(size: '300x300', search_terms: [], match_all: false)
+      # rubocop:disable Metrics/ParameterLists
+      def image(legacy_size = NOT_GIVEN, legacy_search_terms = NOT_GIVEN, legacy_match_all = NOT_GIVEN, size: '300x300', search_terms: [], match_all: false)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_size != NOT_GIVEN
+          warn_with_uplevel 'Passing `size` with the 1st argument of `LoremFlickr.image` is deprecated. Use keyword argument like `LoremFlickr.image(size: ...)` instead.', uplevel: 1
+          size = legacy_size
+        end
+        if legacy_search_terms != NOT_GIVEN
+          warn_with_uplevel 'Passing `search_terms` with the 2nd argument of `LoremFlickr.image` is deprecated. Use keyword argument like `LoremFlickr.image(search_terms: ...)` instead.', uplevel: 1
+          search_terms = legacy_search_terms
+        end
+        if legacy_match_all != NOT_GIVEN
+          warn_with_uplevel 'Passing `match_all` with the 3rd argument of `LoremFlickr.image` is deprecated. Use keyword argument like `LoremFlickr.image(match_all: ...)` instead.', uplevel: 1
+          match_all = legacy_match_all
+        end
+
         build_url(size, nil, search_terms, match_all)
       end
 
-      def grayscale_image(size: '300x300', search_terms: ['all'], match_all: false)
+      # rubocop:disable Metrics/ParameterLists
+      def grayscale_image(legacy_size = NOT_GIVEN, legacy_search_terms = NOT_GIVEN, legacy_match_all = NOT_GIVEN, size: '300x300', search_terms: ['all'], match_all: false)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_size != NOT_GIVEN
+          warn_with_uplevel 'Passing `size` with the 1st argument of `LoremFlickr.grayscale_image` is deprecated. Use keyword argument like `LoremFlickr.grayscale_image(size: ...)` instead.', uplevel: 1
+          size = legacy_size
+        end
+        if legacy_search_terms != NOT_GIVEN
+          warn_with_uplevel 'Passing `search_terms` with the 2nd argument of `LoremFlickr.grayscale_image` is deprecated. Use keyword argument like `LoremFlickr.grayscale_image(search_terms: ...)` instead.', uplevel: 1
+          search_terms = legacy_search_terms
+        end
+        if legacy_match_all != NOT_GIVEN
+          warn_with_uplevel 'Passing `match_all` with the 3rd argument of `LoremFlickr.grayscale_image` is deprecated. Use keyword argument like `LoremFlickr.grayscale_image(match_all: ...)` instead.', uplevel: 1
+          match_all = legacy_match_all
+        end
+
         raise ArgumentError, 'Search terms must be specified for grayscale images' unless search_terms.any?
 
         build_url(size, 'g', search_terms, match_all)
       end
 
-      def pixelated_image(size: '300x300', search_terms: ['all'], match_all: false)
+      # rubocop:disable Metrics/ParameterLists
+      def pixelated_image(legacy_size = NOT_GIVEN, legacy_search_terms = NOT_GIVEN, legacy_match_all = NOT_GIVEN, size: '300x300', search_terms: ['all'], match_all: false)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_size != NOT_GIVEN
+          warn_with_uplevel 'Passing `size` with the 1st argument of `LoremFlickr.pixelated_image` is deprecated. Use keyword argument like `LoremFlickr.pixelated_image(size: ...)` instead.', uplevel: 1
+          size = legacy_size
+        end
+        if legacy_search_terms != NOT_GIVEN
+          warn_with_uplevel 'Passing `search_terms` with the 2nd argument of `LoremFlickr.pixelated_image` is deprecated. Use keyword argument like `LoremFlickr.pixelated_image(search_terms: ...)` instead.', uplevel: 1
+          search_terms = legacy_search_terms
+        end
+        if legacy_match_all != NOT_GIVEN
+          warn_with_uplevel 'Passing `match_all` with the 3rd argument of `LoremFlickr.pixelated_image` is deprecated. Use keyword argument like `LoremFlickr.pixelated_image(match_all: ...)` instead.', uplevel: 1
+          match_all = legacy_match_all
+        end
+
         raise ArgumentError, 'Search terms must be specified for pixelated images' unless search_terms.any?
 
         build_url(size, 'p', search_terms, match_all)
       end
 
-      def colorized_image(size: '300x300', color: 'red', search_terms: ['all'], match_all: false)
+      # rubocop:disable Metrics/ParameterLists
+      def colorized_image(legacy_size = NOT_GIVEN, legacy_color = NOT_GIVEN, legacy_search_terms = NOT_GIVEN, legacy_match_all = NOT_GIVEN, size: '300x300', color: 'red', search_terms: ['all'], match_all: false)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_size != NOT_GIVEN
+          warn_with_uplevel 'Passing `size` with the 1st argument of `LoremFlickr.colorized_image` is deprecated. Use keyword argument like `LoremFlickr.colorized_image(size: ...)` instead.', uplevel: 1
+          size = legacy_size
+        end
+        if legacy_color != NOT_GIVEN
+          warn_with_uplevel 'Passing `color` with the 2nd argument of `LoremFlickr.colorized_image` is deprecated. Use keyword argument like `LoremFlickr.colorized_image(color: ...)` instead.', uplevel: 1
+          color = legacy_color
+        end
+        if legacy_search_terms != NOT_GIVEN
+          warn_with_uplevel 'Passing `search_terms` with the 3rd argument of `LoremFlickr.colorized_image` is deprecated. Use keyword argument like `LoremFlickr.colorized_image(search_terms: ...)` instead.', uplevel: 1
+          search_terms = legacy_search_terms
+        end
+        if legacy_match_all != NOT_GIVEN
+          warn_with_uplevel 'Passing `match_all` with the 4th argument of `LoremFlickr.colorized_image` is deprecated. Use keyword argument like `LoremFlickr.colorized_image(match_all: ...)` instead.', uplevel: 1
+          match_all = legacy_match_all
+        end
+
         raise ArgumentError, 'Search terms must be specified for colorized images' unless search_terms.any?
         raise ArgumentError, "Supported colorizations are #{SUPPORTED_COLORIZATIONS.join(', ')}" unless SUPPORTED_COLORIZATIONS.include?(color)
 

--- a/lib/faker/default/lorem_pixel.rb
+++ b/lib/faker/default/lorem_pixel.rb
@@ -18,7 +18,32 @@ module Faker
                                 transport].freeze
 
       # rubocop:disable Metrics/ParameterLists
-      def image(size: '300x300', is_gray: false, category: nil, number: nil, text: nil, secure: true)
+      def image(legacy_size = NOT_GIVEN, legacy_is_gray = NOT_GIVEN, legacy_category = NOT_GIVEN, legacy_number = NOT_GIVEN, legacy_text = NOT_GIVEN, legacy_secure = NOT_GIVEN, size: '300x300', is_gray: false, category: nil, number: nil, text: nil, secure: true)
+        if legacy_size != NOT_GIVEN
+          warn_with_uplevel 'Passing `size` with the 1st argument of `LoremPixel.image` is deprecated. Use keyword argument like `LoremPixel.image(size: ...)` instead.', uplevel: 1
+          size = legacy_size
+        end
+        if legacy_is_gray != NOT_GIVEN
+          warn_with_uplevel 'Passing `is_gray` with the 2nd argument of `LoremPixel.image` is deprecated. Use keyword argument like `LoremPixel.image(is_gray: ...)` instead.', uplevel: 1
+          is_gray = legacy_is_gray
+        end
+        if legacy_category != NOT_GIVEN
+          warn_with_uplevel 'Passing `category` with the 3rd argument of `LoremPixel.image` is deprecated. Use keyword argument like `LoremPixel.image(category: ...)` instead.', uplevel: 1
+          category = legacy_category
+        end
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 4th argument of `LoremPixel.image` is deprecated. Use keyword argument like `LoremPixel.image(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_text != NOT_GIVEN
+          warn_with_uplevel 'Passing `text` with the 5th argument of `LoremPixel.image` is deprecated. Use keyword argument like `LoremPixel.image(text: ...)` instead.', uplevel: 1
+          text = legacy_text
+        end
+        if legacy_secure != NOT_GIVEN
+          warn_with_uplevel 'Passing `secure` with the 6th argument of `LoremPixel.image` is deprecated. Use keyword argument like `LoremPixel.image(secure: ...)` instead.', uplevel: 1
+          secure = legacy_secure
+        end
+
         raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
         raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
         raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?

--- a/lib/faker/default/markdown.rb
+++ b/lib/faker/default/markdown.rb
@@ -59,7 +59,16 @@ module Faker
         send(method_list[rand(0..method_list.length - 1)])
       end
 
-      def sandwich(sentences: 3, repeat: 1)
+      def sandwich(legacy_sentences = NOT_GIVEN, legacy_repeat = NOT_GIVEN, sentences: 3, repeat: 1)
+        if legacy_sentences != NOT_GIVEN
+          warn_with_uplevel 'Passing `sentences` with the 1st argument of `Markdown.sandwich` is deprecated. Use keyword argument like `Markdown.sandwich(sentences: ...)` instead.', uplevel: 1
+          sentences = legacy_sentences
+        end
+        if legacy_repeat != NOT_GIVEN
+          warn_with_uplevel 'Passing `repeat` with the 2nd argument of `Markdown.sandwich` is deprecated. Use keyword argument like `Markdown.sandwich(repeat: ...)` instead.', uplevel: 1
+          repeat = legacy_repeat
+        end
+
         text_block = []
         text_block << headers
         repeat.times do

--- a/lib/faker/default/measurement.rb
+++ b/lib/faker/default/measurement.rb
@@ -6,35 +6,75 @@ module Faker
       ALL = 'all'
       NONE = 'none'
 
-      def height(amount: rand(10))
+      def height(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.height` is deprecated. Use keyword argument like `Measurement.height(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'height')
       end
 
-      def length(amount: rand(10))
+      def length(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.length` is deprecated. Use keyword argument like `Measurement.length(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'length')
       end
 
-      def volume(amount: rand(10))
+      def volume(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.volume` is deprecated. Use keyword argument like `Measurement.volume(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'volume')
       end
 
-      def weight(amount: rand(10))
+      def weight(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.weight` is deprecated. Use keyword argument like `Measurement.weight(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'weight')
       end
 
-      def metric_height(amount: rand(10))
+      def metric_height(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.metric_height` is deprecated. Use keyword argument like `Measurement.metric_height(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'metric_height')
       end
 
-      def metric_length(amount: rand(10))
+      def metric_length(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.metric_length` is deprecated. Use keyword argument like `Measurement.metric_length(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'metric_length')
       end
 
-      def metric_volume(amount: rand(10))
+      def metric_volume(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.metric_volume` is deprecated. Use keyword argument like `Measurement.metric_volume(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'metric_volume')
       end
 
-      def metric_weight(amount: rand(10))
+      def metric_weight(legacy_amount = NOT_GIVEN, amount: rand(10))
+        if legacy_amount != NOT_GIVEN
+          warn_with_uplevel 'Passing `amount` with the 1st argument of `Measurement.metric_weight` is deprecated. Use keyword argument like `Measurement.metric_weight(amount: ...)` instead.', uplevel: 1
+          amount = legacy_amount
+        end
+
         define_measurement_locale(amount, 'metric_weight')
       end
 

--- a/lib/faker/default/name.rb
+++ b/lib/faker/default/name.rb
@@ -46,7 +46,12 @@ module Faker
         fetch('name.suffix')
       end
 
-      def initials(number: 3)
+      def initials(legacy_number = NOT_GIVEN, number: 3)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Name.initials` is deprecated. Use keyword argument like `Name.initials(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+
         (0...number).map { rand(65..90).chr }.join
       end
     end

--- a/lib/faker/default/nhs.rb
+++ b/lib/faker/default/nhs.rb
@@ -15,7 +15,12 @@ module Faker
                                                            .join('')
       end
 
-      def check_digit(number: 0)
+      def check_digit(legacy_number = NOT_GIVEN, number: 0)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `NationalHealthService.check_digit` is deprecated. Use keyword argument like `NationalHealthService.check_digit(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+
         sum = 0
         number.to_s.chars.each_with_index do |digit, idx|
           position = idx + 1

--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -3,7 +3,12 @@
 module Faker
   class Number < Base
     class << self
-      def number(digits: 10)
+      def number(legacy_digits = NOT_GIVEN, digits: 10)
+        if legacy_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `digits` with the 1st argument of `Number.number` is deprecated. Use keyword argument like `Number.number(digits: ...)` instead.', uplevel: 1
+          digits = legacy_digits
+        end
+
         return if digits < 1
         return 0 if digits == 1
 
@@ -11,11 +16,21 @@ module Faker
         ([non_zero_digit] + generate(digits - 1)).join.to_i
       end
 
-      def leading_zero_number(digits: 10)
+      def leading_zero_number(legacy_digits = NOT_GIVEN, digits: 10)
+        if legacy_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `digits` with the 1st argument of `Number.leading_zero_number` is deprecated. Use keyword argument like `Number.leading_zero_number(digits: ...)` instead.', uplevel: 1
+          digits = legacy_digits
+        end
+
         '0' + (2..digits).collect { digit }.join
       end
 
-      def decimal_part(digits: 10)
+      def decimal_part(legacy_digits = NOT_GIVEN, digits: 10)
+        if legacy_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `digits` with the 1st argument of `Number.decimal_part` is deprecated. Use keyword argument like `Number.decimal_part(digits: ...)` instead.', uplevel: 1
+          digits = legacy_digits
+        end
+
         num = ''
         if digits > 1
           num = non_zero_digit
@@ -24,7 +39,16 @@ module Faker
         leading_zero_number(digits: digits) + num.to_s
       end
 
-      def decimal(l_digits: 5, r_digits: 2)
+      def decimal(legacy_l_digits = NOT_GIVEN, legacy_r_digits = NOT_GIVEN, l_digits: 5, r_digits: 2)
+        if legacy_l_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `l_digits` with the 1st argument of `Number.decimal` is deprecated. Use keyword argument like `Number.decimal(l_digits: ...)` instead.', uplevel: 1
+          l_digits = legacy_l_digits
+        end
+        if legacy_r_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `r_digits` with the 2nd argument of `Number.decimal` is deprecated. Use keyword argument like `Number.decimal(r_digits: ...)` instead.', uplevel: 1
+          r_digits = legacy_r_digits
+        end
+
         l_d = number(digits: l_digits)
         r_d = if r_digits == 1
                 generate(r_digits)
@@ -44,34 +68,80 @@ module Faker
         rand(10)
       end
 
-      def hexadecimal(digits: 6)
+      def hexadecimal(legacy_digits = NOT_GIVEN, digits: 6)
+        if legacy_digits != NOT_GIVEN
+          warn_with_uplevel 'Passing `digits` with the 1st argument of `Number.hexadecimal` is deprecated. Use keyword argument like `Number.hexadecimal(digits: ...)` instead.', uplevel: 1
+          digits = legacy_digits
+        end
+
         hex = ''
         digits.times { hex += rand(15).to_s(16) }
         hex
       end
 
-      def normal(mean: 1, standard_deviation: 1)
+      def normal(legacy_mean = NOT_GIVEN, legacy_standard_deviation = NOT_GIVEN, mean: 1, standard_deviation: 1)
+        if legacy_mean != NOT_GIVEN
+          warn_with_uplevel 'Passing `mean` with the 1st argument of `Number.normal` is deprecated. Use keyword argument like `Number.normal(mean: ...)` instead.', uplevel: 1
+          mean = legacy_mean
+        end
+        if legacy_standard_deviation != NOT_GIVEN
+          warn_with_uplevel 'Passing `standard_deviation` with the 2nd argument of `Number.normal` is deprecated. Use keyword argument like `Number.normal(standard_deviation: ...)` instead.', uplevel: 1
+          standard_deviation = legacy_standard_deviation
+        end
+
         theta = 2 * Math::PI * rand
         rho = Math.sqrt(-2 * Math.log(1 - rand))
         scale = standard_deviation * rho
         mean + scale * Math.cos(theta)
       end
 
-      def between(from: 1.00, to: 5000.00)
+      def between(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from: 1.00, to: 5000.00)
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Number.between` is deprecated. Use keyword argument like `Number.between(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Number.between` is deprecated. Use keyword argument like `Number.between(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+
         Faker::Base.rand_in_range(from, to)
       end
 
-      def within(range: 1.00..5000.00)
+      def within(legacy_range = NOT_GIVEN, range: 1.00..5000.00)
+        if legacy_range != NOT_GIVEN
+          warn_with_uplevel 'Passing `range` with the 1st argument of `Number.within` is deprecated. Use keyword argument like `Number.within(range: ...)` instead.', uplevel: 1
+          range = legacy_range
+        end
+
         between(from: range.min, to: range.max)
       end
 
-      def positive(from: 1.00, to: 5000.00)
+      def positive(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from: 1.00, to: 5000.00)
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Number.positive` is deprecated. Use keyword argument like `Number.positive(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Number.positive` is deprecated. Use keyword argument like `Number.positive(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+
         random_number = between(from: from, to: to)
 
         greater_than_zero(random_number)
       end
 
-      def negative(from: -5000.00, to: -1.00)
+      def negative(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from: -5000.00, to: -1.00)
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Number.negative` is deprecated. Use keyword argument like `Number.negative(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Number.negative` is deprecated. Use keyword argument like `Number.negative(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+
         random_number = between(from: from, to: to)
 
         less_than_zero(random_number)

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -15,7 +15,22 @@ module Faker
     end
 
     class << self
-      def google(name: nil, email: nil, uid: Number.number(digits: 9).to_s)
+      # rubocop:disable Metrics/ParameterLists
+      def google(legacy_name = NOT_GIVEN, legacy_email = NOT_GIVEN, legacy_uid = NOT_GIVEN, name: nil, email: nil, uid: Number.number(digits: 9).to_s)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Omniauth.google` is deprecated. Use keyword argument like `Omniauth.google(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+        if legacy_email != NOT_GIVEN
+          warn_with_uplevel 'Passing `email` with the 2nd argument of `Omniauth.google` is deprecated. Use keyword argument like `Omniauth.google(email: ...)` instead.', uplevel: 1
+          email = legacy_email
+        end
+        if legacy_uid != NOT_GIVEN
+          warn_with_uplevel 'Passing `uid` with the 3rd argument of `Omniauth.google` is deprecated. Use keyword argument like `Omniauth.google(uid: ...)` instead.', uplevel: 1
+          uid = legacy_uid
+        end
+
         auth = Omniauth.new(name: name, email: email)
         {
           provider: 'google_oauth2',
@@ -64,7 +79,26 @@ module Faker
         }
       end
 
-      def facebook(name: nil, email: nil, username: nil, uid: Number.number(digits: 7).to_s)
+      # rubocop:disable Metrics/ParameterLists
+      def facebook(legacy_name = NOT_GIVEN, legacy_email = NOT_GIVEN, legacy_username = NOT_GIVEN, legacy_uid = NOT_GIVEN, name: nil, email: nil, username: nil, uid: Number.number(digits: 7).to_s)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Omniauth.facebook` is deprecated. Use keyword argument like `Omniauth.facebook(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+        if legacy_email != NOT_GIVEN
+          warn_with_uplevel 'Passing `email` with the 2nd argument of `Omniauth.facebook` is deprecated. Use keyword argument like `Omniauth.facebook(email: ...)` instead.', uplevel: 1
+          email = legacy_email
+        end
+        if legacy_username != NOT_GIVEN
+          warn_with_uplevel 'Passing `username` with the 3rd argument of `Omniauth.facebook` is deprecated. Use keyword argument like `Omniauth.facebook(username: ...)` instead.', uplevel: 1
+          username = legacy_username
+        end
+        if legacy_uid != NOT_GIVEN
+          warn_with_uplevel 'Passing `uid` with the 4th argument of `Omniauth.facebook` is deprecated. Use keyword argument like `Omniauth.facebook(uid: ...)` instead.', uplevel: 1
+          uid = legacy_uid
+        end
+
         auth = Omniauth.new(name: name, email: email)
         username ||= "#{auth.first_name.downcase[0]}#{auth.last_name.downcase}"
         {
@@ -106,7 +140,22 @@ module Faker
         }
       end
 
-      def twitter(name: nil, nickname: nil, uid: Number.number(digits: 6).to_s)
+      # rubocop:disable Metrics/ParameterLists
+      def twitter(legacy_name = NOT_GIVEN, legacy_nickname = NOT_GIVEN, legacy_uid = NOT_GIVEN, name: nil, nickname: nil, uid: Number.number(digits: 6).to_s)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Omniauth.twitter` is deprecated. Use keyword argument like `Omniauth.twitter(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+        if legacy_nickname != NOT_GIVEN
+          warn_with_uplevel 'Passing `nickname` with the 2nd argument of `Omniauth.twitter` is deprecated. Use keyword argument like `Omniauth.twitter(nickname: ...)` instead.', uplevel: 1
+          nickname = legacy_nickname
+        end
+        if legacy_uid != NOT_GIVEN
+          warn_with_uplevel 'Passing `uid` with the 3rd argument of `Omniauth.twitter` is deprecated. Use keyword argument like `Omniauth.twitter(uid: ...)` instead.', uplevel: 1
+          uid = legacy_uid
+        end
+
         auth = Omniauth.new(name: name)
         nickname ||= auth.name.downcase.delete(' ')
         location = city_state
@@ -179,7 +228,22 @@ module Faker
         }
       end
 
-      def linkedin(name: nil, email: nil, uid: Number.number(digits: 6).to_s)
+      # rubocop:disable Metrics/ParameterLists
+      def linkedin(legacy_name = NOT_GIVEN, legacy_email = NOT_GIVEN, legacy_uid = NOT_GIVEN, name: nil, email: nil, uid: Number.number(digits: 6).to_s)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Omniauth.linkedin` is deprecated. Use keyword argument like `Omniauth.linkedin(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+        if legacy_email != NOT_GIVEN
+          warn_with_uplevel 'Passing `email` with the 2nd argument of `Omniauth.linkedin` is deprecated. Use keyword argument like `Omniauth.linkedin(email: ...)` instead.', uplevel: 1
+          email = legacy_email
+        end
+        if legacy_uid != NOT_GIVEN
+          warn_with_uplevel 'Passing `uid` with the 3rd argument of `Omniauth.linkedin` is deprecated. Use keyword argument like `Omniauth.linkedin(uid: ...)` instead.', uplevel: 1
+          uid = legacy_uid
+        end
+
         auth = Omniauth.new(name: name, email: email)
         first_name = auth.first_name.downcase
         last_name = auth.last_name.downcase
@@ -242,7 +306,22 @@ module Faker
         }
       end
 
-      def github(name: nil, email: nil, uid: Number.number(digits: 8).to_s)
+      # rubocop:disable Metrics/ParameterLists
+      def github(legacy_name = NOT_GIVEN, legacy_email = NOT_GIVEN, legacy_uid = NOT_GIVEN, name: nil, email: nil, uid: Number.number(digits: 8).to_s)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_name != NOT_GIVEN
+          warn_with_uplevel 'Passing `name` with the 1st argument of `Omniauth.github` is deprecated. Use keyword argument like `Omniauth.github(name: ...)` instead.', uplevel: 1
+          name = legacy_name
+        end
+        if legacy_email != NOT_GIVEN
+          warn_with_uplevel 'Passing `email` with the 2nd argument of `Omniauth.github` is deprecated. Use keyword argument like `Omniauth.github(email: ...)` instead.', uplevel: 1
+          email = legacy_email
+        end
+        if legacy_uid != NOT_GIVEN
+          warn_with_uplevel 'Passing `uid` with the 3rd argument of `Omniauth.github` is deprecated. Use keyword argument like `Omniauth.github(uid: ...)` instead.', uplevel: 1
+          uid = legacy_uid
+        end
+
         auth = Omniauth.new(name: name, email: email)
         login = auth.name.downcase.tr(' ', '-')
         html_url = "https://github.com/#{login}"

--- a/lib/faker/default/phone_number.rb
+++ b/lib/faker/default/phone_number.rb
@@ -40,7 +40,12 @@ module Faker
       # US and Canada only
       # Can be used for both extensions and last four digits of phone number.
       # Since extensions can be of variable length, this method taks a length parameter
-      def subscriber_number(length: 4)
+      def subscriber_number(legacy_length = NOT_GIVEN, length: 4)
+        if legacy_length != NOT_GIVEN
+          warn_with_uplevel 'Passing `length` with the 1st argument of `PhoneNumber.subscriber_number` is deprecated. Use keyword argument like `PhoneNumber.subscriber_number(length: ...)` instead.', uplevel: 1
+          length = legacy_length
+        end
+
         rand.to_s[2..(1 + length)]
       end
 

--- a/lib/faker/default/placeholdit.rb
+++ b/lib/faker/default/placeholdit.rb
@@ -5,7 +5,30 @@ module Faker
     class << self
       SUPPORTED_FORMATS = %w[png jpg gif jpeg].freeze
 
-      def image(size: '300x300', format: 'png', background_color: nil, text_color: nil, text: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def image(legacy_size = NOT_GIVEN, legacy_format = NOT_GIVEN, legacy_background_color = NOT_GIVEN, legacy_text_color = NOT_GIVEN, legacy_text = NOT_GIVEN, size: '300x300', format: 'png', background_color: nil, text_color: nil, text: nil)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_size != NOT_GIVEN
+          warn_with_uplevel 'Passing `size` with the 1st argument of `Placeholdit.image` is deprecated. Use keyword argument like `Placeholdit.image(size: ...)` instead.', uplevel: 1
+          size = legacy_size
+        end
+        if legacy_format != NOT_GIVEN
+          warn_with_uplevel 'Passing `format` with the 2nd argument of `Placeholdit.image` is deprecated. Use keyword argument like `Placeholdit.image(format: ...)` instead.', uplevel: 1
+          format = legacy_format
+        end
+        if legacy_background_color != NOT_GIVEN
+          warn_with_uplevel 'Passing `background_color` with the 3rd argument of `Placeholdit.image` is deprecated. Use keyword argument like `Placeholdit.image(background_color: ...)` instead.', uplevel: 1
+          background_color = legacy_background_color
+        end
+        if legacy_text_color != NOT_GIVEN
+          warn_with_uplevel 'Passing `text_color` with the 4th argument of `Placeholdit.image` is deprecated. Use keyword argument like `Placeholdit.image(text_color: ...)` instead.', uplevel: 1
+          text_color = legacy_text_color
+        end
+        if legacy_text != NOT_GIVEN
+          warn_with_uplevel 'Passing `text` with the 5th argument of `Placeholdit.image` is deprecated. Use keyword argument like `Placeholdit.image(text: ...)` instead.', uplevel: 1
+          text = legacy_text
+        end
+
         background_color = generate_color if background_color == :random
         text_color = generate_color if text_color == :random
 

--- a/lib/faker/default/relationship.rb
+++ b/lib/faker/default/relationship.rb
@@ -5,7 +5,12 @@ module Faker
     flexible :relationship
 
     class << self
-      def familial(connection: nil)
+      def familial(legacy_connection = NOT_GIVEN, connection: nil)
+        if legacy_connection != NOT_GIVEN
+          warn_with_uplevel 'Passing `connection` with the 1st argument of `Relationship.familial` is deprecated. Use keyword argument like `Relationship.familial(connection: ...)` instead.', uplevel: 1
+          connection = legacy_connection
+        end
+
         familial_connections = translate('faker.relationship.familial').keys
 
         if connection.nil?

--- a/lib/faker/default/source.rb
+++ b/lib/faker/default/source.rb
@@ -3,16 +3,35 @@
 module Faker
   class Source < Base
     class << self
-      def hello_world(lang: :ruby)
+      def hello_world(legacy_lang = NOT_GIVEN, lang: :ruby)
+        if legacy_lang != NOT_GIVEN
+          warn_with_uplevel 'Passing `lang` with the 1st argument of `Source.hello_world` is deprecated. Use keyword argument like `Source.hello_world(lang: ...)` instead.', uplevel: 1
+          lang = legacy_lang
+        end
+
         fetch("source.hello_world.#{lang}")
       end
 
-      def print(str: 'some string', lang: :ruby)
+      def print(legacy_str = NOT_GIVEN, legacy_lang = NOT_GIVEN, str: 'some string', lang: :ruby)
+        if legacy_str != NOT_GIVEN
+          warn_with_uplevel 'Passing `str` with the 1st argument of `Source.print` is deprecated. Use keyword argument like `Source.print(str: ...)` instead.', uplevel: 1
+          str = legacy_str
+        end
+        if legacy_lang != NOT_GIVEN
+          warn_with_uplevel 'Passing `lang` with the 2nd argument of `Source.print` is deprecated. Use keyword argument like `Source.print(lang: ...)` instead.', uplevel: 1
+          lang = legacy_lang
+        end
+
         code = fetch("source.print.#{lang}")
         code.gsub('faker_string_to_print', str)
       end
 
-      def print_1_to_10(lang: :ruby)
+      def print_1_to_10(legacy_lang = NOT_GIVEN, lang: :ruby)
+        if legacy_lang != NOT_GIVEN
+          warn_with_uplevel 'Passing `lang` with the 1st argument of `Source.print_1_to_10` is deprecated. Use keyword argument like `Source.print_1_to_10(lang: ...)` instead.', uplevel: 1
+          lang = legacy_lang
+        end
+
         fetch("source.print_1_to_10.#{lang}")
       end
     end

--- a/lib/faker/default/string.rb
+++ b/lib/faker/default/string.rb
@@ -3,7 +3,12 @@
 module Faker
   class String < Base
     class << self
-      def random(length: 32)
+      def random(legacy_length = NOT_GIVEN, length: 32)
+        if legacy_length != NOT_GIVEN
+          warn_with_uplevel 'Passing `length` with the 1st argument of `String.random` is deprecated. Use keyword argument like `String.random(length: ...)` instead.', uplevel: 1
+          length = legacy_length
+        end
+
         utf8string select_a length
       end
 

--- a/lib/faker/default/stripe.rb
+++ b/lib/faker/default/stripe.rb
@@ -3,7 +3,12 @@
 module Faker
   class Stripe < Base
     class << self
-      def valid_card(card_type: nil)
+      def valid_card(legacy_card_type = NOT_GIVEN, card_type: nil)
+        if legacy_card_type != NOT_GIVEN
+          warn_with_uplevel 'Passing `card_type` with the 1st argument of `Stripe.valid_card` is deprecated. Use keyword argument like `Stripe.valid_card(card_type: ...)` instead.', uplevel: 1
+          card_type = legacy_card_type
+        end
+
         valid_cards = translate('faker.stripe.valid_cards').keys
 
         if card_type.nil?
@@ -18,7 +23,12 @@ module Faker
         fetch('stripe.valid_cards.' + card_type)
       end
 
-      def valid_token(card_type: nil)
+      def valid_token(legacy_card_type = NOT_GIVEN, card_type: nil)
+        if legacy_card_type != NOT_GIVEN
+          warn_with_uplevel 'Passing `card_type` with the 1st argument of `Stripe.valid_token` is deprecated. Use keyword argument like `Stripe.valid_token(card_type: ...)` instead.', uplevel: 1
+          card_type = legacy_card_type
+        end
+
         valid_tokens = translate('faker.stripe.valid_tokens').keys
 
         if card_type.nil?
@@ -33,7 +43,12 @@ module Faker
         fetch('stripe.valid_tokens.' + card_type)
       end
 
-      def invalid_card(card_error: nil)
+      def invalid_card(legacy_card_error = NOT_GIVEN, card_error: nil)
+        if legacy_card_error != NOT_GIVEN
+          warn_with_uplevel 'Passing `card_error` with the 1st argument of `Stripe.invalid_card` is deprecated. Use keyword argument like `Stripe.invalid_card(card_error: ...)` instead.', uplevel: 1
+          card_error = legacy_card_error
+        end
+
         invalid_cards = translate('faker.stripe.invalid_cards').keys
 
         if card_error.nil?
@@ -57,7 +72,12 @@ module Faker
         rand_in_range(start_year, start_year + 5).to_s
       end
 
-      def ccv(card_type: nil)
+      def ccv(legacy_card_type = NOT_GIVEN, card_type: nil)
+        if legacy_card_type != NOT_GIVEN
+          warn_with_uplevel 'Passing `card_type` with the 1st argument of `Stripe.ccv` is deprecated. Use keyword argument like `Stripe.ccv(card_type: ...)` instead.', uplevel: 1
+          card_type = legacy_card_type
+        end
+
         (card_type.to_s == 'amex' ? rand_in_range(1000, 9999) : rand_in_range(100, 999)).to_s
       end
     end

--- a/lib/faker/default/time.rb
+++ b/lib/faker/default/time.rb
@@ -13,7 +13,22 @@ module Faker
     }.freeze
 
     class << self
-      def between(from:, to:, format: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def between(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, legacy_format = NOT_GIVEN, from:, to:, format: nil)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Time.between` is deprecated. Use keyword argument like `Time.between(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Time.between` is deprecated. Use keyword argument like `Time.between(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+        if legacy_format != NOT_GIVEN
+          warn_with_uplevel 'Passing `format` with the 3rd argument of `Time.between` is deprecated. Use keyword argument like `Time.between(format: ...)` instead.', uplevel: 1
+          format = legacy_format
+        end
+
         from = get_time_object(from)
         to = get_time_object(to)
 
@@ -21,17 +36,66 @@ module Faker
         time_with_format(time, format)
       end
 
-      def between_dates(from:, to:, period: :all, format: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def between_dates(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, legacy_period = NOT_GIVEN, legacy_format = NOT_GIVEN, from:, to:, period: :all, format: nil)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Time.between_dates` is deprecated. Use keyword argument like `Time.between_dates(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Time.between_dates` is deprecated. Use keyword argument like `Time.between_dates(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+        if legacy_period != NOT_GIVEN
+          warn_with_uplevel 'Passing `period` with the 3rd argument of `Time.between_dates` is deprecated. Use keyword argument like `Time.between_dates(period: ...)` instead.', uplevel: 1
+          period = legacy_period
+        end
+        if legacy_format != NOT_GIVEN
+          warn_with_uplevel 'Passing `format` with the 4th argument of `Time.between_dates` is deprecated. Use keyword argument like `Time.between_dates(format: ...)` instead.', uplevel: 1
+          format = legacy_format
+        end
+
         date = Faker::Date.between(from: from, to: to)
         time = date_with_random_time(date, period)
         time_with_format(time, format)
       end
 
-      def forward(days: 365, period: :all, format: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def forward(legacy_days = NOT_GIVEN, legacy_period = NOT_GIVEN, legacy_format = NOT_GIVEN, days: 365, period: :all, format: nil)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_days != NOT_GIVEN
+          warn_with_uplevel 'Passing `days` with the 1st argument of `Time.forward` is deprecated. Use keyword argument like `Time.forward(days: ...)` instead.', uplevel: 1
+          days = legacy_days
+        end
+        if legacy_period != NOT_GIVEN
+          warn_with_uplevel 'Passing `period` with the 2nd argument of `Time.forward` is deprecated. Use keyword argument like `Time.forward(period: ...)` instead.', uplevel: 1
+          period = legacy_period
+        end
+        if legacy_format != NOT_GIVEN
+          warn_with_uplevel 'Passing `format` with the 3rd argument of `Time.forward` is deprecated. Use keyword argument like `Time.forward(format: ...)` instead.', uplevel: 1
+          format = legacy_format
+        end
+
         time_with_format(date_with_random_time(Faker::Date.forward(days: days), period), format)
       end
 
-      def backward(days: 365, period: :all, format: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def backward(legacy_days = NOT_GIVEN, legacy_period = NOT_GIVEN, legacy_format = NOT_GIVEN, days: 365, period: :all, format: nil)
+        # rubocop:enable Metrics/ParameterLists
+        if legacy_days != NOT_GIVEN
+          warn_with_uplevel 'Passing `days` with the 1st argument of `Time.backward` is deprecated. Use keyword argument like `Time.backward(days: ...)` instead.', uplevel: 1
+          days = legacy_days
+        end
+        if legacy_period != NOT_GIVEN
+          warn_with_uplevel 'Passing `period` with the 2nd argument of `Time.backward` is deprecated. Use keyword argument like `Time.backward(period: ...)` instead.', uplevel: 1
+          period = legacy_period
+        end
+        if legacy_format != NOT_GIVEN
+          warn_with_uplevel 'Passing `format` with the 3rd argument of `Time.backward` is deprecated. Use keyword argument like `Time.backward(format: ...)` instead.', uplevel: 1
+          format = legacy_format
+        end
+
         time_with_format(date_with_random_time(Faker::Date.backward(days: days), period), format)
       end
 

--- a/lib/faker/default/twitter.rb
+++ b/lib/faker/default/twitter.rb
@@ -3,7 +3,16 @@
 module Faker
   class Twitter < Base
     class << self
-      def user(include_status: true, include_email: false)
+      def user(legacy_include_status = NOT_GIVEN, legacy_include_email = NOT_GIVEN, include_status: true, include_email: false)
+        if legacy_include_status != NOT_GIVEN
+          warn_with_uplevel 'Passing `include_status` with the 1st argument of `Twitter.user` is deprecated. Use keyword argument like `Twitter.user(include_status: ...)` instead.', uplevel: 1
+          include_status = legacy_include_status
+        end
+        if legacy_include_email != NOT_GIVEN
+          warn_with_uplevel 'Passing `include_email` with the 2nd argument of `Twitter.user` is deprecated. Use keyword argument like `Twitter.user(include_email: ...)` instead.', uplevel: 1
+          include_email = legacy_include_email
+        end
+
         user_id = id
         background_image_url = Faker::LoremPixel.image(size: '600x400') # TODO: Make the dimensions change
         profile_image_url = Faker::Avatar.image(slug: user_id, size: '48x48')
@@ -54,7 +63,16 @@ module Faker
         user
       end
 
-      def status(include_user: true, include_photo: false)
+      def status(legacy_include_user = NOT_GIVEN, legacy_include_photo = NOT_GIVEN, include_user: true, include_photo: false)
+        if legacy_include_user != NOT_GIVEN
+          warn_with_uplevel 'Passing `include_user` with the 1st argument of `Twitter.status` is deprecated. Use keyword argument like `Twitter.status(include_user: ...)` instead.', uplevel: 1
+          include_user = legacy_include_user
+        end
+        if legacy_include_photo != NOT_GIVEN
+          warn_with_uplevel 'Passing `include_photo` with the 2nd argument of `Twitter.status` is deprecated. Use keyword argument like `Twitter.status(include_photo: ...)` instead.', uplevel: 1
+          include_photo = legacy_include_photo
+        end
+
         status_id = id
         status = {
           id: status_id,
@@ -116,7 +134,12 @@ module Faker
         }
       end
 
-      def status_entities(include_photo: false)
+      def status_entities(legacy_include_photo = NOT_GIVEN, include_photo: false)
+        if legacy_include_photo != NOT_GIVEN
+          warn_with_uplevel 'Passing `include_photo` with the 1st argument of `Twitter.status_entities` is deprecated. Use keyword argument like `Twitter.status_entities(include_photo: ...)` instead.', uplevel: 1
+          include_photo = legacy_include_photo
+        end
+
         entities = {
           hashtags:  [],
           symbols:  [],

--- a/lib/faker/default/types.rb
+++ b/lib/faker/default/types.rb
@@ -7,7 +7,12 @@ module Faker
     COMPLEX_TYPES = %i[hash array].freeze
 
     class << self
-      def rb_string(words: 1)
+      def rb_string(legacy_words = NOT_GIVEN, words: 1)
+        if legacy_words != NOT_GIVEN
+          warn_with_uplevel 'Passing `words` with the 1st argument of `Types.rb_string` is deprecated. Use keyword argument like `Types.rb_string(words: ...)` instead.', uplevel: 1
+          words = legacy_words
+        end
+
         resolved_num = resolve(words)
         word_list =
           translate('faker.lorem.words')
@@ -20,11 +25,29 @@ module Faker
         sample(CHARACTERS)
       end
 
-      def rb_integer(from: 0, to: 100)
+      def rb_integer(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from: 0, to: 100)
+        if legacy_from != NOT_GIVEN
+          warn_with_uplevel 'Passing `from` with the 1st argument of `Types.rb_integer` is deprecated. Use keyword argument like `Types.rb_integer(from: ...)` instead.', uplevel: 1
+          from = legacy_from
+        end
+        if legacy_to != NOT_GIVEN
+          warn_with_uplevel 'Passing `to` with the 2nd argument of `Types.rb_integer` is deprecated. Use keyword argument like `Types.rb_integer(to: ...)` instead.', uplevel: 1
+          to = legacy_to
+        end
+
         rand(from..to).to_i
       end
 
-      def rb_hash(number: 1, type: random_type)
+      def rb_hash(legacy_number = NOT_GIVEN, legacy_type = NOT_GIVEN, number: 1, type: random_type)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Types.rb_hash` is deprecated. Use keyword argument like `Types.rb_hash(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+        if legacy_type != NOT_GIVEN
+          warn_with_uplevel 'Passing `type` with the 2nd argument of `Types.rb_hash` is deprecated. Use keyword argument like `Types.rb_hash(type: ...)` instead.', uplevel: 1
+          type = legacy_type
+        end
+
         {}.tap do |hsh|
           Lorem.words(number: number * 2).uniq.first(number).each do |s|
             hsh.merge!(s.to_sym => type)
@@ -32,11 +55,21 @@ module Faker
         end
       end
 
-      def complex_rb_hash(number: 1)
+      def complex_rb_hash(legacy_number = NOT_GIVEN, number: 1)
+        if legacy_number != NOT_GIVEN
+          warn_with_uplevel 'Passing `number` with the 1st argument of `Types.complex_rb_hash` is deprecated. Use keyword argument like `Types.complex_rb_hash(number: ...)` instead.', uplevel: 1
+          number = legacy_number
+        end
+
         rb_hash(number: number, type: random_complex_type)
       end
 
-      def rb_array(len: 1)
+      def rb_array(legacy_len = NOT_GIVEN, len: 1)
+        if legacy_len != NOT_GIVEN
+          warn_with_uplevel 'Passing `len` with the 1st argument of `Types.rb_array` is deprecated. Use keyword argument like `Types.rb_array(len: ...)` instead.', uplevel: 1
+          len = legacy_len
+        end
+
         [].tap do |ar|
           len.times do
             ar.push random_type

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -26,7 +26,12 @@ module Faker
         fetch('vehicle.makes')
       end
 
-      def model(make_of_model: '')
+      def model(legacy_make_of_model = NOT_GIVEN, make_of_model: '')
+        if legacy_make_of_model != NOT_GIVEN
+          warn_with_uplevel 'Passing `make_of_model` with the 1st argument of `Vehicle.model` is deprecated. Use keyword argument like `Vehicle.model(make_of_model: ...)` instead.', uplevel: 1
+          make_of_model = legacy_make_of_model
+        end
+
         return fetch("vehicle.models_by_make.#{make}") if make_of_model.empty?
 
         fetch("vehicle.models_by_make.#{make_of_model}")
@@ -85,13 +90,27 @@ module Faker
         Faker::Time.backward(days: rand_in_range(365, 5475), period: :all, format: '%Y').to_i
       end
 
-      def mileage(min: MILEAGE_MIN, max: MILEAGE_MAX)
+      def mileage(legacy_min = NOT_GIVEN, legacy_max = NOT_GIVEN, min: MILEAGE_MIN, max: MILEAGE_MAX)
+        if legacy_min != NOT_GIVEN
+          warn_with_uplevel 'Passing `min` with the 1st argument of `Vehicle.mileage` is deprecated. Use keyword argument like `Vehicle.mileage(min: ...)` instead.', uplevel: 1
+          min = legacy_min
+        end
+        if legacy_max != NOT_GIVEN
+          warn_with_uplevel 'Passing `max` with the 2nd argument of `Vehicle.mileage` is deprecated. Use keyword argument like `Vehicle.mileage(max: ...)` instead.', uplevel: 1
+          max = legacy_max
+        end
+
         rand_in_range(min, max)
       end
 
       alias kilometrage mileage
 
-      def license_plate(state_abreviation: '')
+      def license_plate(legacy_state_abreviation = NOT_GIVEN, state_abreviation: '')
+        if legacy_state_abreviation != NOT_GIVEN
+          warn_with_uplevel 'Passing `state_abreviation` with the 1st argument of `Vehicle.license_plate` is deprecated. Use keyword argument like `Vehicle.license_plate(state_abreviation: ...)` instead.', uplevel: 1
+          state_abreviation = legacy_state_abreviation
+        end
+
         return regexify(bothify(fetch('vehicle.license_plate'))) if state_abreviation.empty?
 
         key = 'vehicle.license_plate_by_state.' + state_abreviation

--- a/lib/faker/default/world_cup.rb
+++ b/lib/faker/default/world_cup.rb
@@ -15,11 +15,25 @@ module Faker
         fetch('world_cup.stadiums')
       end
 
-      def group(group: 'group_A')
+      def group(legacy_group = NOT_GIVEN, group: 'group_A')
+        if legacy_group != NOT_GIVEN
+          warn_with_uplevel 'Passing `group` with the 1st argument of `WorldCup.group` is deprecated. Use keyword argument like `WorldCup.group(group: ...)` instead.', uplevel: 1
+          group = legacy_group
+        end
+
         fetch("world_cup.groups.#{group}")
       end
 
-      def roster(country: 'Egypt', type: 'coach')
+      def roster(legacy_country = NOT_GIVEN, legacy_type = NOT_GIVEN, country: 'Egypt', type: 'coach')
+        if legacy_country != NOT_GIVEN
+          warn_with_uplevel 'Passing `country` with the 1st argument of `WorldCup.roster` is deprecated. Use keyword argument like `WorldCup.roster(country: ...)` instead.', uplevel: 1
+          country = legacy_country
+        end
+        if legacy_type != NOT_GIVEN
+          warn_with_uplevel 'Passing `type` with the 2nd argument of `WorldCup.roster` is deprecated. Use keyword argument like `WorldCup.roster(type: ...)` instead.', uplevel: 1
+          type = legacy_type
+        end
+
         fetch("world_cup.rosters.#{country}.#{type}")
       end
     end

--- a/lib/faker/games/dota.rb
+++ b/lib/faker/games/dota.rb
@@ -20,7 +20,12 @@ module Faker
           fetch('games.dota.player')
         end
 
-        def quote(hero: 'abaddon')
+        def quote(legacy_hero = NOT_GIVEN, hero: 'abaddon')
+          if legacy_hero != NOT_GIVEN
+            warn_with_uplevel 'Passing `hero` with the 1st argument of `Dota.quote` is deprecated. Use keyword argument like `Dota.quote(hero: ...)` instead.', uplevel: 1
+            hero = legacy_hero
+          end
+
           fetch("games.dota.#{hero}.quote")
         end
       end

--- a/lib/faker/movies/star_wars.rb
+++ b/lib/faker/movies/star_wars.rb
@@ -44,7 +44,12 @@ module Faker
           sentence + sample(['.', '?', '!'])
         end
 
-        def quote(character: nil)
+        def quote(legacy_character = NOT_GIVEN, character: nil)
+          if legacy_character != NOT_GIVEN
+            warn_with_uplevel 'Passing `character` with the 1st argument of `StarWars.quote` is deprecated. Use keyword argument like `StarWars.quote(character: ...)` instead.', uplevel: 1
+            character = legacy_character
+          end
+
           quoted_characters = translate('faker.star_wars.quotes')
 
           if character.nil?

--- a/test/faker/default/test_faker_measurement.rb
+++ b/test/faker/default/test_faker_measurement.rb
@@ -53,7 +53,7 @@ class TestFakerMeasurement < Test::Unit::TestCase
     amount = 'hello world!'
 
     assert_raise ArgumentError do
-      @tester.volume(amount)
+      @tester.volume(amount: amount)
     end
   end
 end


### PR DESCRIPTION
## Summary

An `ArgumentError` occurred when upgrading to Faker 2.0.
I didn't know what argument to change until I arrived at the changelog.
https://github.com/faker-ruby/faker/blob/v2.1.2/CHANGELOG.md#important-note

This PR will warn users what keyword arguments should be changed when positional arguments is used.

This reduces users pain and makes upgrades easier.

The following is an example.

```console
% cat example.rb
require 'faker'

Faker::Address.zip_code('NY')
```

### Before

```console
% bundle exec ruby example.rb
Traceback (most recent call last):
        1: from example.rb:3:in `<main>'
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faker-2.1.2/lib/faker/default/address.rb:32:in
`zip_code': wrong number of arguments (given 1, expected 0) (ArgumentError)
```

### After

```console
% bundle exec ruby example.rb
example.rb:3: Passing `state_abbreviation` with the 1st argument of
`Address.zip_code` is deprecated. Use keyword argument like
`Address.zip_code(state_abbreviation: ...)` instead.
```

## Other Information

The `uplevel` keyword argument of `warn` method is a feature from Ruby 2.5. Faker supports Ruby 2.3 orh higehr, so it is emulated with `warn_with_uplevel` method.

