### PR TITLE
Add Faker::Gender.short_binary_type

### DIFF
--- a/doc/default/gender.md
+++ b/doc/default/gender.md
@@ -6,4 +6,6 @@ Available since version 1.9.0.
 Faker::Gender.type #=> "Non-binary"
 
 Faker::Gender.binary_type #=> "Female"
+
+Faker::Gender.short_binary_type #=> "f"
 ```

--- a/lib/faker/default/gender.rb
+++ b/lib/faker/default/gender.rb
@@ -28,6 +28,19 @@ module Faker
       def binary_type
         fetch('gender.binary_types')
       end
+
+      ##
+      # Produces either 'f' or 'm'.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Gender.short_binary_type #=> "f"
+      #
+      # @faker.version next
+      def short_binary_type
+        fetch('gender.short_binary_types')
+      end
     end
   end
 end

--- a/lib/locales/en/gender.yml
+++ b/lib/locales/en/gender.yml
@@ -3,3 +3,4 @@ en:
     gender:
       types: ["Female", "Male", "Non-binary", "Agender", "Genderfluid", "Genderqueer", "Bigender", "Polygender"]
       binary_types: ["Female", "Male"]
+      short_binary_types: ["f", "m"]

--- a/test/faker/default/test_faker_gender.rb
+++ b/test/faker/default/test_faker_gender.rb
@@ -14,4 +14,8 @@ class TestFakerGender < Test::Unit::TestCase
   def test_binary_type
     assert @tester.binary_type.match(/\w+/)
   end
+
+  def test_short_binary_type
+    assert @tester.short_binary_type.match(/f|m/)
+  end
 end


### PR DESCRIPTION
`No-Story`

Description:
------
Today I had the need to have `f` or `m` for a gender parameter.
We use this `f` or `m` in a lot of different scenarios but mostly to:
- append to a file_path to use the proper default avatar according to gender
- append to a string to fetch the correct translation from I18n.t

Please let me know if there's something missing in this PR or if you need more use cases.

Cheers,
Bruno