### PR TITLE
Fix Educator methods returning bad data.

### DIFF
--- a/lib/locales/en/educator.yml
+++ b/lib/locales/en/educator.yml
@@ -1,7 +1,7 @@
 en:
   faker:
     educator:
-      name:
+      school_name:
         - Bluemeadow
         - Brighthurst
         - Brookville
@@ -23,11 +23,11 @@ en:
         - High School
         - Secondary College
       university:
-        - "#{name} #{Educator.tertiary.university_type}"
+        - "#{Educator.school_name} #{Educator.tertiary.university_type}"
       secondary_school:
-        - "#{name} #{secondary}"
+        - "#{Educator.school_name} #{secondary}"
       campus:
-        - "#{name} Campus"
+        - "#{Educator.school_name} Campus"
       subject:
         - Applied Science (Psychology)
         - Architectural Technology


### PR DESCRIPTION
Issue# 
------
Fixes #1857.

Description:
------
`name` is already registered on classes in Ruby, so it just returns `Faker::Educator` instead of a value from the name list. This fixes the problem by renaming the key to `school_name`.