### PR TITLE
Update documentation for unique.exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ manually set values).
 # Faker::<generator>.unique.exclude(method, arguments, list)
 
 # Add 'azerty' and 'wxcvbn' to the string generator with 6 char length
-Faker::Lorem.unique.exclude :string, [6], %w[azerty wxcvbn]
+Faker::Lorem.unique.exclude :string, [number: 6], %w[azerty wxcvbn]
 ```
 
 ### Deterministic Random

--- a/test/faker/default/test_faker_lorem.rb
+++ b/test/faker/default/test_faker_lorem.rb
@@ -123,4 +123,10 @@ class TestFakerLorem < Test::Unit::TestCase
     @tester.unique.exclude(:character, [], values)
     assert_raise(Faker::UniqueGenerator::RetryLimitExceeded) { @tester.unique.character }
   end
+
+  def test_unique_with_already_set_values_and_parameter
+    values = ('a'..'z').to_a + ('0'..'9').to_a
+    @tester.unique.exclude(:characters, [number: 1], values)
+    assert_raise(Faker::UniqueGenerator::RetryLimitExceeded) { @tester.unique.characters(number: 1) }
+  end
 end


### PR DESCRIPTION
Issue# 
------
`No-Story`

Description:
------
Documentation for `unique.exclude` was missing an update for the option
parameters format (e.g.: `number: 3`). This updates README and adds a
test for exclusions with arguments.