### PR TITLE
Fix .gitignore for YARD.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ coverage/*
 .ruby-version
 .ruby-gemset
 
+# Ignore YARD metadata and documentation.
 .yardoc/
-doc/
+yard_docs/


### PR DESCRIPTION
Pretty simple change. `doc/` is already used by the existing documentation, and we've configured YARD to generate its docs into `yard_docs/`.