### PR TITLE
Use stdlib ipaddr for internet IP and CIDR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ env:
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.8
-  - 2.4.5
+  - 2.4.9
   - 2.5.3
   - 2.6.1
   - 2.7.0
@@ -21,5 +20,5 @@ script: bundle exec rake
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 matrix:
- allow_failures:
-   - rvm: ruby-head
+  allow_failures:
+    - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+---
 env:
   global:
     - CC_TEST_REPORTER_ID=c9b8356df2031a5a72462555fe898245cf24d83c7bb82c40ddb5c6c6976c4319
 language: ruby
 cache: bundler
 rvm:
+  - 2.3.8
   - 2.4.9
   - 2.5.3
   - 2.6.1

--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -43,19 +43,33 @@ Faker::Internet.domain_word #=> "haleyziemann"
 
 Faker::Internet.domain_suffix #=> "info"
 
+# IP V4 adress
 Faker::Internet.ip_v4_address #=> "24.29.18.175"
-
-# Private IP range according to RFC 1918 and 127.0.0.0/8 and 169.254.0.0/16.
+Faker::Internet.link_local_ip_v4_address #=> "169.254.0.1"
+Faker::Internet.loopback_ip_v4_address #=> "127.0.0.1"
 Faker::Internet.private_ip_v4_address #=> "10.0.0.1"
-
-# Guaranteed not to be in the ip range from the private_ip_v4_address method.
 Faker::Internet.public_ip_v4_address #=> "24.29.18.175"
 
+# IP V4 CIDR
 Faker::Internet.ip_v4_cidr #=> "24.29.18.175/21"
+Faker::Internet.link_local_ip_v4_cidr #=> "169.254.0.0/16" (immutable)
+Faker::Internet.loopback_ip_v4_cidr #=> "127.0.0.0/8" (immutable)
+Faker::Internet.private_ip_v4_uidr #=> "192.168.0.0/16"
+Faker::Internet.public_ip_v4_cidr #=> "192.172.0.0/14"
 
+# IP V6 adress
 Faker::Internet.ip_v6_address #=> "ac5f:d696:3807:1d72:2eb5:4e81:7d2b:e1df"
+Faker::Internet.link_local_ip_v6_address #=> "fea9:9148:9719:27cf:075e:f437:c22f:4496"
+Faker::Internet.loopback_ip_v6_address #=> "0000:0000:0000:0000:0000:0000:0000:0001"
+Faker::Internet.private_ip_v6_address #=> "fc85:ca65:e1f4:a6ed:2751:b25e:09c6:c716"
+Faker::Internet.public_ip_v6_address #=> "0064:ff9b:0000:0000:0000:0000:95e3:bad2"
 
+# IP V6 CIDR
 Faker::Internet.ip_v6_cidr #=> "ac5f:d696:3807:1d72:2eb5:4e81:7d2b:e1df/78"
+Faker::Internet.link_local_ip_v6_cidr #=> "fe80::/10" (immutable)
+Faker::Internet.loopback_ip_v6_cidr #=> "fe80::/10" (immutable)
+Faker::Internet.private_ip_v6_cidr #=> "fc00::/7"
+Faker::Internet.public_ip_v6_cidr #=> "64:ff9b::/96"
 
 # Keyword arguments: prefix
 Faker::Internet.mac_address #=> "e6:0d:00:11:ed:4f"

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -321,7 +321,9 @@ module Faker
       end
 
       def ip_from_subnets(subnets_array, family)
-        ip_range = IPAddr.new(subnets_array.sample).to_range
+        subnet = subnets_array.sample
+        puts subnet
+        ip_range = IPAddr.new(subnet).to_range
         IPAddr.new(rand(ip_range.first.to_i..ip_range.last.to_i), family).to_string
       end
 
@@ -350,6 +352,15 @@ module Faker
       end
 
       def public_ipv4_subnets
