### PR TITLE
restrict EIN to valid prefixes

### DIFF
--- a/lib/faker/default/company.rb
+++ b/lib/faker/default/company.rb
@@ -31,8 +31,11 @@ module Faker
         translate('faker.company.bs').collect { |list| sample(list) }.join(' ')
       end
 
+      # Valid EIN prefixes from the IRS
+      EIN_PREFIXES = %w[01 02 03 04 05 06 10 11 12 13 14 15 16 20 21 22 23 24 25 26 27 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 46 47 48 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 71 72 73 74 75 76 77 80 81 82 83 84 85 86 87 88 90 91 92 93 94 95 98 99].freeze
+
       def ein
-        format('%09d', rand(10**9)).gsub(/(\d{2})(\d{7})/, '\\1-\\2')
+        format('%s-%07d', sample(EIN_PREFIXES), rand(10**7))
       end
 
       def duns_number


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------
This PR changes `Company#ein` to produce only EINs that start with a prefix that the IRS (the issuing authority) actually uses rather than producing the digits purely at random.  The list of valid prefixes comes from the IRS's ["How EINs are Assigned and Valid EIN Prefixes"](https://www.irs.gov/businesses/small-businesses-self-employed/how-eins-are-assigned-and-valid-ein-prefixes).  The format of the returned string is unchanged, so this is a non-breaking change.

We ran into this in our application where we have stricter validation for the format of EINs (looking at their prefix), and Faker would sometimes produce EINs that ran afoul of that violation.