### PR TITLE
Add Faker::Movies::Departed Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
 ### Movies
   - [Faker::Movie](doc/movies/movie.md)
   - [Faker::Movies::BackToTheFuture](doc/movies/back_to_the_future.md)
+  - [Faker::Movies::Departed](doc/movies/departed.md)
   - [Faker::Movies::Ghostbusters](doc/movies/ghostbusters.md)
   - [Faker::Movies::HarryPotter](doc/movies/harry_potter.md)
   - [Faker::Movies::HitchhikersGuideToTheGalaxy](doc/movies/hitchhikers_guide_to_the_galaxy.md)

--- a/doc/movies/departed.md
+++ b/doc/movies/departed.md
@@ -1,0 +1,11 @@
+# Faker::Movies::Departed
+
+Available since version next.
+
+```ruby
+Faker::Movies::Departed.actor #=> "Matt Damon"
+
+Faker::Movies::Departed.character #=> "Frank Costello"
+
+Faker::Movies::Departed.quote #=> "I'm the guy who does his job. You must be the other guy"
+```

--- a/lib/faker/movies/departed.rb
+++ b/lib/faker/movies/departed.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Faker
+  class Movies
+    class Departed < Base
+      class << self
+        ##
+        # Produces an actor from The Departed.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Movies::Departed.actor #=> "Matt Damon"
+        #
+        # @faker.version next
+        def actor
+          fetch('departed.actors')
+        end
+
+        ##
+        # Produces a character from The Departed.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Movies::Departed.character #=> "Frank Costello"
+        #
+        # @faker.version next
+        def character
+          fetch('departed.characters')
+        end
+
+        ##
+        # Produces a quote from The Departed.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Movies::Departed.quote
+        #     #=> "I'm the guy who does his job. You must be the other guy"
+        #
+        # @faker.version next
+        def quote
+          fetch('departed.quotes')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/departed.yml
+++ b/lib/locales/en/departed.yml
@@ -1,0 +1,49 @@
+en:
+  faker:
+    departed:
+      actors:
+      - Leonardo DiCaprio
+      - Matt Damon
+      - Jack Nicholson
+      - Mark Wahlberg
+      - Martin Sheen
+      - Ray Winstone
+      - Vera Farmiga
+      - Anthony Anderson
+      - Alec Baldwin
+      - Kevin Corrigan
+      - James Badge Dale
+      - David O'Hara
+      - Mark Rolston
+      characters:
+      - Billy Costigan
+      - Colin Sullivan
+      - Frank Costello
+      - Sean Dignam
+      - Oliver Queenan
+      - Arnold French
+      - Madolyn Madden
+      - Tony Brown
+      - George Ellerby
+      - Sean Costigan
+      - James Barrigan
+      - Patrick Fitzgibbons
+      - Timothy Delahunt
+      quotes:
+      - I'm the guy who does his job. You must be the other guy.
+      - You have an immaculate record. Some guys don't trust an immaculate record.
+        I do. I have an immaculate record.
+      - You got a nice suit at home or do you like coming to work everyday dressed
+        like you're going to invade Poland?
+      - All due respect Mr. Costello school is out.
+      - Normally he's a very uh nice guy. Don't judge him from this meeting alone.
+      - Maybe. Maybe not. Maybe fuck yourself.
+      - My theory on Feds is that they're like mushrooms feed 'em shit and keep 'em
+        in the dark
+      - Don't laugh! This ain't reality TV!
+      - Let's say you have no idea and leave it at that okay? No idea. Zip. None.
+      - Families are always rising or falling in America am I right?
+      - What Freud said about the Irish is we're the only people who are impervious
+        to psychoanalysis.
+      - One of you mugs got a light?
+      - Do you want to be a cop or do you want to appear to be a cop?

--- a/lib/locales/en/departed.yml
+++ b/lib/locales/en/departed.yml
@@ -47,3 +47,4 @@ en:
         to psychoanalysis.
       - One of you mugs got a light?
       - Do you want to be a cop or do you want to appear to be a cop?
+      - Yeah, it's working... Overtime!

--- a/test/faker/movies/test_faker_departed.rb
+++ b/test/faker/movies/test_faker_departed.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerDeparted < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Movies::Departed
+  end
+
+  def test_actor
+    assert @tester.actor.match(/\w+/)
+  end
+
+  def test_character
+    assert @tester.character.match(/\w+/)
+  end
+
+  def test_quote
+    assert @tester.quote.match(/\w+/)
+  end
+end


### PR DESCRIPTION
Summary
-----

Adds the ability to select actors, characters, or quotes from the movie, [`The Departed`](https://www.imdb.com/title/tt0407887/).

The quotes were copied from [`IMDB`](https://www.imdb.com/title/tt0407887/quotes/?tab=qt&ref_=tt_trv_qu).

The actors and characters were copied from [`IMDB`](https://www.imdb.com/title/tt0407887/fullcredits?ref_=tt_cl_sm#cast).

When character names were incomplete on the `IMDB` website, they were corroborated against using [`The Departed Wiki`](https://the-departed.fandom.com/wiki/Category:Characters).

Issue# 
------

`No-Story`

Description
------

I envision using the class's character and actor names to populate the names of various test factories as well as using the quotes to populate text fields.

