### PR TITLE
Drop EOL Rubies from CI tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '2.3' 
           - '2.4' 
           - '2.5' 
           - '2.6' 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '2.4' 
           - '2.5' 
           - '2.6' 
           - '2.7'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Description: This cop checks the length of lines in the source code. The maximum length is configurable.

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = ['faker']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/master/CHANGELOG.md'
   spec.metadata['source_code_uri'] = 'https://github.com/faker-ruby/faker'

--- a/lib/helpers/base58.rb
+++ b/lib/helpers/base58.rb
@@ -7,7 +7,7 @@ module Faker
       base = alphabet.size
 
       lv = 0
-      str.split('').reverse.each_with_index { |v, i| lv += v.unpack('C')[0] * 256**i }
+      str.split('').reverse.each_with_index { |v, i| lv += v.unpack('C') * 256**i }
 
       ret = +''
       while lv.positive?

--- a/test/faker/default/test_country_code.rb
+++ b/test/faker/default/test_country_code.rb
@@ -23,11 +23,9 @@ class TestCountryCode < Test::Unit::TestCase
   def test_all_country_code_have_country
     codes = Faker::Base.fetch_all('address.country_code')
     lonely_codes = codes.reject do |code|
-      begin
-        Faker::Address.country_by_code(code: code)
-      rescue I18n::MissingTranslationData
-        nil
-      end
+      Faker::Address.country_by_code(code: code)
+    rescue I18n::MissingTranslationData
+      nil
     end
 
     assert_equal([], lonely_codes)


### PR DESCRIPTION
This PR drops Ruby 2.3 and Ruby 2.4 from the list of automatically tested Ruby versions.

- 2.3 was EOL March 31 2019
- 2.4 was EOL March 31 2020