### PR TITLE
fix: city_with_state was not on en locale

### DIFF
--- a/lib/locales/en/address.yml
+++ b/lib/locales/en/address.yml
@@ -570,6 +570,8 @@ en:
         - "#{city_prefix} #{Name.first_name}"
         - "#{Name.first_name}#{city_suffix}"
         - "#{Name.last_name}#{city_suffix}"
+      city_with_state:
+        - "#{city}, #{state}"
       street_name:
         - "#{Name.first_name} #{street_suffix}"
         - "#{Name.last_name} #{street_suffix}"

--- a/test/faker/default/test_faker_address.rb
+++ b/test/faker/default/test_faker_address.rb
@@ -11,6 +11,10 @@ class TestFakerAddress < Test::Unit::TestCase
     assert @tester.city.match(/\w+/)
   end
 
+  def test_city_with_state
+    assert @tester.city(options: { with_state: true }).match(/\w+,\s\w+/)
+  end
+
   def test_street_name
     assert @tester.street_name.match(/\w+\s\w+/)
   end


### PR DESCRIPTION
Issue #1765
------

Example:

https://github.com/faker-ruby/faker/issues/1765

Description:
------
Fixes the call `Faker::Address.city(options: { with_state: true })` so that it doesn't raise an exception and returns the desired result, e.g. `"Northtown, Colorado"`

Code is tested.