### PR TITLE
Return HTTPS URLs from Lorem Flickr

### DIFF
--- a/doc/default/lorem_flickr.md
+++ b/doc/default/lorem_flickr.md
@@ -4,31 +4,31 @@ Available since version 1.9.0.
 
 ```ruby
 # Keyword arguments: size, search_terms, match_all
-Faker::LoremFlickr.image #=> "http://loremflickr.com/300/300"
-Faker::LoremFlickr.image(size: "50x60") #=> "http://loremflickr.com/50/60"
-Faker::LoremFlickr.image(size: "50x60", search_terms: ['sports']) #=> "http://loremflickr.com/50/60/sports"
-Faker::LoremFlickr.image(size: "50x60", search_terms: ['sports', 'fitness']) #=> "http://loremflickr.com/50/60/sports,fitness"
-Faker::LoremFlickr.image(size: "50x60", search_terms: ['sports', 'fitness'], match_all: true) #=> "http://loremflickr.com/50/60/sports,fitness/all"
+Faker::LoremFlickr.image #=> "https://loremflickr.com/300/300"
+Faker::LoremFlickr.image(size: "50x60") #=> "https://loremflickr.com/50/60"
+Faker::LoremFlickr.image(size: "50x60", search_terms: ['sports']) #=> "https://loremflickr.com/50/60/sports"
+Faker::LoremFlickr.image(size: "50x60", search_terms: ['sports', 'fitness']) #=> "https://loremflickr.com/50/60/sports,fitness"
+Faker::LoremFlickr.image(size: "50x60", search_terms: ['sports', 'fitness'], match_all: true) #=> "https://loremflickr.com/50/60/sports,fitness/all"
 
 # Keyword arguments: size, search_terms, match_all
-Faker::LoremFlickr.grayscale_image #=> "http://loremflickr.com/g/300/300/all"
-Faker::LoremFlickr.grayscale_image(size: "50x60") #=> "http://loremflickr.com/g/50/60/all"
-Faker::LoremFlickr.grayscale_image(size: "50x60", search_terms: ['sports']) #=> "http://loremflickr.com/g/50/60/sports"
-Faker::LoremFlickr.grayscale_image(size: "50x60", search_terms: ['sports', 'fitness']) #=> "http://loremflickr.com/g/50/60/sports,fitness"
-Faker::LoremFlickr.grayscale_image(size: "50x60", search_terms: ['sports', 'fitness'], match_all: true) #=> "http://loremflickr.com/g/50/60/sports,fitness/all"
+Faker::LoremFlickr.grayscale_image #=> "https://loremflickr.com/g/300/300/all"
+Faker::LoremFlickr.grayscale_image(size: "50x60") #=> "https://loremflickr.com/g/50/60/all"
+Faker::LoremFlickr.grayscale_image(size: "50x60", search_terms: ['sports']) #=> "https://loremflickr.com/g/50/60/sports"
+Faker::LoremFlickr.grayscale_image(size: "50x60", search_terms: ['sports', 'fitness']) #=> "https://loremflickr.com/g/50/60/sports,fitness"
+Faker::LoremFlickr.grayscale_image(size: "50x60", search_terms: ['sports', 'fitness'], match_all: true) #=> "https://loremflickr.com/g/50/60/sports,fitness/all"
 
 # Keyword arguments: size, search_terms, match_all
-Faker::LoremFlickr.pixelated_image #=> "http://loremflickr.com/p/300/300/all"
-Faker::LoremFlickr.pixelated_image(size: "50x60") #=> "http://loremflickr.com/p/50/60/all"
-Faker::LoremFlickr.pixelated_image(size: "50x60", search_terms: ['sports']) #=> "http://loremflickr.com/p/50/60/sports"
-Faker::LoremFlickr.pixelated_image(size: "50x60", search_terms: ['sports', 'fitness']) #=> "http://loremflickr.com/p/50/60/sports,fitness"
-Faker::LoremFlickr.pixelated_image(size: "50x60", search_terms: ['sports', 'fitness'], match_all: true) #=> "http://loremflickr.com/p/50/60/sports,fitness/all"
+Faker::LoremFlickr.pixelated_image #=> "https://loremflickr.com/p/300/300/all"
+Faker::LoremFlickr.pixelated_image(size: "50x60") #=> "https://loremflickr.com/p/50/60/all"
+Faker::LoremFlickr.pixelated_image(size: "50x60", search_terms: ['sports']) #=> "https://loremflickr.com/p/50/60/sports"
+Faker::LoremFlickr.pixelated_image(size: "50x60", search_terms: ['sports', 'fitness']) #=> "https://loremflickr.com/p/50/60/sports,fitness"
+Faker::LoremFlickr.pixelated_image(size: "50x60", search_terms: ['sports', 'fitness'], match_all: true) #=> "https://loremflickr.com/p/50/60/sports,fitness/all"
 
 # Keyword arguments: size, search_terms, match_all
-Faker::LoremFlickr.colorized_image #=> "http://loremflickr.com/red/300/300/all"
-Faker::LoremFlickr.colorized_image(size: "50x60") #=> "http://loremflickr.com/red/50/60/all"
-Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red') #=> "http://loremflickr.com/red/50/60/all"
-Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red', search_terms: ['sports']) #=> "http://loremflickr.com/red/50/60/sports"
-Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red', search_terms: ['sports', 'fitness']) #=> "http://loremflickr.com/red/50/60/sports,fitness"
-Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red', search_terms: ['sports', 'fitness'], match_all: true) #=> "http://loremflickr.com/red/50/60/sports,fitness/all"
+Faker::LoremFlickr.colorized_image #=> "https://loremflickr.com/red/300/300/all"
+Faker::LoremFlickr.colorized_image(size: "50x60") #=> "https://loremflickr.com/red/50/60/all"
+Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red') #=> "https://loremflickr.com/red/50/60/all"
+Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red', search_terms: ['sports']) #=> "https://loremflickr.com/red/50/60/sports"
+Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red', search_terms: ['sports', 'fitness']) #=> "https://loremflickr.com/red/50/60/sports,fitness"
+Faker::LoremFlickr.colorized_image(size: "50x60", color: 'red', search_terms: ['sports', 'fitness'], match_all: true) #=> "https://loremflickr.com/red/50/60/sports,fitness/all"
 ```

