### PR TITLE
Workaround for cc-test-reporter with SimpleCov 0.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ DEPENDENCIES
   pry (= 0.14.0)
   rake (= 13.0.3)
   rubocop (= 1.11.0)
-  simplecov (= 0.17.1)
+  simplecov (= 0.17.1, < 0.18)
   test-unit (= 3.4.0)
   timecop (= 0.9.4)
   yard (= 0.9.26)

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -33,7 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pry', '0.14.0')
   spec.add_development_dependency('rake', '13.0.3')
   spec.add_development_dependency('rubocop', '1.11.0')
-  spec.add_development_dependency('simplecov', '0.17.1')
+  # Workaround for cc-test-reporter with SimpleCov 0.18.
+  # Stop upgrading SimpleCov until the following issue will be resolved.
+  # https://github.com/codeclimate/test-reporter/issues/418
+  spec.add_development_dependency('simplecov', '0.17.1', '< 0.18')
   spec.add_development_dependency('test-unit', '3.4.0')
   spec.add_development_dependency('timecop', '0.9.4')
   spec.add_development_dependency('yard', '0.9.26')


### PR DESCRIPTION
Closes #2043.

This PR fixes the following build error when using cc-test-reporter with SimpleCov 0.18.

```console
Run export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
Error: json: cannot unmarshal object into Go struct field input.coverage
of type []formatters.NullInt
Usage:
  cc-test-reporter after-build [flags]

(snip)

Global Flags:
  -d, --debug   run in debug mode

##[error]Process completed with exit code 255.
```

https://github.com/faker-ruby/faker/pull/2043/checks?check_run_id=750522010

This patch is a workaround until the following issue will be resolved.
codeclimate/test-reporter#418
