### PR TITLE
Fix docs for `Faker::Games::Control.altered_world_event`

### DIFF
--- a/lib/faker/games/control.rb
+++ b/lib/faker/games/control.rb
@@ -62,7 +62,7 @@ module Faker
         # @return [String]
         #
         # @example
-        #   Faker::Games::Control.altered_item #=> "Rubber Duck"
+        #   Faker::Games::Control.altered_world_event #=> "Ordinary, Wisconsin"
         #
         # @faker.version next
         def altered_world_event


### PR DESCRIPTION
Noticed that the docs for `altered_world_event` gave an example for `altered_item`.
