### PR TITLE
Extract constants in Faker::Music

### DIFF
--- a/lib/faker/music/music.rb
+++ b/lib/faker/music/music.rb
@@ -3,6 +3,11 @@
 module Faker
   class Music < Base
     class << self
+      NOTE_LETTERS = %w[C D E F G A B].freeze
+      ACCIDENTAL_SIGNS = ['b', '#', ''].freeze
+      KEY_TYPES = ['', 'm'].freeze
+      CHORD_TYPES = ['', 'maj', '6', 'maj7', 'm', 'm7', '-7', '7', 'dom7', 'dim', 'dim7', 'm7b5'].freeze
+
       ##
       # Produces the name of a key/note, using letter notation.
       #
@@ -49,7 +54,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def keys
-        %w[C D E F G A B]
+        NOTE_LETTERS
       end
 
       ##
@@ -59,7 +64,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def key_variants
-        ['b', '#', '']
+        ACCIDENTAL_SIGNS
       end
 
       ##
@@ -72,7 +77,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def key_types
-        ['', 'm']
+        KEY_TYPES
       end
 
       ##
@@ -82,7 +87,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def chord_types
-        ['', 'maj', '6', 'maj7', 'm', 'm7', '-7', '7', 'dom7', 'dim', 'dim7', 'm7b5']
+        CHORD_TYPES
       end
 
       ##


### PR DESCRIPTION
`No-Story`

Description:
------
This PR pulls arrays out of methods in `Faker::Music` into constants in the same class. It's a follow-up to https://github.com/faker-ruby/faker/pull/1873#discussion_r360746180.

This technically does change behavior, as the arrays returned by these methods are now frozen and modifications on them will throw exceptions; for example, the following did not previously throw an exception but now will:

```ruby
arr = Faker::Music.keys
arr.sort!
```