### PR TITLE
Adds a fix for when :en is not one of the available locales

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -24,7 +24,8 @@ module Faker
       attr_writer :random
 
       def locale
-        @locale || I18n.locale
+        # Because I18n.locale defaults to :en, if we don't have :en in our available_locales, errors will happen
+        @locale || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
       end
 
       def own_locale

--- a/test/test_locale.rb
+++ b/test/test_locale.rb
@@ -54,6 +54,13 @@ class TestLocale < Test::Unit::TestCase
     I18n.available_locales += [:en]
   end
 
+  def test_no_en_in_available_locales
+    I18n.available_locales -= [:en]
+    assert_kind_of String, Faker::Address.country
+  ensure
+    I18n.available_locales += [:en]
+  end
+
   def test_with_locale_changes_locale_temporarily
     Faker::Config.locale = 'en-BORK'
     I18n.with_locale(:en) do


### PR DESCRIPTION
Issue# 266
------

Fixes #266 

Description:
------
As described in the issue, whenever `:en` wasn't a part of your `I18n.available_locales`, a few things could break. This was because of I18n defaulting to `:en`, as you can see [here](https://github.com/ruby-i18n/i18n/blob/294212633a0e5ed76878116fb3df2360c7a6938a/lib/i18n/config.rb#L31). This is the smallest change I could make that didn't break any other tests. Of course, I also added a new test checking this behavior.
