### PR TITLE
Update diners_club and jcb test cards since they were updated in Stripe docs

### DIFF
--- a/lib/locales/en/stripe.yml
+++ b/lib/locales/en/stripe.yml
@@ -13,9 +13,9 @@ en:
         amex_2:        "371449635398431"
         discover:      "6011111111111117"
         discover_2:    "6011000990139424"
-        diners_club:   "30569309025904"
-        diners_club_2: "38520000023237"
-        jcb:           "3530111333300000"
+        diners_club:   "3056930009020004"
+        diners_club_2: "36227206271667"
+        jcb:           "3566002020360505"
       valid_tokens:
         visa:          "tok_visa"
         visa_debit:    "tok_visa_debit"


### PR DESCRIPTION
Suddenly our tests started randomly failing with `Your card number is incomplete.`. After debugging seems that diners_club CCs causes this issue.

I checked https://stripe.com/docs/testing and seems like the CCs changed. So this PR updates Faker Stripe CCs with the ones in the official doc.