### PR TITLE
Add international name function

### DIFF
--- a/doc/default/name.md
+++ b/doc/default/name.md
@@ -19,6 +19,10 @@ Faker::Name.prefix           #=> "Mr."
 
 Faker::Name.suffix           #=> "IV"
 
+# Selects a name from a random available locale
+Faker::Name.international_name #=> "Горбунова Евгения Анатольевна"
+Faker::Name.international_name(from_locales: ['en-AU', 'en-US']) #=> "James Smith"
+
 # Keyword arguments: number
 Faker::Name.initials            #=> "NJM"
 Faker::Name.initials(number: 2) #=> "NM"

--- a/lib/faker/default/name.rb
+++ b/lib/faker/default/name.rb
@@ -46,6 +46,13 @@ module Faker
         fetch('name.suffix')
       end
 
+      def international_name(from_locales: I18n.config.available_locales)
+        locale = from_locales.sample(random: Faker::Config.random)
+        with_locale(locale) do
+          name
+        end
+      end
+
       def initials(legacy_number = NOT_GIVEN, number: 3)
         if legacy_number != NOT_GIVEN
           warn_with_uplevel 'Passing `number` with the 1st argument of `Name.initials` is deprecated. Use keyword argument like `Name.initials(number: ...)` instead.', uplevel: 1

--- a/test/faker/default/test_faker_name.rb
+++ b/test/faker/default/test_faker_name.rb
@@ -47,4 +47,9 @@ class TestFakerName < Test::Unit::TestCase
     assert @tester.initials.match(/[A-Z]{3}/)
     assert @tester.initials(number: 2).match(/[A-Z]{2}/)
   end
+
+  def test_international_name
+    assert @tester.international_name.is_a? String
+    assert @tester.international_name(from_locales: ['en-US', 'en-CA']).match(/(\w+\.? ?){2,3}/)
+  end
 end


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------

This adds an international name generator, which selects a random available locale and generates a name from it. It also allows for a subset of locales to be passed in.

When building applications for international usage, it's important to have test data that covers lots of different types of names to catch unicode problems, font problems, UI problems that arise when names are very short or very long, and code that assumes a particular format of name. Adding this method means that people can easily generate test data that covers different name formats and character sets.