### PR TITLE
zh-TW locale fix: Avoid double de-reference for name_with_middle

### DIFF
--- a/lib/locales/zh-TW.yml
+++ b/lib/locales/zh-TW.yml
@@ -23,7 +23,7 @@ zh-TW:
       name:
         - "#{last_name}#{first_name}"
       name_with_middle: # Chinese names don't have middle names or spaces
-        - "#{name}"
+        - "#{last_name}#{first_name}"
 
     phone_number:
       formats: ['###-########', '####-########', '###########']


### PR DESCRIPTION
The `name_with_middle` and `name` are same, so double reference isn't
needed.
