### PR TITLE
Sanitize email when name has special characters

### DIFF
--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -11,6 +11,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.email.match(/.+@.+\.\w+/)
   end
 
+  def test_email_with_non_permitted_characters
+    assert @tester.email(name: 'martín').match(/mart#n@.+\.\w+/)
+  end
+
   def test_email_with_separators
     assert @tester.email(name: 'jane doe', separators: '+').match(/.+\+.+@.+\.\w+/)
   end
@@ -27,8 +31,16 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
   end
 
+  def test_free_email_with_non_permitted_characters
+    assert @tester.free_email(name: 'martín').match(/mart#n@.+\.\w+/)
+  end
+
   def test_safe_email
     assert @tester.safe_email.match(/.+@example.(com|net|org)/)
+  end
+
+  def test_safe_email_with_non_permitted_characters
+    assert @tester.safe_email(name: 'martín').match(/mart#n@.+\.\w+/)
   end
 
   def test_username


### PR DESCRIPTION
Resolves #1974
------
Description:
------
This pull request fixes a small edge case when faking an email with a `name` param with special characters. Lets say, `Faker::Internet.email(name: 'martín')`, should not resolve to `martín@example.com` as it is [not a valid email](https://en.wikipedia.org/wiki/Email_address#Local-part).

With that in mind, the fix replaces the forbidden character with a `#`. That decision was made basically trying to keep the number of characters in the `name` params.

I'm open to any suggestions not only regarding the replacement character (`#`) but also the way this pr is written. Also, willing to add more tests if needed