### PR TITLE
Prevent use of bad version of i18n gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     faker (2.10.0)
-      i18n (>= 1.6, < 2)
+      i18n (>= 1.6, < 1.9, != 1.8.0)
 
 GEM
   remote: https://rubygems.org/

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/github/faker-ruby/faker/master'
   spec.metadata['yard.run'] = 'yri'
 
-  spec.add_dependency('i18n', '>= 1.6', '< 2')
+  spec.add_dependency('i18n', '>= 1.6', '< 1.9', '!= 1.8.0')
 
   spec.add_development_dependency('minitest', '5.13.0')
   spec.add_development_dependency('pry', '0.12.2')


### PR DESCRIPTION
The i18n gem has a breaking issue: https://github.com/ruby-i18n/i18n/issues/507

Modified the gemspec so the bad version won't be used.