### PR TITLE
Add Faker::PhoneNumber.cell_phone_in_e164

### DIFF
--- a/doc/default/phone_number.md
+++ b/doc/default/phone_number.md
@@ -24,6 +24,13 @@ This formatter will return one of the following formats:
   * 1-333-333-3333
   * 333.333.3333
 
+### `.cell_phone_in_e164`
+
+This formatter will return one of the following formats:
+
+  * +33333333333333
+  * +3333333333333
+
 ## Usage
 
 Don't let the example output below fool you -- any format can be returned at random.
@@ -32,6 +39,8 @@ Don't let the example output below fool you -- any format can be returned at ran
 Faker::PhoneNumber.phone_number #=> "397.693.1309 x4321"
 
 Faker::PhoneNumber.cell_phone #=> "(186)285-7925"
+
+Faker::PhoneNumber.cell_phone_in_e164 #=> "+944937040625"
 
 # NOTE NOTE NOTE NOTE
 # For the 'US only' methods below, first you must do the following:

--- a/lib/faker/default/phone_number.rb
+++ b/lib/faker/default/phone_number.rb
@@ -23,6 +23,10 @@ module Faker
         "#{country_code} #{cell_phone}"
       end
 
+      def cell_phone_in_e164
+        cell_phone_with_country_code.delete('^+0-9')
+      end
+
       # US and Canada only
       def area_code
         fetch('phone_number.area_code')

--- a/test/faker/default/test_faker_phone_number.rb
+++ b/test/faker/default/test_faker_phone_number.rb
@@ -19,4 +19,8 @@ class TestFakerPhone < Test::Unit::TestCase
   def test_cell_phone_with_country_code
     assert @tester.cell_phone_with_country_code.match(@phone_with_country_code_regex)
   end
+
+  def test_cell_phone_in_e164
+    assert @tester.cell_phone_in_e164.match(@phone_with_country_code_regex)
+  end
 end


### PR DESCRIPTION
Resolves #1897

Description:

## Old behaviour
```shell
Faker::PhoneNumber.cell_phone_in_e164
=> NoMethodError: undefined method `cell_phone_in_e164' for Faker::PhoneNumber:Class
Did you mean?  cell_phone
```

## New behaviour
```shell
Faker::PhoneNumber.cell_phone_in_e164
=> "+944937040625"
```
