### PR TITLE
Use ruby's `File::Separator` rather than '/' as a default for `directory_separator`

### DIFF
--- a/lib/faker/default/file.rb
+++ b/lib/faker/default/file.rb
@@ -4,7 +4,7 @@ module Faker
   class File < Base
     class << self
       # rubocop:disable Metrics/ParameterLists
-      def dir(legacy_segment_count = NOT_GIVEN, legacy_root = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, segment_count: 3, root: nil, directory_separator: File::Separator)
+      def dir(legacy_segment_count = NOT_GIVEN, legacy_root = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, segment_count: 3, root: nil, directory_separator: ::File::Separator)
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|
           keywords << :segment_count if legacy_segment_count != NOT_GIVEN
@@ -29,7 +29,7 @@ module Faker
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def file_name(legacy_dir = NOT_GIVEN, legacy_name = NOT_GIVEN, legacy_ext = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, dir: nil, name: nil, ext: nil, directory_separator: File::Separator)
+      def file_name(legacy_dir = NOT_GIVEN, legacy_name = NOT_GIVEN, legacy_ext = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, dir: nil, name: nil, ext: nil, directory_separator: ::File::Separator)
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|
           keywords << :dir if legacy_dir != NOT_GIVEN

--- a/lib/faker/default/file.rb
+++ b/lib/faker/default/file.rb
@@ -4,7 +4,7 @@ module Faker
   class File < Base
     class << self
       # rubocop:disable Metrics/ParameterLists
-      def dir(legacy_segment_count = NOT_GIVEN, legacy_root = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, segment_count: 3, root: nil, directory_separator: '/')
+      def dir(legacy_segment_count = NOT_GIVEN, legacy_root = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, segment_count: 3, root: nil, directory_separator: File::Separator)
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|
           keywords << :segment_count if legacy_segment_count != NOT_GIVEN
@@ -29,7 +29,7 @@ module Faker
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def file_name(legacy_dir = NOT_GIVEN, legacy_name = NOT_GIVEN, legacy_ext = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, dir: nil, name: nil, ext: nil, directory_separator: '/')
+      def file_name(legacy_dir = NOT_GIVEN, legacy_name = NOT_GIVEN, legacy_ext = NOT_GIVEN, legacy_directory_separator = NOT_GIVEN, dir: nil, name: nil, ext: nil, directory_separator: File::Separator)
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|
           keywords << :dir if legacy_dir != NOT_GIVEN


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------
Replace `'/'` with `File:: Separator` from [Ruby kernel](https://ruby-doc.org/core-2.7.0/File/Constants.html) as a default `directory_separator` for `File.dir` and `File.file_name` to be more OS-agnostic out of the box.
AFAIK, this constant should exist at least since [Ruby 2.1](https://ruby-doc.org/core-2.1.2/File.html).

Test:
-----
from the guide:
> Please add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, we need a test! We use Minitest in this project.

for my feeling, this is just a small refactoring, thus I did not explicitly add a test.

Running test locally:
```
# tests
1458 tests, 81210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

# rubocop
427 files inspected, no offenses detected
```
