### PR TITLE
Remove "mint green" from list of colors

### DIFF
--- a/lib/locales/en/color.yml
+++ b/lib/locales/en/color.yml
@@ -1,4 +1,4 @@
 en:
   faker:
     color:
-      name: [red, green, blue, yellow, purple, mint green, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]
+      name: [red, green, blue, yellow, purple, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]


### PR DESCRIPTION
The list of colors are all single words except for "mint green".

As mint green is a pretty obscure color and doesn't fit with the format of every other color being a single word.

I purpose we remove this color for consistency.

Issue#: `No-Story`
