### PR TITLE
Add else condition to prevent false positive

### DIFF
--- a/lib/helpers/char.rb
+++ b/lib/helpers/char.rb
@@ -15,6 +15,7 @@ module Faker
         when 'ö' then 'oe'
         when 'ü' then 'ue'
         when 'ß' then 'ss'
+        else match.downcase
         end
       end
     end

--- a/test/faker/default/test_faker_char.rb
+++ b/test/faker/default/test_faker_char.rb
@@ -12,5 +12,7 @@ class TestFakerChar < Test::Unit::TestCase
     assert @tester.fix_umlauts('ö') == 'oe'
     assert @tester.fix_umlauts('ü') == 'ue'
     assert @tester.fix_umlauts('ß') == 'ss'
+    # tests false positive
+    assert @tester.fix_umlauts('ss') == 'ss'
   end
 end


### PR DESCRIPTION
https://github.com/faker-ruby/faker/issues/2005

Description:
------
As described in Issue #2005, the `Faker::Char.fix_umlauts` method has a false positive when the string includes 'ss'. This PR adds an else clause so that the original match (downcased, like the other return values) is returned instead. This PR also adds an additional assertion to the test file to confirm that this false positive is accounted for.

While working on this PR, I observed that this method may be limited in some ways surrounding casing. For example, you might want to replace `Ä` with `Ae` or `AE`, but I thought that would very much complicate the method require several additional test cases and so I left it out for maybe another issue to be added.