### PR TITLE
Refactor Faker::Educator and add docs

### DIFF
--- a/lib/faker/default/educator.rb
+++ b/lib/faker/default/educator.rb
@@ -6,29 +6,29 @@ module Faker
 
     class << self
       def university
-        "#{parse('educator.name')} #{fetch('educator.tertiary.type')}"
+        parse('educator.university')
       end
 
       def degree
-        "#{fetch('educator.tertiary.degree.type')} #{fetch('educator.tertiary.degree.subject')}"
+        parse('educator.degree')
       end
 
       alias course degree
 
       def subject
-        fetch('educator.tertiary.degree.subject')
+        fetch('educator.subject')
       end
 
       def course_name
-        "#{fetch('educator.tertiary.degree.subject')} #{numerify(fetch('educator.tertiary.degree.course_number'))}"
+        numerify(parse('educator.course_name'))
       end
 
       def secondary_school
-        "#{parse('educator.name')} #{fetch('educator.secondary')}"
+        parse('educator.secondary_school')
       end
 
       def campus
-        "#{parse('educator.name')} Campus"
+        parse('educator.campus')
       end
     end
   end

--- a/lib/faker/default/educator.rb
+++ b/lib/faker/default/educator.rb
@@ -5,28 +5,82 @@ module Faker
     flexible :educator
 
     class << self
+      ##
+      # Produces a university name.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Educator.university #=> "Mallowtown Technical College"
+      #
+      # @faker.version 1.6.4
       def university
         parse('educator.university')
       end
 
+      ##
+      # Produces a university degree.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Educator.degree #=> "Associate Degree in Criminology"
+      #
+      # @faker.version 1.9.2
       def degree
         parse('educator.degree')
       end
 
       alias course degree
 
+      ##
+      # Produces a university subject.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Educator.subject #=> "Criminology"
+      #
+      # @faker.version 1.9.2
       def subject
         fetch('educator.subject')
       end
 
+      ##
+      # Produces a course name.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Educator.course_name #=> "Criminology 101"
+      #
+      # @faker.version 1.9.2
       def course_name
         numerify(parse('educator.course_name'))
       end
 
+      ##
+      # Produces a secondary school.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Educator.secondary_school #=> "Iceborough Secondary College"
+      #
+      # @faker.version 1.6.4
       def secondary_school
         parse('educator.secondary_school')
       end
 
+      ##
+      # Produces a campus name.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Educator.campus #=> "Vertapple Campus"
+      #
+      # @faker.version 1.6.4
       def campus
         parse('educator.campus')
       end

--- a/lib/locales/en/educator.yml
+++ b/lib/locales/en/educator.yml
@@ -1,11 +1,74 @@
 en:
   faker:
     educator:
-      name: ['Marblewald', 'Mallowtown', 'Brookville', 'Flowerlake', 'Falconholt', 'Ostbarrow', 'Lakeacre', 'Clearcourt', 'Ironston', 'Mallowpond', 'Iceborough', 'Icelyn', 'Brighthurst', 'Bluemeadow', 'Vertapple', 'Ironbarrow']
-      secondary: ['High School', 'Secondary College', 'High']
+      name:
+        - Marblewald
+        - Mallowtown
+        - Brookville
+        - Flowerlake
+        - Falconholt
+        - Ostbarrow
+        - Lakeacre
+        - Clearcourt
+        - Ironston
+        - Mallowpond
+        - Iceborough
+        - Icelyn
+        - Brighthurst
+        - Bluemeadow
+        - Vertapple
+        - Ironbarrow
+      secondary:
+        - High School
+        - Secondary College
+        - High
+      university:
+        - "#{name} #{Educator.tertiary.university_type}"
+      secondary_school:
+        - "#{name} #{secondary}"
+      campus:
+        - "#{name} Campus"
+      subject:
+        - Arts
+        - Business
+        - Education
+        - Applied Science (Psychology)
+        - Architectural Technology
+        - Biological Science
+        - Biomedical Science
+        - Commerce
+        - Communications
+        - Creative Arts
+        - Criminology
+        - Design
+        - Engineering
+        - Forensic Science
+        - Health Science
+        - Information Systems
+        - Computer Science
+        - Law
+        - Nursing
+        - Medicine
+        - Psychology
+        - Teaching
+      degree:
+        - "#{Educator.tertiary.degree.type} #{subject}"
+      course_name:
+        - "#{subject} #{Educator.tertiary.degree.course_number}"
       tertiary:
