### PR TITLE
Add YARD docs for Doctor Who and fix a method name.

### DIFF
--- a/doc/tv_shows/dr_who.md
+++ b/doc/tv_shows/dr_who.md
@@ -11,7 +11,7 @@ Faker::TvShows::DrWho.catch_phrase #=> "Fantastic!"
 
 Faker::TvShows::DrWho.quote        #=> "Lots of planets have a north!"
 
-Faker::TvShows::DrWho.villian      #=> "The Master"
+Faker::TvShows::DrWho.villain      #=> "The Master"
 
 Faker::TvShows::DrWho.specie       #=> "Dalek"
 ```

--- a/lib/faker/tv_shows/dr_who.rb
+++ b/lib/faker/tv_shows/dr_who.rb
@@ -95,7 +95,7 @@ module Faker
         #   Faker::TvShows::DrWho.villain #=> "The Master"
         #
         # @faker.version next
-        alias :villain, :villian
+        alias :villain :villian
 
         ##
         # Produces a species from Doctor Who.

--- a/lib/faker/tv_shows/dr_who.rb
+++ b/lib/faker/tv_shows/dr_who.rb
@@ -77,12 +77,10 @@ module Faker
         # @return [String]
         #
         # @example
-        #   Faker::TvShows::DrWho.villian #=> "The Master"
+        #   Faker::TvShows::DrWho.villain #=> "The Master"
         #
-        # @deprecated Use the correctly-spelled `villain` method instead.
-        #
-        # @faker.version 1.8.0
-        def villian
+        # @faker.version next
+        def villain
           fetch('dr_who.villains')
         end
 
@@ -92,10 +90,12 @@ module Faker
         # @return [String]
         #
         # @example
-        #   Faker::TvShows::DrWho.villain #=> "The Master"
+        #   Faker::TvShows::DrWho.villian #=> "The Master"
         #
-        # @faker.version next
-        alias villain villian
+        # @deprecated Use the correctly-spelled `villain` method instead.
+        #
+        # @faker.version 1.8.0
+        alias villian villain
 
         ##
         # Produces a species from Doctor Who.

--- a/lib/faker/tv_shows/dr_who.rb
+++ b/lib/faker/tv_shows/dr_who.rb
@@ -95,7 +95,7 @@ module Faker
         #   Faker::TvShows::DrWho.villain #=> "The Master"
         #
         # @faker.version next
-        alias :villain :villian
+        alias villain villian
 
         ##
         # Produces a species from Doctor Who.

--- a/lib/faker/tv_shows/dr_who.rb
+++ b/lib/faker/tv_shows/dr_who.rb
@@ -95,7 +95,7 @@ module Faker
         #   Faker::TvShows::DrWho.villain #=> "The Master"
         #
         # @faker.version next
-        alias_method :villain, :villian
+        alias :villain, :villian
 
         ##
         # Produces a species from Doctor Who.

--- a/lib/faker/tv_shows/dr_who.rb
+++ b/lib/faker/tv_shows/dr_who.rb
@@ -83,7 +83,7 @@ module Faker
         #
         # @faker.version 1.8.0
         def villian
-          fetch('dr_who.villians')
+          fetch('dr_who.villains')
         end
 
         ##

--- a/lib/faker/tv_shows/dr_who.rb
+++ b/lib/faker/tv_shows/dr_who.rb
@@ -6,30 +6,106 @@ module Faker
       flexible :dr_who
 
       class << self
+        ##
+        # Produces a character from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.character #=> "Captain Jack Harkness"
+        #
+        # @faker.version 1.8.0
         def character
           fetch('dr_who.character')
         end
 
+        ##
+        # Produces an iteration of The Doctor from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.the_doctor #=> "Ninth Doctor"
+        #
+        # @faker.version 1.8.0
         def the_doctor
           fetch('dr_who.the_doctors')
         end
 
+        ##
+        # Produces an actor from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.actor #=> "Matt Smith"
+        #
+        # @faker.version 1.9.0
         def actor
           fetch('dr_who.actors')
         end
 
+        ##
+        # Produces a catch phrase from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.catch_phrase #=> "Fantastic!"
+        #
+        # @faker.version 1.8.0
         def catch_phrase
           fetch('dr_who.catch_phrases')
         end
 
+        ##
+        # Produces a quote from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.quote #=> "Lots of planets have a north!"
+        #
+        # @faker.version 1.8.0
         def quote
           fetch('dr_who.quotes')
         end
 
+        ##
+        # Produces a villain from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.villian #=> "The Master"
+        #
+        # @deprecated Use the correctly-spelled `villain` method instead.
+        #
+        # @faker.version 1.8.0
         def villian
           fetch('dr_who.villians')
         end
 
+        ##
+        # Produces a villain from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.villain #=> "The Master"
+        #
+        # @faker.version next
+        alias_method :villain, :villian
+
+        ##
+        # Produces a species from Doctor Who.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::DrWho.specie #=> "Dalek"
+        #
+        # @faker.version 1.8.0
         def specie
           fetch('dr_who.species')
         end

--- a/lib/locales/en/dr_who.yml
+++ b/lib/locales/en/dr_who.yml
@@ -41,7 +41,7 @@ en:
         "Aw, I wanted to be ginger! I've never been ginger!",
         "Crossing into established events is strictly forbidden. Except for cheap tricks.",
       ]
-      villians: [
+      villains: [
         "Helen A", "Abzorbaloff", "Animus", "The Master", "Davros", "Dalek Emperor"
       ]
       species: [

--- a/test/faker/tv_shows/test_dr_who.rb
+++ b/test/faker/tv_shows/test_dr_who.rb
@@ -28,8 +28,13 @@ class TestFakerTvShowsDrWho < Test::Unit::TestCase
     10.times { assert @tester.quote.match(/[\w]+/) }
   end
 
+  # deprecated
   def test_villian
     10.times { assert @tester.villian.match(/[\w]+/) }
+  end
+
+  def test_villain
+    10.times { assert @tester.villain.match(/[\w]+/) }
   end
 
   def test_specie
@@ -43,7 +48,8 @@ class TestFakerTvShowsDrWho < Test::Unit::TestCase
       assert @tester.the_doctor  .is_a? String
       assert @tester.catch_phrase.is_a? String
       assert @tester.quote       .is_a? String
-      assert @tester.villian     .is_a? String
+      assert @tester.villian     .is_a? String # deprecated
+      assert @tester.villain     .is_a? String
       assert @tester.specie      .is_a? String
     end
   end


### PR DESCRIPTION
This adds YARD docs for the Doctor Who faker, and also adds an alias of 'villain' for 'villian', since it's spelled wrong. I've marked 'villian' as being deprecated and replaced it in the Markdown examples.

EDIT: Also changed the YML key, I assume we consider those 'private' so we can change them as we like?