### PR TITLE
fix from Color.name to Color.color_name

### DIFF
--- a/test/test_ar_locale.rb
+++ b/test/test_ar_locale.rb
@@ -42,7 +42,7 @@ class TestArLocale < Test::Unit::TestCase
   end
 
   def test_ar_color_name
-    assert Faker::Color.name.is_a? String
+    assert Faker::Color.color_name.is_a? String
   end
 
   def test_ar_commerce_methods

--- a/test/test_ca_locale.rb
+++ b/test/test_ca_locale.rb
@@ -12,7 +12,7 @@ class TestCaLocale < Test::Unit::TestCase
   end
 
   def test_ca_color_methods
-    assert Faker::Color.name.is_a? String
+    assert Faker::Color.color_name.is_a? String
   end
 
   def test_ca_name_methods

--- a/test/test_de_locale.rb
+++ b/test/test_de_locale.rb
@@ -40,7 +40,7 @@ class TestDeLocale < Test::Unit::TestCase
   end
 
   def test_de_color_methods
-    assert Faker::Color.name.is_a? String
+    assert Faker::Color.color_name.is_a? String
   end
 
   def test_de_company_methods

--- a/test/test_es_locale.rb
+++ b/test/test_es_locale.rb
@@ -49,7 +49,7 @@ class TestEsLocale < Test::Unit::TestCase
   end
 
   def test_es_color_methods
-    assert Faker::Color.name.is_a? String
+    assert Faker::Color.color_name.is_a? String
   end
 
   def test_es_company_methods

--- a/test/test_ja_locale.rb
+++ b/test/test_ja_locale.rb
@@ -30,7 +30,7 @@ class TestJaLocale < Test::Unit::TestCase
   end
 
   def test_ja_color_methods
-    assert Faker::Color.name.is_a? String
+    assert Faker::Color.color_name.is_a? String
   end
 
   def test_ja_coffee_methods


### PR DESCRIPTION
Color.name is not written in example code but Color.color_name is written in exampe. so fixed test codes.

https://github.com/faker-ruby/faker/blob/master/CHANGELOG.md#v162-2016-02-20

```shell
 → git grep  "Color\.name"
no results
```

examples code

```ruby
Faker::Color.hex_color #=> "#31a785"

Faker::Color.color_name #=> "yellow"

Faker::Color.rgb_color #=> [54, 233, 67]

Faker::Color.hsl_color #=> [69.87, 0.66, 0.3]

Faker::Color.hsla_color #=> [154.77, 0.36, 0.9, 0.26170574657729073]
```

reference : https://github.com/faker-ruby/faker/blob/master/doc/default/color.md