### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [PR #1750](https://github.com/faker-ruby/faker/pull/1750) add only japanese word spec [@4geru](https://github.com/4geru)
 - [PR #1740](https://github.com/faker-ruby/faker/pull/1740) Add more YARD docs [@connorshea](https://github.com/connorshea)
-- [PR #1747](https://github.com/faker-ruby/faker/pull/1747) Fix PR linkss [@geniou](https://github.com/geniou)
+- [PR #1747](https://github.com/faker-ruby/faker/pull/1747) Fix PR links [@geniou](https://github.com/geniou)
 
 ## Feature Request
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Change Log
 
+## [v2.4.0](https://github.com/faker-ruby/faker/tree/v2.4.0) (2019-19-09)
+
+## Documentation
+
+- [PR #1750](https://github.com/faker-ruby/faker/pull/1750) add only japanese word spec [@4geru](https://github.com/4geru)
+- [PR #1740](https://github.com/faker-ruby/faker/pull/1740) Add more YARD docs [@connorshea](https://github.com/connorshea)
+- [PR #1747](https://github.com/faker-ruby/faker/pull/1747) Fix PR linkss [@geniou](https://github.com/geniou)
+
+## Feature Request
+
+- [PR #1742](https://github.com/faker-ruby/faker/pull/1742) Add Faker::Blockchain::Aeternity [@2pd](https://github.com/2pd)
+
+## Update locales
+
+- [PR #1743](https://github.com/faker-ruby/faker/pull/1743) Fix another ambiguity in element_symbol field [@psibi](https://github.com/psibi)
+- [PR #1748](https://github.com/faker-ruby/faker/pull/1748) fix typo from bread to breed [@4geru](https://github.com/4geru)
+- [PR #1752](https://github.com/faker-ruby/faker/pull/1752) fix creature i18n path in japanese [@4geru](https://github.com/4geru)
+
+## Update local dependencies
+
+The following development dependencies were updated:
+- Update simplecov requirement from = 0.17.0 to = 0.17.1 (#1749)
+
+------------------------------------------------------------------------------
+
 ## [v2.3.0](https://github.com/faker-ruby/faker/tree/v2.3.0) (2019-12-09)
 
 ## Documentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    faker (2.3.0)
+    faker (2.4.0)
       i18n (~> 1.6.0)
 
 GEM

--- a/lib/faker/version.rb
+++ b/lib/faker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Faker #:nodoc:
-  VERSION = '2.3.0'
+  VERSION = '2.4.0'
 end


### PR DESCRIPTION
Bump version to `2.4.0` to introduce `Faker::Blockchain::Aeternity` generator.

`2.4.0` also fixes several locales and documentation.