### PR TITLE
Split lint and test Github actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,20 @@ on:
     branches: [ master ]
 
 jobs:
+  lint:
+    name: Rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run Rubocop
+        run: bundle exec rake rubocop
   test: 
     name: Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
@@ -44,7 +58,7 @@ jobs:
         ./cc-test-reporter before-build
     
     - name: Run tests
-      run: bundle exec rake
+      run: bundle exec rake test
 
     - name: Publish code coverage
       env:


### PR DESCRIPTION
Splits the Github actions into lint and test, that way linting is only done once per PR instead of once in each version of ruby we're supporting