### PR TITLE
Update 'prepare' regexp to allow hyphen

### DIFF
--- a/lib/helpers/char.rb
+++ b/lib/helpers/char.rb
@@ -5,7 +5,7 @@ module Faker
     def self.prepare(string)
       result = romanize_cyrillic string
       result = fix_umlauts result
-      result.gsub(/\W/, '').downcase
+      result.gsub(/[^\w-]/, '').downcase
     end
 
     def self.fix_umlauts(string)

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -151,11 +151,11 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_domain_name_without_subdomain
-    assert @tester.domain_name.match(/\w+\.\w+/)
+    assert @tester.domain_name.match(/[\w-]+\.\w+/)
   end
 
   def test_domain_name_with_subdomain
-    assert @tester.domain_name(subdomain: true).match(/\w+\.\w+\.\w+/)
+    assert @tester.domain_name(subdomain: true).match(/[\w-]+\.[\w-]+\.\w+/)
   end
 
   def test_domain_name_with_subdomain_and_with_domain_option_given
@@ -167,7 +167,7 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_domain_word
-    assert @tester.domain_word.match(/^\w+$/)
+    assert @tester.domain_word.match(/^[\w-]+$/)
   end
 
   def test_domain_suffix

--- a/test/test_uk_locale.rb
+++ b/test/test_uk_locale.rb
@@ -39,7 +39,7 @@ class TestUkLocale < Test::Unit::TestCase
 
   def test_uk_internet_methods
     assert Faker::Internet.email.match(/.+@[^.].+\.\w+/)
-    assert Faker::Internet.domain_word.match(/^\w+$/)
+    assert Faker::Internet.domain_word.match(/^[\w-]+$/)
   end
 
   def test_uk_name_methods


### PR DESCRIPTION
https://github.com/faker-ruby/faker/issues/1954
------
Description:
------

Fix edge case where domain has a hyphen in it (example: `foo-bar.com`) by updating regexp in `Faker::Char.prepare` and update test assertion to account for change.

The only other place where I see this change having an impact is in `Faker::Internet.username`, however there are currently no names in the locale file that contain a hyphen and so it seems like it would be overkill to account for this in the `prepare` method.
