### PR TITLE
Quebec province postal codes starts by [GHJ], adding missing two

### DIFF
--- a/lib/locales/en-CA.yml
+++ b/lib/locales/en-CA.yml
@@ -1,7 +1,7 @@
 en-CA:
   faker:
     address:
-      postcode: /[A-CEJ-NPR-TVXY][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
+      postcode: /[A-CEGJ-NPR-TVXY][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
       state: [Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Northwest Territories, Nunavut, Ontario, Prince Edward Island, Quebec, Saskatchewan, Yukon]
       state_abbr: ["AB", "BC", "MB", "NB", "NL", "NS", "NU", "NT", "ON", "PE", "QC", "SK", "YT"]
       default_country: [Canada]

--- a/lib/locales/en-CA.yml
+++ b/lib/locales/en-CA.yml
@@ -1,7 +1,7 @@
 en-CA:
   faker:
     address:
-      postcode: /[A-CEGJ-NPR-TVXY][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
+      postcode: /[A-CEGHJ-NPR-TVXY][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
       state: [Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Northwest Territories, Nunavut, Ontario, Prince Edward Island, Quebec, Saskatchewan, Yukon]
       state_abbr: ["AB", "BC", "MB", "NB", "NL", "NS", "NU", "NT", "ON", "PE", "QC", "SK", "YT"]
       default_country: [Canada]


### PR DESCRIPTION
Description:
------
Add Quebec province postal codes to `Faker::Address`.