--- a/lib/faker/default/lorem_flickr.rb
+++ b/lib/faker/default/lorem_flickr.rb
@@ -33,7 +33,7 @@ module Faker
       def build_url(size, format, search_terms, match_all)
         raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
 
-        url_parts = ['http://loremflickr.com']
+        url_parts = ['https://loremflickr.com']
         url_parts << format
         url_parts += size.split('x')
         url_parts << search_terms.compact.join(',') if search_terms.any?

--- a/test/faker/default/test_faker_lorem_flickr.rb
+++ b/test/faker/default/test_faker_lorem_flickr.rb
@@ -9,11 +9,11 @@ class TestFakerLoremFlickr < Test::Unit::TestCase
   end
 
   def test_image
-    assert @tester.image == 'http://loremflickr.com/300/300'
+    assert @tester.image == 'https://loremflickr.com/300/300'
   end
 
   def test_image_with_size
-    assert @tester.image(size: '50x60') == 'http://loremflickr.com/50/60'
+    assert @tester.image(size: '50x60') == 'https://loremflickr.com/50/60'
   end
 
   def test_image_with_incorrect_size
@@ -23,19 +23,19 @@ class TestFakerLoremFlickr < Test::Unit::TestCase
   end
 
   def test_image_with_single_search_term
-    assert @tester.image(size: '50x60', search_terms: %w[faker]) == 'http://loremflickr.com/50/60/faker'
+    assert @tester.image(size: '50x60', search_terms: %w[faker]) == 'https://loremflickr.com/50/60/faker'
   end
 
   def test_image_with_multiple_search_terms
-    assert @tester.image(size: '50x60', search_terms: %w[dog cat]) == 'http://loremflickr.com/50/60/dog,cat'
+    assert @tester.image(size: '50x60', search_terms: %w[dog cat]) == 'https://loremflickr.com/50/60/dog,cat'
   end
 
   def test_image_with_search_terms_and_match_all
-    assert @tester.image(size: '50x60', search_terms: %w[dog cat], match_all: true) == 'http://loremflickr.com/50/60/dog,cat/all'
+    assert @tester.image(size: '50x60', search_terms: %w[dog cat], match_all: true) == 'https://loremflickr.com/50/60/dog,cat/all'
   end
 
   def test_grayscale_image
-    @tester.grayscale_image == 'http://loremflickr.com/g/300/300/all'
+    @tester.grayscale_image == 'https://loremflickr.com/g/300/300/all'
   end
 
   def test_grayscale_image_with_incorrect_size
@@ -45,23 +45,23 @@ class TestFakerLoremFlickr < Test::Unit::TestCase
   end
 
   def test_grayscale_image_without_search_terms
-    @tester.grayscale_image(size: '50x60') == 'http://loremflickr.com/g/50/60/all'
+    @tester.grayscale_image(size: '50x60') == 'https://loremflickr.com/g/50/60/all'
   end
 
   def test_grayscale_image_with_single_search_term
-    assert @tester.grayscale_image(size: '50x60', search_terms: %w[faker]) == 'http://loremflickr.com/g/50/60/faker'
+    assert @tester.grayscale_image(size: '50x60', search_terms: %w[faker]) == 'https://loremflickr.com/g/50/60/faker'
   end
 
   def test_grayscale_image_with_multiple_search_terms
-    assert @tester.grayscale_image(size: '50x60', search_terms: %w[dog cat]) == 'http://loremflickr.com/g/50/60/dog,cat'
+    assert @tester.grayscale_image(size: '50x60', search_terms: %w[dog cat]) == 'https://loremflickr.com/g/50/60/dog,cat'
   end
 
   def test_grayscale_image_with_search_terms_and_match_all
