### PR TITLE
Filter Generated Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ development.
   - [Usage](#usage)
     - [CLI](#cli)
     - [Ensuring unique values](#ensuring-unique-values)
+    - [Filtering generated values](#filtering-generated-values)
     - [Deterministic Random](#deterministic-random)
   - [Generators](#generators)
     - [Default](#default)
@@ -97,6 +98,34 @@ manually set values).
 # Add 'azerty' and 'wxcvbn' to the string generator with 6 char length
 Faker::Lorem.unique.exclude :string, [6], %w[azerty wxcvbn]
 ```
+
+### Filtering Generated Values
+
+You can constrain generated values using `select` and `reject` methods.
+
+These accept both accept a block, with `select` only permitting values for which
+this block evaluates to `true` and `reject` only permitting values for which it
+evaluates to `false`.
+
+For example:
+
+```ruby
+Faker::Number.select(&:even?).number
+# and
+Faker::Number.reject(&:odd?).number 
+```
+
+both generate even integers.
+
+You can also chain these methods together with the `unique` method.
+
+For example:
+
+```ruby
+Faker::Number.unique.reject(&:odd?).select(&:nonzero?).digit
+```
+
+generates unique, even, nonzero digit 
 
 ### Deterministic Random
 Faker supports seeding of its pseudo-random number generator (PRNG) to provide deterministic output of repeated method calls.

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -38,6 +38,8 @@ module Faker
   end
 
   class Base
+    extend Filtering
+
     Numbers = Array(0..9)
     ULetters = Array('A'..'Z')
     LLetters = Array('a'..'z')

--- a/lib/helpers/filter.rb
+++ b/lib/helpers/filter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Faker
+  class Filter
+    def initialize(generator, max_retries, &filter)
+      @generator = generator
+      @max_retries = max_retries
+      @filter = filter
+    end
+
+    def method_missing(name, *arguments)
+      return super unless respond_to_missing? name
+
+      @max_retries.times do
+        result = @generator.public_send(name, *arguments)
+
+        next unless @filter.call(result)
+
+        return result
+      end
+
+      raise RetryLimitExceeded, "Retry limit exceeded for #{name}"
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      @generator.respond_to?(method_name) || super
+    end
+
+    RetryLimitExceeded = Class.new(StandardError)
+  end
+end

--- a/lib/helpers/filter.rb
+++ b/lib/helpers/filter.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'filtering'
+
 module Faker
   class Filter
+    include Filtering
+
     def initialize(generator, max_retries, &filter)
       @generator = generator
       @max_retries = max_retries

--- a/lib/helpers/filtering.rb
+++ b/lib/helpers/filtering.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Faker
+  module Filtering
+    MAX_RETRIES = 10_000
+
+    def select(max_retries = MAX_RETRIES)
+      Filter.new(self, max_retries) { |result| yield result }
+    end
+
+    def reject(max_retries = MAX_RETRIES)
+      select(max_retries) { |result| !yield(result) }
+    end
+  end
+end

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -14,8 +14,9 @@ module Faker
       @previous_results = Hash.new { |hash, key| hash[key] = Set.new }
     end
 
-    # rubocop:disable Style/MethodMissingSuper
     def method_missing(name, *arguments)
+      return super unless respond_to_missing? name
+
       self.class.marked_unique.add(self)
 
       @max_retries.times do
@@ -29,10 +30,9 @@ module Faker
 
       raise RetryLimitExceeded, "Retry limit exceeded for #{name}"
     end
-    # rubocop:enable Style/MethodMissingSuper
 
     def respond_to_missing?(method_name, include_private = false)
-      method_name.to_s.start_with?('faker_') || super
+      @generator.respond_to?(method_name) || super
     end
 
     RetryLimitExceeded = Class.new(StandardError)

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'filtering'
+
 module Faker
   class UniqueGenerator
+    include Filtering
+
     @marked_unique = Set.new # Holds names of generators with unique values
 
     class << self

--- a/test/faker/default/test_faker_filter.rb
+++ b/test/faker/default/test_faker_filter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerFilter < Test::Unit::TestCase
+  def test_filters
+    filter_proc = proc { |letter| letter == 'A' }
+    generator = Faker::Filter.new(Faker::Base, 10_000, &filter_proc)
+
+    assert_equal('A', generator.letterify('?'))
+  end
+
+  def test_respond_to_missing
+    stubbed_generator = Struct.new(:faker_address).new
+
+    generator = Faker::Filter.new(stubbed_generator, 3)
+
+    assert_equal(true, generator.send(:respond_to_missing?, 'faker_address'))
+    assert_equal(false, generator.send(:respond_to_missing?, 'address'))
+  end
+
+  def test_returns_error_when_retries_exceeded
+    filter_proc = proc { false }
+    generator = Faker::Filter.new(Faker::Base, 1, &filter_proc)
+
+    assert_raises Faker::Filter::RetryLimitExceeded do
+      generator.letterify('?')
+    end
+  end
+
+  def test_includes_field_name_in_error
+    filter_proc = proc { false }
+    generator = Faker::Filter.new(Faker::Base, 1, &filter_proc)
+
+    assert_raise_message 'Retry limit exceeded for letterify' do
+      generator.letterify('?')
+    end
+  end
+end

--- a/test/faker/default/test_faker_unique_generator.rb
+++ b/test/faker/default/test_faker_unique_generator.rb
@@ -11,12 +11,12 @@ class TestFakerUniqueGenerator < Test::Unit::TestCase
   end
 
   def test_respond_to_missing
-    stubbed_generator = Object.new
+    stubbed_generator = Struct.new(:faker_address).new
 
     generator = Faker::UniqueGenerator.new(stubbed_generator, 3)
 
-    assert_equal(generator.send(:respond_to_missing?, 'faker_address'), true)
-    assert_equal(generator.send(:respond_to_missing?, 'address'), false)
+    assert_equal(true, generator.send(:respond_to_missing?, 'faker_address'))
+    assert_equal(false, generator.send(:respond_to_missing?, 'address'))
   end
 
   def test_returns_error_when_retries_exceeded

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -45,7 +45,7 @@ class TestDeterminism < Test::Unit::TestCase
 
   def subclasses
     Faker.constants.delete_if do |subclass|
-      %i[Base Bank Books Cat Char Base58 ChileRut CLI Config Creature Date Dog DragonBall Dota ElderScrolls Fallout Games GamesHalfLife HeroesOfTheStorm Internet JapaneseMedia LeagueOfLegends Movies Myst Overwatch OnePiece Pokemon Sports SwordArtOnline TvShows Time VERSION Witcher WorldOfWarcraft Zelda].include?(subclass)
+      %i[Base Bank Books Cat Char Base58 ChileRut CLI Config Creature Date Dog DragonBall Dota ElderScrolls Filtering Fallout Games GamesHalfLife HeroesOfTheStorm Internet JapaneseMedia LeagueOfLegends Movies Myst Overwatch OnePiece Pokemon Sports SwordArtOnline TvShows Time VERSION Witcher WorldOfWarcraft Zelda].include?(subclass)
     end.sort
   end
 

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -13,6 +13,10 @@ end
 class TestFaker < Test::Unit::TestCase
   def setup; end
 
+  def teardown
+    Faker::UniqueGenerator.clear
+  end
+
   def test_numerify
     100.times do
       assert Faker::Base.numerify('###').match(/[1-9]\d{2}/)
@@ -122,5 +126,42 @@ class TestFaker < Test::Unit::TestCase
     end
 
     assert_equal(unique_numbers.uniq, unique_numbers)
+  end
+
+  def test_select
+    filter = proc { |letter| letter =~ /[AEIOU]/ }
+    selected_letters = Array.new(8) do
+      Faker::Base.select(&filter).letterify('?')
+    end
+
+    assert selected_letters.all?(&filter)
+  end
+
+  def test_reject
+    filter = proc { |letter| letter =~ /[ABCDEFGHIJ]/ }
+    selected_letters = Array.new(8) do
+      Faker::Base.reject(&filter).letterify('?')
+    end
+
+    assert selected_letters.none?(&filter)
+  end
+
+  def test_unique_and_select
+    filter = proc { |letter| letter =~ /[AEIOU]/ }
+    selected_letters = Array.new(5) do
+      Faker::Base.unique.select(&filter).letterify('?')
+    end
+
+    assert_equal(%w[A E I O U], selected_letters.sort)
+  end
+
+  def test_select_and_reject
+    selection_filter = proc { |letter| letter =~ /[AEIOU]/ }
+    rejection_filter = proc { |letter| letter =~ /[EIOU]/ }
+    selected_letters = Array.new(5) do
+      Faker::Base.select(&selection_filter).reject(&rejection_filter).letterify('?')
+    end
+
+    assert selected_letters.all? { |letter| letter == 'A' }
   end
 end


### PR DESCRIPTION
`No-Story`

Description:
------
I thought it might be nice to be able to constrain values generated by `Faker` to some subset of those defined for a given generator. 

This PR allows one to invoke `select` on a generator, passing a block, where the generator will then only output values for which the block evaluates to true.

A contrived example:

```ruby
Faker::Number.select(&:even?).number
```
Outputs only even integers.

The same result can be achieved using the equivalent `reject` method.

I.e. The following is equivalent to the above:

```ruby
Faker::Number.reject(&:odd?).number
```

Furthermore, these filters can be a chained after unique constraints:

So

```ruby
Faker::Number.unique.select(&:even?).reject(&:negative?).number
```

Returns unique positive integers.

_Further details about the implementation can be found in the commit messages._
