### PR TITLE
Add submodule resolution, Faker.address -> Faker::Address

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   faker!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
   faker!

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -267,6 +267,32 @@ module Faker
       end
     end
   end
+
+  class << self
+    def method_missing(mth, *args, &block)
+      klass = faker_module(mth)
+      klass ? klass : super
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      faker_module(method_name) ? true : false
+    end
+
+    def name
+      Faker::Name
+    end
+
+    private
+
+    def faker_module(name)
+      class_name = name.to_s.gsub(/^\w|_\w/, &:upcase).delete('_')
+      begin
+        Faker.const_get(class_name)
+      rescue NameError
+        nil
+      end
+    end
+  end
 end
 
 # require faker objects

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -188,10 +188,10 @@ module Faker
       #   name:
       #     girls_name: ["Alice", "Cheryl", "Tatiana"]
       # Then you can call Faker::Name.girls_name and it will act like #first_name
-      def method_missing(mth, *args, &block)
+      def method_missing(method_name, *args, &block)
         super unless @flexible_key
 
-        if (translation = translate("faker.#{@flexible_key}.#{mth}"))
+        if (translation = translate("faker.#{@flexible_key}.#{method_name}"))
           sample(translation)
         else
           super
@@ -269,8 +269,8 @@ module Faker
   end
 
   class << self
-    def method_missing(mth, *args, &block)
-      klass = faker_module(mth)
+    def method_missing(method_name, *args, &block)
+      klass = faker_module(method_name)
       klass || super
     end
 

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -271,10 +271,10 @@ module Faker
   class << self
     def method_missing(mth, *args, &block)
       klass = faker_module(mth)
-      klass ? klass : super
+      klass || super
     end
 
-    def respond_to_missing?(method_name, include_private = false)
+    def respond_to_missing?(method_name)
       faker_module(method_name) ? true : false
     end
 

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -123,4 +123,8 @@ class TestFaker < Test::Unit::TestCase
 
     assert_equal(unique_numbers.uniq, unique_numbers)
   end
+
+  def test_submodule_resolution
+    assert_equal(Faker.test_fake, Faker::TestFake)
+  end
 end


### PR DESCRIPTION
Description:
------
Adds a method_missing to the Faker module that allows you to write `Faker.address` instead of `Faker::Address`, e.g. `Faker.address.city` instead of `Faker::Address.city`.
