### PR TITLE
Allow all versions of i18n from 1.6 up to 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     docile (1.3.2)
-    i18n (1.8.0)
+    i18n (1.8.1)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     faker (2.10.0)
-      i18n (>= 1.6, < 1.9)
+      i18n (>= 1.6, < 2)
 
 GEM
   remote: https://rubygems.org/

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/github/faker-ruby/faker/master'
   spec.metadata['yard.run'] = 'yri'
 
-  spec.add_dependency('i18n', '>= 1.6', '< 1.9')
+  spec.add_dependency('i18n', '>= 1.6', '< 2')
 
   spec.add_development_dependency('minitest', '5.13.0')
   spec.add_development_dependency('pry', '0.12.2')


### PR DESCRIPTION
It's unlikely that any new features in i18n 1.x will be incompatible with faker.

Let's open up the version restriction to allow any version of 1.x after 1.6. Only when version 2 comes out should we expect breaking changes.

At the minute, downstream systems have to wait for a new release of faker, for every minor release of i18n.