### PR TITLE
Generate NPI with valid checksum.

### DIFF
--- a/doc/default/code.md
+++ b/doc/default/code.md
@@ -1,7 +1,10 @@
 # Faker::Code
 
 ```ruby
-Faker::Code.npi #=> "0000126252"
+Faker::Code.npi #=> "1234567893"
+
+# legacy defaults to true.
+Faker::Code.npi(legacy: false) #=> "5234567894"
 
 Faker::Code.isbn #=> "759021701-8"
 

--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -6,8 +6,9 @@ module Faker
     class << self
       # Generates a 10 digit NPI (National Provider Identifier
       # issued to health care providers in the United States)
-      def npi
-        base_npi = rand(100_000_000..299_999_999).to_s
+      def npi(legacy: false)
+        max = legacy ? 299_999_999 : 999_999_999
+        base_npi = rand(100_000_000..max).to_s
 
         summed_digits = base_npi
                         .chars

--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -7,7 +7,7 @@ module Faker
       # Generates a 10 digit NPI (National Provider Identifier
       # issued to health care providers in the United States)
       def npi
-        base_npi = rand(10**9).to_s.rjust(9, '0')
+        base_npi = rand(100_000_000..299_999_999).to_s
 
         summed_digits = base_npi
                         .chars

--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -7,7 +7,19 @@ module Faker
       # Generates a 10 digit NPI (National Provider Identifier
       # issued to health care providers in the United States)
       def npi
-        rand(10**10).to_s.rjust(10, '0')
+        base_npi = rand(10**9).to_s.rjust(9, '0')
+
+        summed_digits = base_npi
+                        .chars
+                        .each_with_index
+                        .map { |n, i| (i.even? ? n.to_i * 2 : n).to_s }
+                        .join
+                        .chars
+                        .inject(0) { |sum, digit| sum + digit.to_i }
+
+        npi_checksum = (10 - (24 + summed_digits) % 10).to_s.chars.last
+
+        base_npi + npi_checksum
       end
 
       # By default generates 10 sign isbn code in format 123456789-X

--- a/test/faker/default/test_faker_code.rb
+++ b/test/faker/default/test_faker_code.rb
@@ -7,8 +7,14 @@ class TestFakerCode < Test::Unit::TestCase
     @tester = Faker::Code
   end
 
-  def test_npi_regexp
-    assert @tester.npi.match(/(1|2)[0-9]{9}/)
+  def test_npi_legacy_regexp
+    assert @tester.npi(legacy: true).match(/(1|2)[0-9]{9}/)
+  end
+
+  def test_npi
+    Faker::Config.random.stub(:rand, 523_456_789) do
+      assert @tester.npi == '5234567894'
+    end
   end
 
   def test_deterministic_npi

--- a/test/faker/default/test_faker_code.rb
+++ b/test/faker/default/test_faker_code.rb
@@ -8,7 +8,7 @@ class TestFakerCode < Test::Unit::TestCase
   end
 
   def test_npi_regexp
-    assert @tester.npi.match(/[0-9]{10}/)
+    assert @tester.npi.match(/(1|2)[0-9]{9}/)
   end
 
   def test_deterministic_npi

--- a/test/faker/default/test_faker_code.rb
+++ b/test/faker/default/test_faker_code.rb
@@ -19,6 +19,12 @@ class TestFakerCode < Test::Unit::TestCase
     assert v == @tester.npi
   end
 
+  def test_valid_npi
+    Faker::Config.random.stub(:rand, 123_456_789) do
+      assert @tester.npi == '1234567893'
+    end
+  end
+
   def test_default_isbn_regexp
     assert @tester.isbn.match(/^\d{9}-[\d|X]$/)
   end


### PR DESCRIPTION
No-Story
------

Description:
------
National Provider Identifiers need to confirm to a particular format
involving the calculation of a luhn checksum. This commit modifies
the npi generator to produce npi's which comply with the required
format.

https://www.cms.gov/Regulations-and-Guidance/Administrative-Simplification/NationalProvIdentStand/Downloads/NPIcheckdigit.pdf

