### PR TITLE
add domain_suffix option to internet .email and .domain_name

### DIFF
--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -1,11 +1,16 @@
 # Faker::Internet
 
 ```ruby
-# Keyword arguments: name, separators, domain
+# Keyword arguments: name, separators, subdomain, domain, domain_suffix
 Faker::Internet.email #=> "eliza@mann.net"
 Faker::Internet.email(name: 'Nancy') #=> "nancy@terry.biz"
 Faker::Internet.email(name: 'Janelle Santiago', separators: '+') #=> janelle+santiago@becker.com"
 Faker::Internet.email(domain: 'example') #=> alice@example.name"
+Faker::Internet.email(subdomain: true) #=> alice@keebler.sons.name"
+Faker::Internet.email(domain_suffix: 'xyz') #=> alice@terry.xyz"
+Faker::Internet.email(domain: 'example', domain_suffix: 'xyz') #=> alice@example.xyz"
+Faker::Internet.email(domain: 'company.example', domain_suffix: 'xyz') #=> alice@company.example.xyz"
+Faker::Internet.email(subdomain: true, domain: 'company.example', domain_suffix: 'xyz') #=> alice@keebler.company.example.xyz"
 
 # Keyword arguments: name
 Faker::Internet.free_email #=> "freddy@gmail.com"
@@ -34,10 +39,12 @@ Faker::Internet.password(min_length: 10, max_length: 20) #=> "EoC9ShWd1hWq4vBgFw
 Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true) #=> "3k5qS15aNmG"
 Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true, special_characters: true) #=> "*%NkOnJsH4"
 
-# Keyword arguments: subdomain, domain
+# Keyword arguments: subdomain, domain, domain_suffix
 Faker::Internet.domain_name #=> "effertz.info"
 Faker::Internet.domain_name(domain: "example") #=> "example.net"
 Faker::Internet.domain_name(subdomain: true, domain: "example") #=> "horse.example.org"
+Faker::Internet.domain_name(domain: "company.example", domain_suffix: "xyz") #=> "company.example.xyz"
+Faker::Internet.domain_name(subdomain: true, domain: "company.example", domain_suffix: "xyz") #=> "hello.company.example.xyz"
 
 Faker::Internet.domain_word #=> "haleyziemann"
 

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -15,14 +15,6 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.email(name: 'jane doe', separators: '+').match(/.+\+.+@.+\.\w+/)
   end
 
-  def test_email_with_domain_option_given
-    assert @tester.email(name: 'jane doe', domain: 'customdomain').match(/.+@customdomain\.\w+/)
-  end
-
-  def test_email_with_domain_option_given_with_domain_suffix
-    assert @tester.email(name: 'jane doe', domain: 'customdomain.customdomainsuffix').match(/.+@customdomain\.customdomainsuffix/)
-  end
-
   def test_free_email
     assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
   end
@@ -158,12 +150,48 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.domain_name(subdomain: true).match(/\w+\.\w+\.\w+/)
   end
 
-  def test_domain_name_with_subdomain_and_with_domain_option_given
-    assert @tester.domain_name(subdomain: true, domain: 'customdomain').match(/customdomain\.\w+/)
+  def test_domain_name_with_domain_suffix
+    assert @tester.domain_name(domain_suffix: 'domain_suffix').match(/\w+\.domain_suffix/)
+  end
+
+  def test_domain_name_with_subdomain_and_domain_suffix
+    assert @tester.domain_name(subdomain: true, domain_suffix: 'domain_suffix').match(/\w+\.\w+\.domain_suffix/)
+  end
+
+  def test_domain_name_with_subdomain_and_domain_and_domain_suffix
+    assert @tester.domain_name(subdomain: true, domain: 'my.domain', domain_suffix: 'my.domain_suffix').match(/\w+\.my.domain.my.domain_suffix/)
+  end
+
+  def test_domain_name_with_subdomain_and_complex_domain_suffix
+    assert @tester.domain_name(subdomain: true, domain_suffix: 'my.domain.suffix').match(/\w+\.\w+\.my.domain.suffix/)
+  end
+
+  def test_email_with_domain_option_given
+    assert @tester.email(domain: 'custom_domain').match(/.+@custom_domain\.\w+/)
+  end
+
+  def test_email_with_domain_suffix_option_given
+    assert @tester.email(domain_suffix: 'custom_domain_suffix').match(/.+custom_domain_suffix/)
+  end
+
+  def test_email_with_domain_and_domain_suffix_option_given
+    assert @tester.email(domain: 'custom_domain', domain_suffix: 'custom_domain_suffix').match(/.+@custom_domain\.custom_domain_suffix+/)
+  end
+
+  def test_email_with_subdomain_and_domain_suffix_option_given
+    assert @tester.email(subdomain: true, domain_suffix: 'custom_domain_suffix').match(/.+@\w+\.\w+\.custom_domain_suffix/)
+  end
+
+  def test_email_with_subdomain_and_domain_and_domain_suffix_option_given
+    assert @tester.email(subdomain: true, domain: 'custom_domain', domain_suffix: 'custom_domain_suffix').match(/.+@\w+\.custom_domain\.custom_domain_suffix/)
   end
 
   def test_domain_name_with_subdomain_and_with_domain_option_given_with_domain_suffix
     assert @tester.domain_name(subdomain: true, domain: 'customdomain.customdomainsuffix').match(/customdomain\.customdomainsuffix/)
+  end
+
+  def test_email_with_custom_subdomain_and_custom_suffix_option_given
+    assert @tester.email(domain: 'custom_subdomain.custom_domain', domain_suffix: 'custom.domain.suffix').match(/.+@custom_subdomain\.custom_domain\.custom\.domain\.suffix/)
   end
 
   def test_domain_word


### PR DESCRIPTION
Issue# 
------

https://github.com/faker-ruby/faker/issues/1845

Description:
------

Clean and Fix the `Internet.domain_name` and `Internet.email` api as seen with @tiagofsilva 