### PR TITLE
Add i18n backend to manage applications without english as available locale

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -11,10 +11,18 @@ require 'set' # Fixes a bug in i18n 0.6.11
 
 Dir.glob(File.join(File.dirname(__FILE__), 'helpers', '*.rb')).sort.each { |file| require file }
 
-I18n.load_path += Dir[File.join(mydir, 'locales', '**/*.yml')]
-I18n.reload! if I18n.backend.initialized?
-
 module Faker
+  module I18nBackend
+    def store_translations(locale, data, options = I18n::EMPTY_HASH)
+      old_enforce_available_locales = I18n.enforce_available_locales
+      I18n.enforce_available_locales = false if data.keys.include?('faker')
+
+      super
+    ensure
+      I18n.enforce_available_locales = old_enforce_available_locales
+    end
+  end
+
   class Config
     @locale = nil
     @random = nil
@@ -303,6 +311,10 @@ module Faker
     end
   end
 end
+
+I18n::Backend::Simple.include(Faker::I18nBackend)
+I18n.load_path += Dir[File.join(mydir, 'locales', '**/*.yml')]
+I18n.reload! if I18n.backend.initialized?
 
 # require faker objects
 Dir.glob(File.join(File.dirname(__FILE__), 'faker', '/**/*.rb')).sort.each { |file| require file }

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -38,7 +38,7 @@ class TestDeterminism < Test::Unit::TestCase
   end
 
   def all_methods
-    subclasses.map do |subclass|
+    subclasses.reject { |subclass| subclass == :I18nBackend }.map do |subclass|
       subclass_methods(subclass).flatten
     end.flatten.sort
   end


### PR DESCRIPTION
This is a proposal to resolve #278 

I extended `I18n.backend` to not `enforce_available_locales` when datas first keys contains `faker`. That way we ignore `enforce_available_locales` only for files related to Faker.

## References
- https://github.com/faker-ruby/faker/issues/278#issuecomment-519453199
- https://github.com/ruby-i18n/i18n/blob/v1.6.0/lib/i18n/backend/simple.rb#L37