### PR TITLE
Add correct Portugal VAT number generation

### DIFF
--- a/test/faker/default/test_faker_finance.rb
+++ b/test/faker/default/test_faker_finance.rb
@@ -26,4 +26,15 @@ class TestFakerFinance < Test::Unit::TestCase
   def test_south_african_vat_number
     assert_match(/\AZA\d{10,11}\z/, Faker::Finance.vat_number(country: 'ZA'))
   end
+
+  # ref: http://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal
+  def test_portuguese_vat_number
+    number = Faker::Finance.vat_number(country: 'PT')
+
+    assert number.size == 9
+    # check first digit has to be one of the following
+    assert [1, 2, 5, 6, 8, 9].include?(number[0].to_i)
+    # check valid checksum digit
+    assert Faker::Finance.send(:pt_vat_number_checksum_digit, number[0..-2]) == number[-1].to_i
+  end
 end


### PR DESCRIPTION
Issue# 
------
Not directly related to, but discussed in:
https://github.com/faker-ruby/faker/pull/61
https://github.com/faker-ruby/faker/issues/929

Description:
------
Some countries VAT number generation follow specific rules regarding control digits or checksums. For example, Poland, Italy and Spanish use cases were discussed on the aforementioned issues, and Portugal also has a similar use case. Despite the formats on `locales/en/finance.yml` being correct, it does not generate a valid vat number since it doesn't follow all the rules. 

I introduced a change that allows developers to "override" the existing format with a custom function that generates valid vat numbers according to the country's specific rules. Hence, we can keep the current formats, and only rely on the custom methods when they are implemented.

I wasn't really sure about using ruby's `send` method, but from browsing the existing codebase it looked that its use was fairly common, so I ended up using that approach. I guess we could also use an approach based on `case` but then we would have something like the following, which seems a bit more verbose and redundant:
```ruby
case country:
when 'PT`
  pt_vat_number
when `PL`
  pl_vat_number
(...)
```

As as side note, I feel that the VAT number generation (with the use of the `country` parameter) is better implemented than other ID generations, namely `Faker::Company` where numerous `Faker::Company.<country>_organisation_number` methods were created. Perhaps if the maintainers like this solution, this could serve as example for those classes and create similar methods (e.g. `Faker::Company.organization_number(country: 'PT')`).