### PR TITLE
Fix a deprecation warning in unique_generator.rb related to the kwargs change in Ruby 2.7.

### DIFF
--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -15,11 +15,11 @@ module Faker
     end
 
     # rubocop:disable Style/MethodMissingSuper
-    def method_missing(name, *arguments, **kwargs)
+    def method_missing(name, *arguments)
       self.class.marked_unique.add(self)
 
       @max_retries.times do
-        result = @generator.public_send(name, *arguments, **kwargs)
+        result = @generator.public_send(name, *arguments)
 
         next if @previous_results[[name, arguments]].include?(result)
 
@@ -29,6 +29,10 @@ module Faker
 
       raise RetryLimitExceeded, "Retry limit exceeded for #{name}"
     end
+    # Have method_missing use ruby 2.x keywords if the method exists.
+    # This is necessary because the syntax for passing arguments (`...`)
+    # is invalid on versions before Ruby 2.7, so it can't be used.
+    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     # rubocop:enable Style/MethodMissingSuper
 
     def respond_to_missing?(method_name, include_private = false)

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -15,11 +15,11 @@ module Faker
     end
 
     # rubocop:disable Style/MethodMissingSuper
-    def method_missing(name, *arguments)
+    def method_missing(name, *arguments, **kwargs)
       self.class.marked_unique.add(self)
 
       @max_retries.times do
-        result = @generator.public_send(name, *arguments, **{})
+        result = @generator.public_send(name, *arguments, **kwargs)
 
         next if @previous_results[[name, arguments]].include?(result)
 

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -15,11 +15,11 @@ module Faker
     end
 
     # rubocop:disable Style/MethodMissingSuper
-    def method_missing(name, *arguments, **kwargs)
+    def method_missing(name, *arguments)
       self.class.marked_unique.add(self)
 
       @max_retries.times do
-        result = @generator.public_send(name, *arguments, **kwargs)
+        result = @generator.public_send(name, *arguments, **{})
 
         next if @previous_results[[name, arguments]].include?(result)
 

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -15,11 +15,11 @@ module Faker
     end
 
     # rubocop:disable Style/MethodMissingSuper
-    def method_missing(name, *arguments)
+    def method_missing(name, *arguments, **kwargs)
       self.class.marked_unique.add(self)
 
       @max_retries.times do
-        result = @generator.public_send(name, *arguments)
+        result = @generator.public_send(name, *arguments, **kwargs)
 
         next if @previous_results[[name, arguments]].include?(result)
 


### PR DESCRIPTION
This fixes a deprecation warning I was seeing when using `Faker.unique`:

```
/Users/connorshea/.rbenv/versions/2.7.0-preview3/lib/ruby/gems/2.7.0/gems/faker-2.9.0/lib/helpers/unique_generator.rb:22: warning: The last argument is used as the keyword parameter
/Users/connorshea/.rbenv/versions/2.7.0-preview3/lib/ruby/gems/2.7.0/gems/faker-2.9.0/lib/faker/default/number.rb:178: warning: for `between' defined here
```

It also removes ~6000 lines of deprecation warnings from the Faker test suite on Ruby 2.7. (There are still >250k others 😉)

See this post for more info: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/