### PR TITLE
Add Faker::JapaneseMedia::SailorMoon with character, transformation, attack, item, and location

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
 ### Japanese Media
   - [Faker::JapaneseMedia::DragonBall](doc/japanese_media/dragon_ball.md)
   - [Faker::JapaneseMedia::OnePiece](doc/japanese_media/one_piece.md)
+  - [Faker::JapaneseMedia::SailorMoon](doc/japanese_media/sailor_moon.md)
   - [Faker::JapaneseMedia::SwordArtOnline](doc/japanese_media/sword_art_online.md)
 
 ### Movies

--- a/doc/japanese_media/sailor_moon.md
+++ b/doc/japanese_media/sailor_moon.md
@@ -1,16 +1,7 @@
 # Faker::JapaneseMedia::SailorMoon
 
 ```ruby
-Faker::JapaneseMedia::SailorMoon.senshi # => "Sailor Chibimoon"
-
-
-Faker::JapaneseMedia::SailorMoon.secret_identity # => "Hotaru Tomoe"
-
-
-Faker::JapaneseMedia::SailorMoon.villain # => "Queen Nehellenia"
-
-
-Faker::JapaneseMedia::SailorMoon.character # => "Helios"
+Faker::JapaneseMedia::SailorMoon.character # => "Sailor Chibimoon"
 
 
 Faker::JapaneseMedia::SailorMoon.transformation # => "Neptune Planet Power, Make Up!"

--- a/doc/japanese_media/sailor_moon.md
+++ b/doc/japanese_media/sailor_moon.md
@@ -1,0 +1,26 @@
+# Faker::JapaneseMedia::SailorMoon
+
+```ruby
+Faker::JapaneseMedia::SailorMoon.senshi # => "Sailor Chibimoon"
+
+
+Faker::JapaneseMedia::SailorMoon.secret_identity # => "Hotaru Tomoe"
+
+
+Faker::JapaneseMedia::SailorMoon.villain # => "Queen Nehellenia"
+
+
+Faker::JapaneseMedia::SailorMoon.character # => "Helios"
+
+
+Faker::JapaneseMedia::SailorMoon.transformation # => "Neptune Planet Power, Make Up!"
+
+
+Faker::JapaneseMedia::SailorMoon.attack # => "Venus Love and Beauty Shock"
+
+
+Faker::JapaneseMedia::SailorMoon.item # => "Kaleido Moon Scope"
+
+
+Faker::JapaneseMedia::SailorMoon.location # => "Azabu Hikawa Shrine"
+```

--- a/lib/faker/japanese_media/sailor_moon.rb
+++ b/lib/faker/japanese_media/sailor_moon.rb
@@ -55,6 +55,19 @@ module Faker
         def item
           fetch('sailor_moon.item')
         end
+
+        ##
+        # Produces the name of a location from Sailor Moon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::SailorMoon.location #=> "Game Center Crown"
+        #
+        # @faker.version 1.8.0
+        def location
+          fetch('sailor_moon.location')
+        end
       end
     end
   end

--- a/lib/faker/japanese_media/sailor_moon.rb
+++ b/lib/faker/japanese_media/sailor_moon.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Faker
+  class JapaneseMedia
+    class SailorMoon < Base
+      class << self
+        ##
+        # Produces the name of a character from Sailor Moon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::SailorMoon.character #=> "Mistress 9"
+        #
+        # @faker.version 1.8.0
+        def character
+          fetch('sailor_moon.character')
+        end
+
+        ##
+        # Produces a transformation phrase from Sailor Moon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::SailorMoon.transformation #=> "Fighter Star Power, Make Up!"
+        #
+        # @faker.version 1.8.0
+        def transformation
+          fetch('sailor_moon.transformation')
+        end
+
+        ##
+        # Produces an attack phrase from Sailor Moon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::SailorMoon.attack #=> "Jupiter Oak Evolution"
+        #
+        # @faker.version 1.8.0
+        def attack
+          fetch('sailor_moon.attack')
+        end
+
+        ##
+        # Produces the name of an item from Sailor Moon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::SailorMoon.item #=> "Crisis Moon Compact"
+        #
+        # @faker.version 1.8.0
+        def item
+          fetch('sailor_moon.item')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/sailor_moon.yml
+++ b/lib/locales/en/sailor_moon.yml
@@ -1,0 +1,197 @@
+en:
+  faker:
+    sailor_moon:
+      character:
+        - Sailor Moon
+        - Sailor Mercury
+        - Sailor Mars
+        - Sailor Venus
+        - Sailor Jupiter
+        - Sailor Chibimoon
+        - Sailor Uranus
+        - Sailor Neptune
+        - Sailor Pluto
+        - Sailor Saturn
+        - Sailor Chibi Chibi Moon
+        - Sailor Iron Mouse
+        - Sailor Lead Crow
+        - Sailor Aluminum Siren
+        - Sailor Tin Nyanko
+        - Sailor Heavy Metal Papillon
+        - Sailor Galaxia
+        - Sailor Cosmos
+        - Sailor Star Fighter
+        - Sailor Star Healer
+        - Sailor Star Maker
+        - Tuxedo Kamen
+        - Prince Endymion
+        - King Endymion
+        - Queen Serenity
+        - Princess Serenity
+        - Neo Queen Serenity
+        - Princess Small Lady
+        - Helios
+        - Pegasus
+        - Luna
+        - Artemis
+        - Diana
+        - Ikuko Tsukino
+        - Kenji Tsukino
+        - Shingo Tsukino
+        - Naru Osaka
+        - Gurio Umino
+        - Usagi Tsukino
+        - Ami Mizuno
+        - Rei Hino
+        - Minako Aino
+        - Makoto Kino
+        - Chibi-Usa Tsukino
+        - Haruka Tenou
+        - Michiru Kaiou
+        - Setsuna Meiou
+        - Hotaru Tomoe
+        - Mamoru Chiba
+        - Seiya Kou
+        - Yaten Kou
+        - Taiki Kou
+        - Queen Beryl
+        - Queen Metalia
+        - Zoisite
+        - Jadeite
+        - Nephrite
+        - Kunzite
+        - Wiseman
+        - Prince Demande
+        - Saphir
+        - Emeraude
+        - Rubeus
+        - Koan
+        - Berthier
+        - Calaveras
+        - Petz
+        - Black Lady
+        - Mistress 9
+        - Pharaoh 90
+        - Kaolinite
+        - Eudial
+        - Mimete
+        - Tellu
+        - Viluy
+        - Cyprine
+        - Ptilol
+        - Queen Nehellenia
+        - Zirconia
+        - CereCere
+        - VesVes
+        - JunJun
+        - PallaPalla
+        - Tiger's Eye
+        - Hawk's Eye
+        - Fisheye
+      transformation:
+        - Moon Prism Power, Make Up!
+        - Moon Crystal Power, Make Up!
+        - Moon Cosmic Power, Make Up!
+        - Moon Crisis, Make Up!
+        - Moon Eternal, Make Up!
+        - Mercury Star Power, Make Up!
+        - Mercury Crystal Power, Make Up!
+        - Mercury Planet Power, Make Up!
+        - Mars Star Power, Make Up!
+        - Mars Crystal Power, Make Up!
+        - Mars Planet Power, Make Up!
+        - Venus Star Power, Make Up!
+        - Venus Crystal Power, Make Up!
+        - Venus Planet Power, Make Up!
+        - Jupiter Star Power, Make Up!
+        - Jupiter Crystal Power, Make Up!
+        - Jupiter Planet Power, Make Up!
+        - Uranus Planet Power, Make Up!
+        - Neptune Planet Power, Make Up!
+        - Pluto Planet Power, Make Up!
+        - Saturn Planet Power, Make Up!
+        - Fighter Star Power, Make Up!
+        - Healer Star Power, Make Up!
+        - Maker Star Power, Make Up!
+      attack:
+        - Moon Tiara Action
+        - Moon Healing Escalation
+        - Moon Princess Halation
+        - Moon Spiral Heart Attack
+        - Rainbow Moon Heartache
+        - Moon Gorgeous Meditation
+        - Starlight Honeymoon Therapy Kiss
+        - Pink Sugar Heart Attack
+        - Twinkle Yell
+        - Mercury Bubble Blast
+        - Mercury Aqua Illusion
+        - Mercury Aqua Rhapsody
+        - Mercury Aqua Mirage
+        - Mars Fire Soul
+        - Mars Burning Mandala
+        - Mars Flame Sniper
+        - Venus Love-Me Chain
+        - Venus Crescent Beam
+        - Venus Love and Beauty Shock
+        - Jupiter Supreme Thunder
+        - Jupiter Sparkling Wide Pressure
+        - Jupiter Oak Evolution
+        - World Shaking
+        - Space Sword Blaster
+        - Deep Submerge
+        - Submarine Reflection
+        - Dead Scream
+        - Silence Wall
+        - Silence Glaive Surprise
+        - Star Serious Laser
+        - Star Sensitive Inferno
+        - Star Gentle Uterus
+      item:
+        - Crystal Star Compact
+        - Cosmic Heart Compact
+        - Crisis Moon Compact
+        - Prism Heart Compact
+        - Star Power Stick
+        - Crystal Change Rod
+        - Lip Rod
+        - Eternal Moon Article
+        - Cutie Moon Rod
+        - Spiral Heart Moon Rod
+        - Kaleido Moon Scope
+        - Eternal Tiare
+        - Holy Chalice
+        - Pink Moon Stick
+        - Crystal Carillon
+        - Stallion Reve
+        - Mercury Harp
+        - Mars Arrow
+        - Venus Chain Belt
+        - Jupiter Lightning Antenna
+        - Deep Aqua Mirror
+        - Space Sword
+        - Garnet Rod
+        - Garnet Orb
+        - Silence Glaive
+        - Silver Crystal
+        - Golden Crystal
+        - Heart Crystal
+        - Dream Mirror
+        - Star Seed
+        - Disguise Pen
+        - Luna-P
+      location:
+        - Moon Kingdom
+        - Crystal Tokyo
+        - Elysion
+        - Azabu Juuban
+        - Azabu Hikawa Shrine
+        - Mugen Academy
+        - Game Center Crown
+        - Fruits Parlor Crown
+        - Karaoke Crown
+        - Osa-P Jewellers
+        - Star Light Tower
+        - Dead Moon Circus
+        - Ginga TV
+        - Star Garden
+        - Galaxy Cauldron

--- a/test/faker/japanese_media/test_faker_sailor_moon.rb
+++ b/test/faker/japanese_media/test_faker_sailor_moon.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerSailorMoon < Test::Unit::TestCase
+  def setup
+    @tester = Faker::JapaneseMedia::SailorMoon
+  end
+
+  def test_character
+    assert @tester.character.match(/\w+/)
+  end
+
+  def test_transformation
+    assert @tester.transformation.match(/\w+/)
+  end
+
+  def test_attack
+    assert @tester.attack.match(/\w+/)
+  end
+
+  def test_item
+    assert @tester.item.match(/\w+/)
+  end
+end

--- a/test/faker/japanese_media/test_faker_sailor_moon.rb
+++ b/test/faker/japanese_media/test_faker_sailor_moon.rb
@@ -22,4 +22,8 @@ class TestFakerSailorMoon < Test::Unit::TestCase
   def test_item
     assert @tester.item.match(/\w+/)
   end
+
+  def test_location
+    assert @tester.location.match(/\w+/)
+  end
 end


### PR DESCRIPTION
This PR adds a new generator for the Sailor Moon series. I added this faker because there was no representation for the mahou shoujo genre, but I know a lot of women in tech who would love to use this faker -- myself included!