+        # 64.0.0.0/2 is public but reserved (and huge)
+        # it include 127.0.0.0/8
+        # so it is converted below into:
+        # 64.0.0.0/3
+        # 96.0.0.0/4
+        # 112.0.0.0/5
+        # 120.0.0.0/6
+        # 124.0.0.0/7
+        # 126.0.0.0/8
         %w[
           0.0.0.0/5
           8.0.0.0/7
@@ -357,7 +368,12 @@ module Faker
           12.0.0.0/6
           16.0.0.0/4
           32.0.0.0/3
-          64.0.0.0/2
+          64.0.0.0/3
+          96.0.0.0/4
+          112.0.0.0/5
+          120.0.0.0/6
+          124.0.0.0/7
+          126.0.0.0/8
           128.0.0.0/3
           160.0.0.0/5
           168.0.0.0/6

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -228,43 +228,43 @@ module Faker
       end
 
       def public_ip_v4_cidr
-        public_ipv4_subnets.sample
+        random_netmask(public_ipv4_subnets.sample, 32)
       end
 
       def loopback_ip_v4_cidr
-        link_local_ipv4_subnets[0]
+        random_netmask(loopback_ipv4_subnets[0], 32)
       end
 
       def link_local_ip_v4_cidr
-        link_local_ipv4_subnets[0]
+        random_netmask(link_local_ipv4_subnets[0], 32)
       end
 
       def private_ip_v4_cidr
-        private_ipv4_subnets.sample
+        random_netmask(private_ipv4_subnets.sample, 32)
       end
 
       def ip_v4_cidr
-        (loopback_ipv4_subnets + link_local_ipv4_subnets + public_ipv4_subnets + private_ipv4_subnets).sample
+        random_netmask((loopback_ipv4_subnets + link_local_ipv4_subnets + public_ipv4_subnets + private_ipv4_subnets).sample, 32)
       end
 
       def public_ip_v6_cidr
-        public_ipv6_subnets.sample
+        random_netmask(public_ipv6_subnets.sample, 128)
       end
 
       def loopback_ip_v6_cidr
-        link_local_ipv6_subnets[0]
+        random_netmask(loopback_ipv6_subnets[0], 128)
       end
 
       def link_local_ip_v6_cidr
-        link_local_ipv6_subnets[0]
+        random_netmask(link_local_ipv6_subnets[0], 128)
       end
 
       def private_ip_v6_cidr
-        private_ipv6_subnets.sample
+        random_netmask(private_ipv6_subnets.sample, 128)
       end
 
       def ip_v6_cidr
-        (loopback_ipv6_subnets + link_local_ipv6_subnets + public_ipv6_subnets + private_ipv6_subnets).sample
+        random_netmask((loopback_ipv6_subnets + link_local_ipv6_subnets + public_ipv6_subnets + private_ipv6_subnets).sample, 128)
       end
 
       # rubocop:disable Metrics/ParameterLists
@@ -314,6 +314,11 @@ module Faker
       alias user_name username
 
       private
+
+      def random_netmask(cidr, max_value)
+        address, mask = cidr.split('/')
+        "#{address}/#{rand(mask.to_i..max_value)}"
+      end
 
       def ip_from_subnets(subnets_array, family)
         ip_range = IPAddr.new(subnets_array.sample).to_range

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -228,11 +228,11 @@ module Faker
       end
 
       def ip_v4_cidr
-        "#{ip_v4_address}/#{rand(1..32)}"
+        (loopback_ipv4_subnets + link_local_ipv4_subnets + public_ipv4_subnets + private_ipv4_subnets).sample
       end
 
       def ip_v6_cidr
-        "#{ip_v6_address}/#{rand(1..128)}"
+        (loopback_ipv6_subnets + link_local_ipv6_subnets + public_ipv6_subnets + private_ipv6_subnets).sample
       end
 
       # rubocop:disable Metrics/ParameterLists

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -227,8 +227,40 @@ module Faker
         send(method)
       end
 
+      def public_ip_v4_cidr
+        public_ipv4_subnets.sample
+      end
+
+      def loopback_ip_v4_cidr
+        link_local_ipv4_subnets[0]
+      end
+
+      def link_local_ip_v4_cidr
+        link_local_ipv4_subnets[0]
+      end
+
+      def private_ip_v4_cidr
+        private_ipv4_subnets.sample
+      end
+
       def ip_v4_cidr
         (loopback_ipv4_subnets + link_local_ipv4_subnets + public_ipv4_subnets + private_ipv4_subnets).sample
+      end
+
+      def public_ip_v6_cidr
+        public_ipv6_subnets.sample
+      end
+
+      def loopback_ip_v6_cidr
+        link_local_ipv6_subnets[0]
+      end
+
+      def link_local_ip_v6_cidr
+        link_local_ipv6_subnets[0]
+      end
+
+      def private_ip_v6_cidr
+        private_ipv6_subnets.sample
       end
 
       def ip_v6_cidr

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -199,6 +199,9 @@ class TestFakerInternet < Test::Unit::TestCase
       address = @tester.public_ip_v4_address
       if RUBY_VERSION >= '2.5.0'
         ip_address = IPAddr.new(address, Socket::AF_INET) # may throw in case of invalid address, but the  case is handled above
+        puts "#{ip_address} link_local ? #{ip_address.link_local?}"
+        puts "#{ip_address} private ? #{ip_address.private?}"
+        puts "#{ip_address} loopback? #{ip_address.loopback?}"
         assert !(ip_address.private? || ip_address.loopback? || ip_address.link_local?)
       else
         assert Faker::Internet.send(:public_ipv4_subnets).detect(false) { |i| IPAddr.new(i).include?(address) }

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -184,50 +184,18 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_private_ip_v4_address
-    regexps = [
-      /^10\./,                                       # 10.0.0.0    - 10.255.255.255
-      /^100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7])\./,   # 100.64.0.0  - 100.127.255.255
-      /^127\./,                                      # 127.0.0.0   - 127.255.255.255
-      /^169\.254\./,                                 # 169.254.0.0 - 169.254.255.255
-      /^172\.(1[6-9]|2\d|3[0-1])\./,                 # 172.16.0.0  - 172.31.255.255
-      /^192\.0\.0\./,                                # 192.0.0.0   - 192.0.0.255
-      /^192\.168\./,                                 # 192.168.0.0 - 192.168.255.255
-      /^198\.(1[8-9])\./                             # 198.18.0.0  - 198.19.255.255
-    ]
-    expected = Regexp.new regexps.collect { |reg| "(#{reg})" }.join('|')
-
     1000.times do
       address = @tester.private_ip_v4_address
