### PR TITLE
decimal within range method added

### DIFF
--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'pry'
 
 module Faker
   class Number < Base
@@ -84,6 +83,7 @@ module Faker
           keywords << :l_digits if legacy_l_digits != NOT_GIVEN
           keywords << :r_digits if legacy_r_digits != NOT_GIVEN
         end
+
         l_d = number(digits: l_digits)
         r_d = if r_digits == 1
                 generate(r_digits)
@@ -94,6 +94,19 @@ module Faker
               end
         "#{l_d}.#{r_d}".to_f
       end
+
+      ##
+      # Produces a number between two provided values. Boundaries are inclusive.
+      #
+      # @param l_digits [Integer] Number of digits that the generated decimal should have to the left of the decimal point.
+      # @param r_digits [Integer] Number of digits that the generated decimal should have to the right of the decimal point.
+      # @param range [Range] The range from which to generate a number.
+      # @return [Float]
+      #
+      # @example
+      #   Faker::Number.decimal_within(l_digits: 1, r_digits: 1, range: 1..10) #=> 4.0
+      #
+      # @faker.version 1.0.0
 
       def decimal_within(
         legacy_l_digits = NOT_GIVEN,

--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -107,7 +107,6 @@ module Faker
       #   Faker::Number.decimal_within(l_digits: 1, r_digits: 1, range: 1..10) #=> 4.0
       #
       # @faker.version 1.0.0
-
       def decimal_within(
         legacy_l_digits = NOT_GIVEN,
         legacy_r_digits = NOT_GIVEN,

--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pry'
 
 module Faker
   class Number < Base
@@ -83,7 +84,6 @@ module Faker
           keywords << :l_digits if legacy_l_digits != NOT_GIVEN
           keywords << :r_digits if legacy_r_digits != NOT_GIVEN
         end
-
         l_d = number(digits: l_digits)
         r_d = if r_digits == 1
                 generate(r_digits)
@@ -92,6 +92,24 @@ module Faker
                 # so it does not get truncated on converting to float
                 generate(r_digits - 1).join + non_zero_digit.to_s
               end
+        "#{l_d}.#{r_d}".to_f
+      end
+
+      def decimal_within(
+        legacy_l_digits = NOT_GIVEN,
+        legacy_r_digits = NOT_GIVEN,
+        legacy_range = NOT_GIVEN,
+        l_digits: 5, r_digits: 2, range: 1.00..5000.00
+      )
+        warn_for_deprecated_arguments do |keywords|
+          keywords << :l_digits if legacy_l_digits != NOT_GIVEN
+          keywords << :r_digits if legacy_r_digits != NOT_GIVEN
+          keywords << :range if legacy_range != NOT_GIVEN
+        end
+
+        return if l_digits < 1 || r_digits < 1
+        r_d = rand(range.min..range.max).round
+        l_d = rand(range.min..range.max).round
         "#{l_d}.#{r_d}".to_f
       end
 

--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -106,7 +106,7 @@ module Faker
       # @example
       #   Faker::Number.decimal_within(l_digits: 1, r_digits: 1, range: 1..10) #=> 4.0
       #
-      # @faker.version 1.0.0
+      # @faker.version next
       def decimal_within(
         legacy_l_digits = NOT_GIVEN,
         legacy_r_digits = NOT_GIVEN,

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -47,6 +47,8 @@ class TestFakerNumber < Test::Unit::TestCase
     assert @tester.decimal_within(l_digits: 1, r_digits: 1, range: 0..1).to_s.match(/[0-1]{1}\.[0-1]{1}/)
     assert @tester.decimal_within(l_digits: 1).to_s.match(/[0-9]{1}\.[0-9]{2}/)
     assert @tester.decimal(l_digits: 4, r_digits: 5).to_s.match(/[0-9]{4}\.[0-9]{5}/)
+    assert @tester.decimal_within(l_digits: 3, r_digits: 3, range: 1..100).to_s.match(/[0-9]*\.[0-9]*/)
+    assert @tester.decimal_within(l_digits: 3, r_digits: 3, range: 1..1000).to_s.match(/[0-9]*\.[0-9]*/)
   end
 
   def test_digit

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -43,6 +43,12 @@ class TestFakerNumber < Test::Unit::TestCase
     assert @tester.decimal(l_digits: 4, r_digits: 5).to_s.match(/[0-9]{4}\.[0-9]{5}/)
   end
 
+  def test_decimal_within
+    assert @tester.decimal_within(l_digits: 1, r_digits: 1, range: 0..1).to_s.match(/[0-1]{1}\.[0-1]{1}/)
+    assert @tester.decimal_within(l_digits: 1).to_s.match(/[0-9]{1}\.[0-9]{2}/)
+    assert @tester.decimal(l_digits: 4, r_digits: 5).to_s.match(/[0-9]{4}\.[0-9]{5}/)
+  end
+
   def test_digit
     assert @tester.digit.to_s.match(/[0-9]{1}/)
     assert((1..1000).collect { |_i| @tester.digit == 9 }.include?(true))


### PR DESCRIPTION
Issue #1939

Description:
```rb
Faker::Number.decimal_within(l_digits: 2, r_digits: 2, range: 0..100)
```
```shell
#=> 29.32
```

in cases like this
```rb
Faker::Number.decimal_within(l_digits: 5, r_digits: 2, range: 0..100)
```
the range has priority, the number will remain between the range.