### PR TITLE
Fix an error for `Faker::Computer.os`

### DIFF
--- a/lib/faker/default/computer.rb
+++ b/lib/faker/default/computer.rb
@@ -32,17 +32,16 @@ module Faker
       ##
       # Produces the name of a computer os.
       #
-      # @param platform [String] optionally specify the platform
+      # @param platform [String] optionally specify the platform `linux`, `macos`, or `windows`.
       # @return [String]
       #
       # @example
       #   Faker::Computer.os #=> "RHEL 6.10"
       #
       # @faker.version next
-      def os(platform:)
+      def os(platform: self.platform)
         platform = self.platform unless fetch_all('computer.platform').include?(platform)
-        platform = search_format(platform)
-        fetch("computer.#{platform}.os")
+        fetch("computer.os.#{platform.downcase}")
       end
 
       ##


### PR DESCRIPTION
Follow up to #1948.

This PR fixes the following error for `Faker::Computer.os`.

```console
% cd path/to/faker-ruby/faker
% bundle exec ruby -Itest test/test_determinism.rb
Loaded suite test/test_determinism
(snip)

test/test_determinism.rb:13:in `test_determinism'
test/test_determinism.rb:13:in `each_index'
     11:   def test_determinism
     12:     Faker::Config.random = Random.new(42)
     13:     @all_methods.each_index do |index|
  => 14:       store_result @all_methods[index]
     15:     end
     16:
     17:     @first_run.freeze
test/test_determinism.rb:14:in `block in test_determinism'
test/test_determinism.rb:34:in `store_result'
test/test_determinism.rb:37:in `rescue in store_result'
Error: test_determinism(TestDeterminism): RuntimeError:
Faker::Computer.os raised "missing keyword: :platform"
```