-    assert @tester.grayscale_image(size: '50x60', search_terms: %w[dog cat], match_all: true) == 'http://loremflickr.com/g/50/60/dog,cat/all'
+    assert @tester.grayscale_image(size: '50x60', search_terms: %w[dog cat], match_all: true) == 'https://loremflickr.com/g/50/60/dog,cat/all'
   end
 
   def test_pixelated_image
-    @tester.pixelated_image == 'http://loremflickr.com/p/300/300/all'
+    @tester.pixelated_image == 'https://loremflickr.com/p/300/300/all'
   end
 
   def test_pixelated_image_with_incorrect_size
@@ -71,23 +71,23 @@ class TestFakerLoremFlickr < Test::Unit::TestCase
   end
 
   def test_pixelated_image_without_search_terms
-    @tester.pixelated_image(size: '50x60') == 'http://loremflickr.com/p/50/60/all'
+    @tester.pixelated_image(size: '50x60') == 'https://loremflickr.com/p/50/60/all'
   end
 
   def test_pixelated_image_with_single_search_term
-    assert @tester.pixelated_image(size: '50x60', search_terms: %w[faker]) == 'http://loremflickr.com/p/50/60/faker'
+    assert @tester.pixelated_image(size: '50x60', search_terms: %w[faker]) == 'https://loremflickr.com/p/50/60/faker'
   end
 
   def test_pixelated_image_with_multiple_search_terms
-    assert @tester.pixelated_image(size: '50x60', search_terms: %w[dog cat]) == 'http://loremflickr.com/p/50/60/dog,cat'
+    assert @tester.pixelated_image(size: '50x60', search_terms: %w[dog cat]) == 'https://loremflickr.com/p/50/60/dog,cat'
   end
 
   def test_pixelated_image_with_search_terms_and_match_all
-    assert @tester.pixelated_image(size: '50x60', search_terms: %w[dog cat], match_all: true) == 'http://loremflickr.com/p/50/60/dog,cat/all'
+    assert @tester.pixelated_image(size: '50x60', search_terms: %w[dog cat], match_all: true) == 'https://loremflickr.com/p/50/60/dog,cat/all'
   end
 
   def test_colorized_image
-    @tester.colorized_image == 'http://loremflickr.com/red/300/300/all'
+    @tester.colorized_image == 'https://loremflickr.com/red/300/300/all'
   end
 
   def test_colorized_image_with_incorrect_size
@@ -97,7 +97,7 @@ class TestFakerLoremFlickr < Test::Unit::TestCase
   end
 
   def test_colorized_image_without_search_terms
-    @tester.colorized_image(size: '50x60', color: 'red') == 'http://loremflickr.com/red/50/60/all'
+    @tester.colorized_image(size: '50x60', color: 'red') == 'https://loremflickr.com/red/50/60/all'
   end
 
   def test_colorized_image_with_unsupported_colorization
@@ -108,19 +108,19 @@ class TestFakerLoremFlickr < Test::Unit::TestCase
 
   def test_colorized_image_with_single_search_term
     @colorizations.each do |colorization|
-      assert @tester.colorized_image(size: '50x60', color: colorization, search_terms: %w[faker]) == "http://loremflickr.com/#{colorization}/50/60/faker"
+      assert @tester.colorized_image(size: '50x60', color: colorization, search_terms: %w[faker]) == "https://loremflickr.com/#{colorization}/50/60/faker"
     end
   end
 
   def test_colorized_image_with_multiple_search_terms
     @colorizations.each do |colorization|
-      assert @tester.colorized_image(size: '50x60', color: colorization, search_terms: %w[dog cat]) == "http://loremflickr.com/#{colorization}/50/60/dog,cat"
+      assert @tester.colorized_image(size: '50x60', color: colorization, search_terms: %w[dog cat]) == "https://loremflickr.com/#{colorization}/50/60/dog,cat"
     end
   end
 
   def test_colorized_image_with_search_terms_and_match_all
     @colorizations.each do |colorization|
-      assert @tester.colorized_image(size: '50x60', color: colorization, search_terms: %w[dog cat], match_all: true) == "http://loremflickr.com/#{colorization}/50/60/dog,cat/all"
+      assert @tester.colorized_image(size: '50x60', color: colorization, search_terms: %w[dog cat], match_all: true) == "https://loremflickr.com/#{colorization}/50/60/dog,cat/all"
     end
   end
 end


### PR DESCRIPTION
Description:
------
This changes the LoremFlickr generator to return `https` URLs instead of `http` URLs. [LoremFlickr](https://loremflickr.com/) supports HTTPS, so I don't really see much of a reason not to change it in Faker.

I _guess_ this is a breaking change if anyone is using a very specific setup where HTTPS doesn't work, but I think that's enough of an edge case - and this would benefit other users enough - that it shouldn't matter.