### PR TITLE
Add mock data for Apple OAuth

### DIFF
--- a/doc/default/omniauth.md
+++ b/doc/default/omniauth.md
@@ -259,4 +259,35 @@ Faker::Omniauth.github #=>
     }
   }
 }
+
+Faker::Omniauth.apple #=>
+{
+  :provider => "apple",
+  :uid => "529731.75429b71301caccc750a77b9369d2bc5.7027",
+  :info => {
+    :sub => "529731.75429b71301caccc750a77b9369d2bc5.7027",
+    :email => "robert.kirlin@example.net",
+    :first_name => "Robert",
+    :last_name => "Kirlin"
+  },
+  :credentials => {
+    :token => "ba6089c326c800190b88746f8a2e13f7",
+    :refresh_token => "ebcdb693d801c5055fe62ff37b48c3b6",
+    :expires_at => 1579805533,
+    :expires => true
+  },
+  :extra => {
+    :raw_info => {
+      :iss => "https://appleid.apple.com",
+      :aud => "CLIENT_ID",
+      :exp => 1591575417,
+      :iat => 1571433587,
+      :sub => "529731.75429b71301caccc750a77b9369d2bc5.7027",
+      :at_hash => "d8bc8da580222598bba9da1470ad7b94",
+      :auth_time => 1583778038,
+      :email => "robert.kirlin@example.net",
+      :email_verified => true
+    }
+  }
+}
 ```

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -341,6 +341,40 @@ module Faker
         }
       end
 
+      def apple(name: nil, email: nil, uid: nil)
+        uid ||= "#{Number.number(digits: 6)}.#{Number.hexadecimal(digits: 32)}.#{Number.number(digits: 4)}"
+        auth = Omniauth.new(name: name, email: email)
+        {
+          provider: 'apple',
+          uid: uid,
+          info: {
+            sub: uid,
+            email: auth.email,
+            first_name: auth.first_name,
+            last_name: auth.last_name
+          },
+          credentials: {
+            token: Crypto.md5,
+            refresh_token: Crypto.md5,
+            expires_at: Time.forward.to_i,
+            expires: true
+          },
+          extra: {
+            raw_info: {
+              iss: 'https://appleid.apple.com',
+              aud: 'CLIENT_ID',
+              exp: Time.forward.to_i,
+              iat: Time.forward.to_i,
+              sub: uid,
+              at_hash: Crypto.md5,
+              auth_time: Time.forward.to_i,
+              email: auth.email,
+              email_verified: true
+            }
+          }
+        }
+      end
+
       private
 
       def gender

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -341,6 +341,14 @@ module Faker
         }
       end
 
+      ##
+      # Generate a mock Omniauth response from Apple
+      #
+      # @param name [String] A specific name to return in the response
+      # @param email [String] A specific email to return in the response
+      # @param uid [String] A specific UID to return in the response
+      #
+      # @return [Hash] An auth hash in the format provided by omniauth-apple
       def apple(name: nil, email: nil, uid: nil)
         uid ||= "#{Number.number(digits: 6)}.#{Number.hexadecimal(digits: 32)}.#{Number.number(digits: 4)}"
         auth = Omniauth.new(name: name, email: email)

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -549,6 +549,45 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal custom_uid, extra_raw_info[:id]
   end
 
+  def test_omniauth_apple
+    auth            = @tester.apple
+    info            = auth[:info]
+    credentials     = auth[:credentials]
+    extra           = auth[:extra]
+    raw_info        = extra[:raw_info]
+    first_name      = info[:first_name].downcase
+    last_name       = info[:last_name].downcase
+
+    assert_equal 'apple', auth[:provider]
+    assert_instance_of String, auth[:uid]
+    assert_equal 44, auth[:uid].length
+    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert_equal auth[:uid], info[:sub]
+    assert_instance_of String, info[:first_name]
+    assert_instance_of String, info[:last_name]
+    assert_instance_of String, credentials[:token]
+    assert_instance_of String, credentials[:refresh_token]
+
+    if RUBY_VERSION < '2.4.0'
+      assert_instance_of Fixnum, credentials[:expires_at]
+      assert_instance_of Fixnum, raw_info[:exp]
+      assert_instance_of Fixnum, raw_info[:iat]
+      assert_instance_of Fixnum, raw_info[:auth_time]
+    else
+      assert_instance_of Integer, credentials[:expires_at]
+      assert_instance_of Integer, raw_info[:exp]
+      assert_instance_of Integer, raw_info[:iat]
+      assert_instance_of Integer, raw_info[:auth_time]
+    end
+
+    assert_equal 'https://appleid.apple.com', raw_info[:iss]
+    assert_instance_of String, raw_info[:aud]
+    assert_equal auth[:uid], raw_info[:sub]
+    assert_instance_of String, raw_info[:at_hash]
+    assert_equal info[:email], raw_info[:email]
+    assert raw_info[:email_verified]
+  end
+
   def word_count(string)
     string.split(' ').length
   end


### PR DESCRIPTION
Issue# 
------
`No-Story`

Description:
------
Adds a mock for Apple OAuth, `Faker::Omniauth.apple`. This supports testing the `omniauth-apple` gem.

There is an interesting gotcha with Apple OAuth, that they only return the email data the _first_ time a user authenticates. I erred on the side of having it always available rather than never, but if there's a better way to represent that, I'm definitely open to it. Maybe `Faker::Omniauth.apple(email: false)`