### PR TITLE
Exclude string.rb from consideration by YARD.

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,6 @@
 --no-private
 --tag faker.version:"Available since"
 --exclude lib/faker/deprecate/
+--exclude lib/faker/default/string.rb
 --output-dir yard_docs
 lib/**/*.rb


### PR DESCRIPTION
This is a bit of a dumb hack. Without this, YARD will assume all references to "String" (so prettty much every return type in the entire codebase) mean `Faker::String`, which is incorrect, and also messes up the auto-generated Sorbet types and the VS Code IntelliSense provided by [solargraph](https://github.com/castwide/solargraph).

The long-term solution for this is probably to deprecate `Faker::String` and move the `Faker::String.random` method into `Faker::Types`.

The downside to this solution is that the `Faker::String` class is excluded from the YARD docs, but unfortunately I can't think of a better option (I generally consider replacing every instance of `String` in the YARD docs with `::String` to not be a reasonable solution).

@vbrazo @Zeragamba thoughts?