### PR TITLE
Adds domain option for Internet email and domain_name methods

### DIFF
--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -1,10 +1,11 @@
 # Faker::Internet
 
 ```ruby
-# Keyword arguments: name, separators
+# Keyword arguments: name, separators, domain
 Faker::Internet.email #=> "eliza@mann.net"
 Faker::Internet.email(name: 'Nancy') #=> "nancy@terry.biz"
 Faker::Internet.email(name: 'Janelle Santiago', separators: '+') #=> janelle+santiago@becker.com"
+Faker::Internet.email(domain: 'example.com') #=> alice@example.com"
 
 # Keyword arguments: name
 Faker::Internet.free_email #=> "freddy@gmail.com"
@@ -32,7 +33,10 @@ Faker::Internet.password(min_length: 10, max_length: 20) #=> "EoC9ShWd1hWq4vBgFw
 Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true) #=> "3k5qS15aNmG"
 Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true, special_characters: true) #=> "*%NkOnJsH4"
 
+# Keyword arguments: subdomain, domain
 Faker::Internet.domain_name #=> "effertz.info"
+Faker::Internet.domain_name(domain: "example.com") #=> "example.com"
+Faker::Internet.domain_name(subdomain: true, domain: "example.com") #=> "horse.example.com"
 
 Faker::Internet.domain_word #=> "haleyziemann"
 

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -3,16 +3,16 @@
 module Faker
   class Internet < Base
     class << self
-      def email(legacy_name = NOT_GIVEN, legacy_separators = NOT_GIVEN, name: nil, separators: nil)
+      def email(legacy_name = NOT_GIVEN, legacy_separators = NOT_GIVEN, name: nil, separators: nil, domain: nil)
         warn_for_deprecated_arguments do |keywords|
           keywords << :name if legacy_name != NOT_GIVEN
           keywords << :separators if legacy_separators != NOT_GIVEN
         end
 
         if separators
-          [username(specifier: name, separators: separators), domain_name].join('@')
+          [username(specifier: name, separators: separators), domain_name(domain: domain)].join('@')
         else
-          [username(specifier: name), domain_name].join('@')
+          [username(specifier: name), domain_name(domain: domain)].join('@')
         end
       end
 
@@ -135,14 +135,15 @@ module Faker
         temp
       end
 
-      def domain_name(legacy_subdomain = NOT_GIVEN, subdomain: false)
+      def domain_name(legacy_subdomain = NOT_GIVEN, subdomain: false, domain: nil)
         warn_for_deprecated_arguments do |keywords|
           keywords << :subdomain if legacy_subdomain != NOT_GIVEN
         end
 
         with_locale(:en) do
-          domain_elements = [Char.prepare(domain_word), domain_suffix]
-          domain_elements.unshift(Char.prepare(domain_word)) if subdomain
+          _domain_word = domain || domain_word
+          domain_elements = [Char.prepare(_domain_word), domain_suffix]
+          domain_elements.unshift(Char.prepare(_domain_word)) if subdomain
           domain_elements.join('.')
         end
       end

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -141,9 +141,9 @@ module Faker
         end
 
         with_locale(:en) do
-          _domain_word = domain || domain_word
-          domain_elements = [Char.prepare(_domain_word), domain_suffix]
-          domain_elements.unshift(Char.prepare(_domain_word)) if subdomain
+          given_domain_word = domain || domain_word
+          domain_elements = [Char.prepare(given_domain_word), domain_suffix]
+          domain_elements.unshift(Char.prepare(given_domain_word)) if subdomain
           domain_elements.join('.')
         end
       end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -15,6 +15,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.email(name: 'jane doe', separators: '+').match(/.+\+.+@.+\.\w+/)
   end
 
+  def test_email_with_domain_option_given
+    assert @tester.email(name: 'jane doe', domain: 'customdomain').match(/.+@customdomain\.\w+/)
+  end
+
   def test_free_email
     assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
   end
@@ -148,6 +152,10 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_domain_name_with_subdomain
     assert @tester.domain_name(subdomain: true).match(/\w+\.\w+\.\w+/)
+  end
+
+  def test_domain_name_with_subdomain_and_with_domain_option_given
+    assert @tester.domain_name(subdomain: true, domain: 'customdomain').match(/customdomain\.\w+/)
   end
 
   def test_domain_word


### PR DESCRIPTION
Issue #1624 
------

Example:
```
Internet.email(name: 'jane doe', domain: 'customdomain')
#=> jane.doe@customdomain.co
```

Description:
------
This PR's main goal is to add another option to Internet.email method (fixes #1624), which is the `domain` param. Also makes possible to generate a `domain_name` with a custom domain and random subdomain.