### PR TITLE
Add new full_address_as_hash method which return the required address…

### DIFF
--- a/lib/faker/default/address.rb
+++ b/lib/faker/default/address.rb
@@ -333,6 +333,27 @@ module Faker
       def full_address
         parse('address.full_address')
       end
+
+      ##
+      # Produces Address hash of required fields
+      #
+      # @return [Hash]
+      #
+      # @example
+      #   Faker::Address.full_address_as_hash(:longitude,
+      #                                       :latitude,
+      #                                       :country_name_to_code,
+      #                                       country_name_to_code: {name: 'united_states'})
+      #     #=> {:longitude=>-101.74428917174603, :latitude=>-37.40056749089944, :country_name_to_code=>"US"}
+      #
+      # @faker.version 2.11.0
+      def full_address_as_hash(*attrs, **attrs_params)
+        attrs.map!(&:to_sym)
+        attrs_params.transform_keys!(&:to_sym)
+        attrs.map do |attr|
+          { "#{attr}": attrs_params[attr] ? send(attr, **attrs_params[attr]) : send(attr) }
+        end.reduce({}, :merge)
+      end
     end
   end
 end

--- a/test/faker/default/test_faker_address.rb
+++ b/test/faker/default/test_faker_address.rb
@@ -86,4 +86,12 @@ class TestFakerAddress < Test::Unit::TestCase
   def test_full_address
     assert @tester.full_address.match(/\w*\.?\s?\d*\s?\d+\s\w+\s\w+,\s\w+\s?\w*,\s[A-Z]{2}\s\d+/)
   end
+
+  def test_full_address_as_hash
+    assert_instance_of Hash, @tester.full_address_as_hash
+  end
+
+  def test_full_address_as_hash_by_longitude
+    assert_instance_of Float, @tester.full_address_as_hash(:longitude)[:longitude]
+  end
 end


### PR DESCRIPTION
… information as a hash

Issue# 1958
resolves #1958 

Description:
------
*Now with this PR merged, We can get the address information separated as a hash object, All you have to do is to give it the keys as symbols and if one of them accepts parameters you can specify them as `keyname: value_hash`*
