### PR TITLE
Adds generation of UK National Insurance numbers to IDNumber class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
-    rake (13.0.0)
+    rake (13.0.1)
     rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -52,7 +52,7 @@ DEPENDENCIES
   faker!
   minitest (= 5.13.0)
   pry (= 0.12.2)
-  rake (= 13.0.0)
+  rake (= 13.0.1)
   rubocop (= 0.76.0)
   simplecov (= 0.17.1)
   test-unit (= 3.3.4)

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency('minitest', '5.13.0')
   spec.add_development_dependency('pry', '0.12.2')
-  spec.add_development_dependency('rake', '13.0.0')
+  spec.add_development_dependency('rake', '13.0.1')
   spec.add_development_dependency('rubocop', '0.76.0')
   spec.add_development_dependency('simplecov', '0.17.1')
   spec.add_development_dependency('test-unit', '3.3.4')

--- a/lib/faker/default/relationship.rb
+++ b/lib/faker/default/relationship.rb
@@ -5,6 +5,15 @@ module Faker
     flexible :relationship
 
     class << self
+      ##
+      # Produces a random family relationship.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Relationship.familial #=> "Grandfather"
+      #
+      # @faker.version 1.9.2
       def familial(legacy_connection = NOT_GIVEN, connection: nil)
         warn_for_deprecated_arguments do |keywords|
           keywords << :connection if legacy_connection != NOT_GIVEN
@@ -26,18 +35,54 @@ module Faker
         fetch('relationship.familial.' + connection)
       end
 
+      ##
+      # Produces a random in-law relationship.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Relationship.in_law #=> "Brother-in-law"
+      #
+      # @faker.version 1.9.2
       def in_law
         fetch('relationship.in_law')
       end
 
+      ##
+      # Produces a random spouse relationship.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Relationship.spouse #=> "Husband"
+      #
+      # @faker.version 1.9.2
       def spouse
         fetch('relationship.spouse')
       end
 
+      ##
+      # Produces a random parent relationship.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Relationship.parent #=> "Father"
+      #
+      # @faker.version 1.9.2
       def parent
         fetch('relationship.parent')
       end
 
+      ##
+      # Produces a random sibling relationship.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Relationship.sibling #=> "Sister"
+      #
+      # @faker.version 1.9.2
       def sibling
         fetch('relationship.sibling')
       end

--- a/lib/faker/default/world_cup.rb
+++ b/lib/faker/default/world_cup.rb
@@ -43,7 +43,7 @@ module Faker
       end
 
       ##
-      # Produces a random national team name from a group. See below examples
+      # Produces a random national team name from a group.
       #
       # @return [String]
       #
@@ -62,7 +62,7 @@ module Faker
       end
 
       ##
-      # Produces a random name from national team roster. See below examples.
+      # Produces a random name from national team roster.
       #
       # @return [String]
       #


### PR DESCRIPTION
`No-Story`

Description:
------
Adds generation of UK National Insurance numbers to `Faker::IDNumber`.
NI number syntax based on the [HRMC NIM39110 standard](https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110)
