### PR TITLE
Add Terry Bogard to Super Smash Bros. options

### DIFF
--- a/lib/locales/en/super_smash_bros.yml
+++ b/lib/locales/en/super_smash_bros.yml
@@ -75,6 +75,7 @@ en:
           - Snake
           - Sonic
           - Squirtle
+          - Terry Bogard
           - Toon Link
           - Villager
           - Wario


### PR DESCRIPTION
Terry has been announced as DLC for Super Smash Bros. Ultimate,
releasing sometime next month. His stage doesn't yet have an official
name, so I can't add that yet, unfortunately.