### PR TITLE
Fix yard documentation issues

### DIFF
--- a/lib/faker/default/address.rb
+++ b/lib/faker/default/address.rb
@@ -102,7 +102,7 @@ module Faker
       # @return [String]
       #
       # @example
-      # Faker::Address.mail_box #=> "PO Box 123"
+      #   Faker::Address.mail_box #=> "PO Box 123"
       #
       # @faker.version 2.9.1
       def mail_box

--- a/lib/faker/default/driving_licence.rb
+++ b/lib/faker/default/driving_licence.rb
@@ -57,10 +57,12 @@ module Faker
       ##
       # Produces a random UK driving licence number in either GB or NI format, at a rate consistent with their relative populations
       #
-      # @param last_name [String] The last name of the driving licence's owner.
-      # @param initials [String] The initials of the driving licence's owner.
-      # @param gender [String] The gender of the driving licence's owner.
-      # @param date_of_birth [String] The date of birth of the driving licence's owner.
+      # @overload uk_driving_licence(last_name, initials, gender, date_of_birth)
+      #   @param last_name [String] The last name of the driving licence's owner.
+      #   @param initials [String] The initials of the driving licence's owner.
+      #   @param gender [String] The gender of the driving licence's owner.
+      #   @param date_of_birth [String] The date of birth of the driving licence's owner.
+      # @overload uk_driving_licence()
       # @return [String]
       #
       # @example

--- a/lib/faker/default/file.rb
+++ b/lib/faker/default/file.rb
@@ -66,7 +66,7 @@ module Faker
       #
       # @param dir [String] Specifies the path used for the generated file.
       # @param name [String] Specifies the filename used for the generated file.
-      # @param extension [String] Specifies the extension used the generated file.
+      # @param ext [String] Specifies the extension used the generated file.
       # @param directory_separator [String] Specifies the separator between the directory and name elements.
       # @return [String]
       #

--- a/lib/faker/default/finance.rb
+++ b/lib/faker/default/finance.rb
@@ -10,7 +10,7 @@ module Faker
       ##
       # Produces a random credit card number.
       #
-      # @param card_type [String] Specific credit card type.
+      # @param types [String] Specific credit card type.
       # @return [String]
       #
       # @example

--- a/lib/faker/default/name.rb
+++ b/lib/faker/default/name.rb
@@ -121,7 +121,7 @@ module Faker
       ##
       # Produces random initials.
       #
-      # @param digits [Integer] Number of digits that the generated initials should have.
+      # @param number [Integer] Number of digits that the generated initials should have.
       # @return [String]
       #
       # @example

--- a/lib/faker/default/twitter.rb
+++ b/lib/faker/default/twitter.rb
@@ -75,8 +75,8 @@ module Faker
       ##
       # Produces a random Twitter user.
       #
-      # @param include_status [Boolean] Include or exclude user status details
-      # @param include_email [Boolean] Include or exclude user email details
+      # @param include_user [Boolean] Include or exclude user details
+      # @param include_photo [Boolean] Include or exclude user photo
       # @return [Hash]
       #
       # @example


### PR DESCRIPTION
Issue# 
-----------------------
https://github.com/faker-ruby/faker/issues/1762
I made a few errors while working on YARD docs which were caught by running `bundle exec yard rake`.
Made one PR to clean them all up, as they are similar.

Description:
-----------------------
Cleaning up the errors found by renaming variables or adding indentation.