### PR TITLE
Allow passing a string to specific Faker::Date methods.

### DIFF
--- a/lib/faker/default/date.rb
+++ b/lib/faker/default/date.rb
@@ -6,8 +6,8 @@ module Faker
       ##
       # Produce a random date between two dates.
       #
-      # @param from [Date] The start of the usable date range.
-      # @param to [Date] The end of the usable date range.
+      # @param from [Date, String] The start of the usable date range.
+      # @param to [Date, String] The end of the usable date range.
       # @return [Date]
       #
       # @example
@@ -32,9 +32,9 @@ module Faker
       ##
       # Produce a random date between two dates.
       #
-      # @param from [Date] The start of the usable date range.
-      # @param to [Date] The end of the usable date range.
-      # @param excepted [Date] A date to exclude.
+      # @param from [Date, String] The start of the usable date range.
+      # @param to [Date, String] The end of the usable date range.
+      # @param excepted [Date, String] A date to exclude.
       # @return [Date]
       #
       # @example


### PR DESCRIPTION
`Faker::Date.between(from: 'January 1, 2014', to: 'December 31, 2014')` is valid because it coerces a string into a date, so we should allow this. (I'd prefer not to use the duck-typing syntax here since it'd be a mess)