### PR TITLE
Use postcode for en-ZA

### DIFF
--- a/lib/locales/en-ZA.yml
+++ b/lib/locales/en-ZA.yml
@@ -5,7 +5,7 @@ en-ZA:
     address:
       country_code: ['ZA']
       default_country: [South Africa, The Replublic of South Africa, SA, Afrique du Sud, Zuid-Afrika]
-      post_code: ['####', '#####']
+      postcode: ['####', '#####']
       provinces: [Limpopo, Gauteng, Free State, North West, Northern Cape, Western Cape, KwaZulu-Natal, Mpumalanga, Eastern Cape]
       province:
         - "#{provinces}"

--- a/test/test_en_za_locale.rb
+++ b/test/test_en_za_locale.rb
@@ -14,7 +14,7 @@ class TestEnZaLocale < Test::Unit::TestCase
   def test_en_za_address_methods
     assert Faker::Address.country_code.is_a? String
     assert Faker::Address.default_country.is_a? String
-    assert Faker::Address.post_code.is_a? String
+    assert Faker::Address.postcode.is_a? String
     assert Faker::Address.province.is_a? String
     assert Faker::Address.state.is_a? String
     assert Faker::Address.city.is_a? String


### PR DESCRIPTION
All the other fake data source uses postcode (instead of `post_code`)

