### PR TITLE
zh-CN locale fix: Directly refer to the expected values

### DIFF
--- a/lib/locales/zh-CN.yml
+++ b/lib/locales/zh-CN.yml
@@ -21,7 +21,7 @@ zh-CN:
       name:
         - "#{last_name}#{first_name}"
       name_with_middle: # Chinese names don't have middle names
-        - "#{name}"
+        - "#{last_name}#{first_name}"
 
     phone_number:
       formats: ['###-########', '####-########', '###########']


### PR DESCRIPTION
Instead of having one extra dereference, this optimizes it to have one
reference only.

