### PR TITLE
Add vat number rule for es-MX

### DIFF
--- a/lib/locales/es-MX.yml
+++ b/lib/locales/es-MX.yml
@@ -100,3 +100,6 @@ es-MX:
       payment_methods: ["Tarjeta de credito", "Tarjeta de débito", "Paypal", "Efectivo", "Transferencia de dinero", "Bitcoins", "Cheque", "Apple Pay", "Google Pay", "WeChat Pay", "Alipay", "Visa Checkout"]
       subscription_terms: ["Diaria", "Semanal", "Mensual", "Anual", "Bienal", "Trienal", "Quinquenal", "De por vida"]
       payment_terms: ["Pago por adelantado", "Mensual", "Anual", "Suscripción completa"]
+    finance:
+      vat_number:
+        MX: /^([A-ZÑ]{3,4})([0-9]{2})(0[1-9]|1[0-2])(0[1-9]|1[0-9]|2[0-9]|3[0-1])[A-Z0-9]{3}$/

--- a/test/test_es_mx_locale.rb
+++ b/test/test_es_mx_locale.rb
@@ -62,4 +62,10 @@ class TestEsMxLocale < Test::Unit::TestCase
     assert Faker::University.suffix.is_a? String
     assert Faker::University.prefix.is_a? String
   end
+
+  def test_es_mx_finance_vat_number
+    vat = Faker::Finance.vat_number(country: 'MX')
+    assert vat.is_a? String
+    assert_match(/([A-ZÑ]){3,4}(\d){6}([A-Z0-9]){3}/, vat)
+  end
 end


### PR DESCRIPTION
This change adds the correct way to generate Mexican vat numbers (or tax ids, aka RFC in Mexico). In Mexico there are two different type of vat numbers: For business and for individuals.
- For business, a RFC has the format: 3 chars (including Ñ) according to business name initials, following of a date in format YYMMDD, then a unique alphanumeric key made of 3 chars.
- For individuals, a RFC has the format: 4 chars (including Ñ) according to name initials, followed of the birth date in format YYMMDD, then a unique alphanumeric key made of 3 chars

I'm adding this change in order to improve our fixtures set at [boxfactura](https://www.boxfactura.com) as we depend in the correctness of a tax id.