-      assert_match expected, address
+      assert IPAddr.new(address, Socket::AF_INET).private?
     end
   end
 
   def test_public_ip_v4_address
-    private = [
-      /^10\./,                                       # 10.0.0.0    - 10.255.255.255
-      /^100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7])\./,   # 100.64.0.0  - 100.127.255.255
-      /^127\./,                                      # 127.0.0.0   - 127.255.255.255
-      /^169\.254\./,                                 # 169.254.0.0 - 169.254.255.255
-      /^172\.(1[6-9]|2\d|3[0-1])\./,                 # 172.16.0.0  - 172.31.255.255
-      /^192\.0\.0\./,                                # 192.0.0.0   - 192.0.0.255
-      /^192\.168\./,                                 # 192.168.0.0 - 192.168.255.255
-      /^198\.(1[8-9])\./                             # 198.18.0.0  - 198.19.255.255
-    ]
-
-    reserved = [
-      /^0\./,                 # 0.0.0.0      - 0.255.255.255
-      /^192\.0\.2\./,         # 192.0.2.0    - 192.0.2.255
-      /^192\.88\.99\./,       # 192.88.99.0  - 192.88.99.255
-      /^198\.51\.100\./,      # 198.51.100.0 - 198.51.100.255
-      /^203\.0\.113\./,       # 203.0.113.0  - 203.0.113.255
-      /^(22[4-9]|23\d)\./,    # 224.0.0.0    - 239.255.255.255
-      /^(24\d|25[0-5])\./     # 240.0.0.0    - 255.255.255.254  and  255.255.255.255
-    ]
-
-    1000.times do
-      address = @tester.public_ip_v4_address
-      private.each { |reg| assert_not_match reg, address }
-      reserved.each { |reg| assert_not_match reg, address }
+    100.times do
+      assert_nothing_raised IPAddr::Error, IPAddr::AddressFamilyError, IPAddr::InvalidAddressError, StandardError do
+        address = IPAddr.new(@tester.ip_v4_address, Socket::AF_INET)
+        raise StandardError, "Invalid IP V4 #{address}" unless address.ipv4?
+      end
     end
   end
 
@@ -252,10 +220,11 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_ip_v6_address
-    assert_equal 7, @tester.ip_v6_address.count(':')
-
     100.times do
-      assert @tester.ip_v6_address.split('.').map { |h| "0x#{h}".hex }.max <= 65_535
+      assert_nothing_raised IPAddr::Error, IPAddr::AddressFamilyError, IPAddr::InvalidAddressError, StandardError do
+        address = IPAddr.new(@tester.ip_v6_address, ::Socket::AF_INET6)
+        raise StandardError, "Invalid IP V6 #{address}" unless address.ipv6?
+      end
     end
   end
 


### PR DESCRIPTION
Issue #1880
------
See the issue for an example

Description:
------
Resolve the issue above, extend IP V4 and IP V6 generator

- Use Ruby stdlib `IPAddr` to generate IP related stuff
- Add a bunch of method to generate local or loopback address for both IP V6 and I V4 while keeping backward compatibility
- Extend CIDR generators (again with local, loopback, private and public method) while keeping the original methods (witch may generate out of RFC boundaries CIDR).

Note: tests were sometimes running 1000 times while using regexp. I do not think it is necessary any more, but i let them as-is.