### PR TITLE
pt locale fix: Make city fields consistent with other

### DIFF
--- a/lib/locales/pt.yml
+++ b/lib/locales/pt.yml
@@ -2,8 +2,8 @@ pt:
   faker:
     address:
       city_name: [Abrantes,Agualva-Cacém,Águeda,Albergaria-a-Velha,Albufeira,Alcácer do Sal,Alcobaça,Alfena,Almada,Almeirim,Alverca do Ribatejo,Amadora,Amarante,Amora,Anadia,Angra do Heroísmo,Aveiro,Barcelos,Barreiro,Beja,Borba,Braga,Bragança,Caldas da Rainha,Câmara de Lobos,Caniço,Cantanhede,Cartaxo,Castelo Branco,Chaves,Coimbra,Costa da Caparica,Covilhã,Elvas,Entroncamento,Ermesinde,Esmoriz,Espinho,Esposende,Estarreja,Estremoz,Évora,Fafe,Faro,Fátima,Felgueiras,Figueira da Foz,Fiães,Freamunde,Funchal,Fundão,Gafanha da Nazaré,Gandra,Gondomar,Gouveia,Guarda,Guimarães,Horta,Ílhavo,Lagoa,Lagoa,Lagos,Lamego,Leiria,Lisboa,Lixa,Loulé,Loures,Lourosa,Macedo de Cavaleiros,Machico,Maia,Mangualde,Marco de Canaveses,Marinha Grande,Matosinhos,Mealhada,Mêda,Miranda do Douro / Miranda de l Douro,Mirandela,Montemor-o-Novo,Montijo,Moura,Odivelas,Olhão da Restauração,Oliveira de Azeméis,Oliveira do Bairro,Oliveira do Hospital,Ourém,Ovar,Paços de Ferreira,Paredes,Penafiel,Peniche,Peso da Régua,Pinhel,Pombal,Ponta Delgada,Ponte de Sor,Portalegre,Portimão,Porto,Póvoa de Santa Iria,Póvoa de Varzim,Praia da Vitória,Quarteira,Queluz,Rebordosa,Reguengos de Monsaraz,Ribeira Grande,Rio Maior,Rio Tinto,Sabugal,Sacavém,Samora Correia,Santa Comba Dão,Santa Cruz,Santa Maria da Feira,Santana,Santarém,Santiago do Cacém,Santo Tirso,São João da Madeira,São Mamede de Infesta,São Pedro do Sul,Lordelo,Seia,Seixal,Senhora da Hora,Serpa,Setúbal,Silves,Sines,Tarouca,Tavira,Tomar,Tondela,Torres Novas,Torres Vedras,Trancoso,Trofa,Valbom,Vale de Cambra,Valença,Valongo,Valpaços,Vendas Novas,Viana do Castelo,Vila Baleira,Vila do Conde,Vila Franca de Xira,Vila Nova de Famalicão,Vila Nova de Foz Côa,Vila Nova de Gaia,Vila Nova de Santo André,Vila Real,Vila Real de Santo António,Viseu,Vizela]
-      city_prefix: ""
-      city_suffix: ""
+      city_prefix: []
+      city_suffix: []
       city:
         - "#{city_name}"
       country: [ "Afeganistão", "Albânia", "Algéria", "Samoa", "Andorra", "Angola", "Anguilla", "Antigua and Barbada", "Argentina", "Armênia", "Aruba", "Austrália", 

--- a/test/test_pt_locale.rb
+++ b/test/test_pt_locale.rb
@@ -20,8 +20,6 @@ class TestPtLocale < Test::Unit::TestCase
     assert Faker::Address.street_suffix.is_a? String
     assert Faker::Address.state.is_a? String
     assert Faker::Address.city_name.is_a? String
-    assert Faker::Address.city_prefix.is_a? String
-    assert Faker::Address.city_suffix.is_a? String
     assert Faker::Address.city.is_a? String
     assert Faker::Address.country.is_a? String
     assert_equal('Portugal', Faker::Address.default_country)


### PR DESCRIPTION
Although it doesn't matter in this case, if it's empty - it should be
list of empty values instead of an empty string.
