### PR TITLE
Removing meaningless begin and end

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -2,10 +2,7 @@
 
 mydir = __dir__
 
-begin
-  require 'psych'
-end
-
+require 'psych'
 require 'i18n'
 require 'set' # Fixes a bug in i18n 0.6.11
 


### PR DESCRIPTION
This begin ... end without rescue or ensure means nothing.  We can just safely remove these `begin` and `end`.

It's been like this since 448cc4f365bf90e984ca5c340b4d7b978054f308 removes `rescue LoadError`.