-        type: ['College', 'University', 'Technical College', 'TAFE']
+        university_type:
+          - College
+          - University
+          - Technical College
+          - TAFE
         degree:
-          subject: ['Arts', 'Business', 'Education', 'Applied Science (Psychology)', 'Architectural Technology', 'Biological Science', 'Biomedical Science', 'Commerce', 'Communications', 'Creative Arts', 'Criminology', 'Design', 'Engineering', 'Forensic Science', 'Health Science', 'Information Systems', 'Computer Science', 'Law', 'Nursing', 'Medicine', 'Psychology', 'Teaching']
-          type: ['Associate Degree in', 'Bachelor of', 'Master of']
-          course_number: ['1##', '2##', '3##', '4##', '5##']
+          type:
+            - Associate Degree in
+            - Bachelor of
+            - Master of
+          course_number:
+            - 1##
+            - 2##
+            - 3##
+            - 4##
+            - 5##

--- a/lib/locales/en/educator.yml
+++ b/lib/locales/en/educator.yml
@@ -29,9 +29,9 @@ en:
       campus:
         - "#{name} Campus"
       subject:
-        - Arts
         - Applied Science (Psychology)
         - Architectural Technology
+        - Arts
         - Biological Science
         - Biomedical Science
         - Business

--- a/lib/locales/en/educator.yml
+++ b/lib/locales/en/educator.yml
@@ -2,26 +2,26 @@ en:
   faker:
     educator:
       name:
-        - Marblewald
-        - Mallowtown
+        - Bluemeadow
+        - Brighthurst
         - Brookville
-        - Flowerlake
-        - Falconholt
-        - Ostbarrow
-        - Lakeacre
         - Clearcourt
-        - Ironston
-        - Mallowpond
+        - Falconholt
+        - Flowerlake
         - Iceborough
         - Icelyn
-        - Brighthurst
-        - Bluemeadow
-        - Vertapple
         - Ironbarrow
+        - Ironston
+        - Lakeacre
+        - Mallowpond
+        - Mallowtown
+        - Marblewald
+        - Ostbarrow
+        - Vertapple
       secondary:
+        - High
         - High School
         - Secondary College
-        - High
       university:
         - "#{name} #{Educator.tertiary.university_type}"
       secondary_school:
@@ -30,17 +30,17 @@ en:
         - "#{name} Campus"
       subject:
         - Arts
-        - Business
-        - Education
         - Applied Science (Psychology)
         - Architectural Technology
         - Biological Science
         - Biomedical Science
+        - Business
         - Commerce
         - Communications
         - Creative Arts
         - Criminology
         - Design
+        - Education
         - Engineering
         - Forensic Science
         - Health Science

--- a/lib/locales/en/educator.yml
+++ b/lib/locales/en/educator.yml
@@ -37,6 +37,7 @@ en:
         - Business
         - Commerce
         - Communications
+        - Computer Science
         - Creative Arts
         - Criminology
         - Design
@@ -45,10 +46,9 @@ en:
         - Forensic Science
         - Health Science
         - Information Systems
-        - Computer Science
         - Law
-        - Nursing
         - Medicine
+        - Nursing
         - Psychology
         - Teaching
       degree:

--- a/lib/locales/en/educator.yml
+++ b/lib/locales/en/educator.yml
@@ -58,9 +58,9 @@ en:
       tertiary:
         university_type:
           - College
-          - University
-          - Technical College
           - TAFE
+          - Technical College
+          - University
         degree:
           type:
             - Associate Degree in


### PR DESCRIPTION
This refactors Faker::Educator to use the `parse` method instead of generating the returned strings in the Ruby code. The behavior of the Educator class methods shouldn't have changed.

It also reformats the YML file to use one line per entry, and adds YARD docs.