### PR TITLE
Fixing the CI failure by fixing the infinite loop in Commerce

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -225,8 +225,16 @@ module Faker
         @unique ||= UniqueGenerator.new(self, max_retries)
       end
 
-      def sample(list)
-        list.respond_to?(:sample) ? list.sample(random: Faker::Config.random) : list
+      def sample(list, num = nil)
+        if list.respond_to?(:sample)
+          if num
+            list.sample(num, random: Faker::Config.random)
+          else
+            list.sample(random: Faker::Config.random)
+          end
+        else
+          list
+        end
       end
 
       def shuffle(list)

--- a/lib/faker/default/commerce.rb
+++ b/lib/faker/default/commerce.rb
@@ -30,9 +30,15 @@ module Faker
 
         categories = categories(num)
 
-        return merge_categories(categories) if num > 1
-
-        categories[0]
+        if categories.is_a?(Array)
+          if categories.length > 1
+            merge_categories(categories)
+          else
+            categories[0]
+          end
+        else
+          categories
+        end
       end
 
       def product_name
@@ -60,13 +66,7 @@ module Faker
       private
 
       def categories(num)
-        categories = []
-        while categories.length < num
-          category = fetch('commerce.department')
-          categories << category unless categories.include?(category)
-        end
-
-        categories
+        sample(fetch_all('commerce.department'), num)
       end
 
       def merge_categories(categories)


### PR DESCRIPTION
It seems that current faker master is broken https://travis-ci.org/github/faker-ruby/faker/builds since 70349612f4ee3de595f36f71015ad95f39583b71.
What's happening here is that the ko locale data provides only one `commerce.department` entry where some tests e.g. https://github.com/faker-ruby/faker/blob/d9b9ad96c45397435cf211f6380435e6aecd4141/test/faker/default/test_faker_commerce.rb#L31 expects more than two `commerce.department` entries to exist, and because [this loop](https://github.com/faker-ruby/faker/blob/d9b9ad96c45397435cf211f6380435e6aecd4141/lib/faker/default/commerce.rb#L64-L67) never ends until it successfully fetches the given number of categories, it results in an infinite loop.

This is rather a code bug than a data inadequacy. No code should cause such an infinite loop regardless of given data.

This patch firstly extends the existing `sample` method to take an argument in the same manner as Ruby's `Array#sample`.
Then now we can simplify the code by using this new `sample` with number instead of fetching multiple times inside the loop.