### PR TITLE
Upgrade the Gemfile.lock to Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=c9b8356df2031a5a72462555fe898245cf24d83c7bb82c40ddb5c6c6976c4319
-sudo: false
 language: ruby
 cache: bundler
 rvm:
@@ -10,6 +9,8 @@ rvm:
   - 2.5.3
   - 2.6.1
   - ruby-head
+before_install:
+  - gem install bundler
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    json (2.2.0)
+    json (2.3.0)
     method_source (0.9.2)
     minitest (5.13.0)
     parallel (1.19.1)
@@ -60,4 +60,4 @@ DEPENDENCIES
   yard (= 0.9.20)
 
 BUNDLED WITH
-   1.17.3
+   2.1.0


### PR DESCRIPTION
This should allow ruby-head to be run in CI.

It also updates the json gem to fix some deprecation warnings it causes.