### PR TITLE
Drop Ruby head version from tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,6 @@ jobs:
           - '2.5' 
           - '2.6' 
           - '2.7'
-          - 'head'
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The head version has been causing errors in some of the PRs that pass all the other versions of Ruby. Since the head version of ruby is under development and not yet officially released it shouldn't be a blocker for getting PRs merged.
