### PR TITLE
Fix tests failing on Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.6.1
   - ruby-head
 before_install:
-  - gem install bundler
+  - gem install bundler:2.1.0
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ rvm:
   - 2.6.1
   - ruby-head
 before_install:
-  - gem install bundler:2.1.0
+  - gem update --system=3.1.1 --force
+  - gem install bundler:2.1.1
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.6.1
   - ruby-head
 before_install:
-  - gem update --system=3.1.1 --force
+  - yes | gem update --system=3.1.1 --force
   - gem install bundler:2.1.1
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/test/faker/default/test_faker_birthday_in_leap_year.rb
+++ b/test/faker/default/test_faker_birthday_in_leap_year.rb
@@ -20,12 +20,23 @@ class TestFakerBirthdayInLeapYear < Test::Unit::TestCase
       @tester.birthday
     end
 
-    assert_raise ArgumentError do
-      ::Date.new(@today.year - @min, @today.month, @today.day)
-    end
+    # The error raised here is changed in Ruby 2.7.
+    if RUBY_VERSION < '2.7'
+      assert_raise ArgumentError do
+        ::Date.new(@today.year - @min, @today.month, @today.day)
+      end
 
-    assert_raise ArgumentError do
-      ::Date.new(@today.year - @max, @today.month, @today.day)
+      assert_raise ArgumentError do
+        ::Date.new(@today.year - @max, @today.month, @today.day)
+      end
+    elsif RUBY_VERSION >= '2.7'
+      assert_raise Date::Error do
+        ::Date.new(@today.year - @min, @today.month, @today.day)
+      end
+
+      assert_raise Date::Error do
+        ::Date.new(@today.year - @max, @today.month, @today.day)
+      end
     end
   end
 end

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -58,8 +58,16 @@ class TestFakerIdNumber < Test::Unit::TestCase
 
   def test_invalid_south_african_id_number
     sample = @tester.invalid_south_african_id_number
-    assert_raises ArgumentError do
-      Date.parse(south_african_id_number_to_date_of_birth_string(sample))
+
+    # The error raised here is changed in Ruby 2.7.
+    if RUBY_VERSION < '2.7'
+      assert_raises ArgumentError do
+        Date.parse(south_african_id_number_to_date_of_birth_string(sample))
+      end
+    elsif RUBY_VERSION >= '2.7'
+      assert_raises Date::Error do
+        Date.parse(south_african_id_number_to_date_of_birth_string(sample))
+      end
     end
   end
 


### PR DESCRIPTION
This is a draft because it depends on #1866. Once that's merged, I'll rebase this PR and this PR can be merged.

These were failing because the error being raised has changed. I'm not sure if this is the best way to solve this problem, I'm open to feedback.