### PR TITLE
FIX internet custom domain with suffix

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -141,9 +141,20 @@ module Faker
         end
 
         with_locale(:en) do
-          given_domain_word = domain || domain_word
-          domain_elements = [Char.prepare(given_domain_word), domain_suffix]
-          domain_elements.unshift(Char.prepare(given_domain_word)) if subdomain
+          domain_elements = []
+
+          if domain
+            domain.split('.').each do |domain_part|
+              domain_elements << Char.prepare(domain_part)
+            end
+            domain_elements << domain_suffix if domain_elements.length < 2
+            domain_elements.unshift(Char.prepare(domain_word)) if subdomain && domain_elements.length < 3
+          else
+            domain_elements << domain_word
+            domain_elements << domain_suffix
+            domain_elements.unshift(Char.prepare(domain_word)) if subdomain
+          end
+
           domain_elements.join('.')
         end
       end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -19,6 +19,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.email(name: 'jane doe', domain: 'customdomain').match(/.+@customdomain\.\w+/)
   end
 
+  def test_email_with_domain_option_given_with_domain_suffix
+    assert @tester.email(name: 'jane doe', domain: 'customdomain.customdomainsuffix').match(/.+@customdomain\.customdomainsuffix/)
+  end
+
   def test_free_email
     assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
   end
@@ -156,6 +160,10 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_domain_name_with_subdomain_and_with_domain_option_given
     assert @tester.domain_name(subdomain: true, domain: 'customdomain').match(/customdomain\.\w+/)
+  end
+
+  def test_domain_name_with_subdomain_and_with_domain_option_given_with_domain_suffixc
+    assert @tester.domain_name(subdomain: true, domain: 'customdomain.customdomainsuffix').match(/customdomain\.customdomainsuffix/)
   end
 
   def test_domain_word


### PR DESCRIPTION
Issue# 
------

https://github.com/faker-ruby/faker/issues/1845

Description:
------
Allow custom "full domain" (domains with suffixes and / or subdomain) to be preserved as is

There are many ways to do it (for exemple this works too) : 
```rb
given_domain_word = domain&.split('.')&.first || domain_word
given_suffix_word = domain&.include?('.') ? domain.split('.').last : domain_suffix
domain_elements = [Char.prepare(given_domain_word), Char.prepare(given_suffix_word)]
domain_elements.unshift(Char.prepare(given_domain_word)) if subdomain
```
But the one in PR seems more preservative (and clear, but not sure about this one)