### PR TITLE
Fix: decimal with r_digits 1 always finishes in 0

### DIFF
--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -85,13 +85,11 @@ module Faker
         end
 
         l_d = number(digits: l_digits)
-        r_d = if r_digits == 1
-                generate(r_digits)
-              else
-                # Ensure the last digit is not zero
-                # so it does not get truncated on converting to float
-                generate(r_digits - 1).join + non_zero_digit.to_s
-              end
+
+        # Ensure the last digit is not zero
+        # so it does not get truncated on converting to float
+        r_d = generate(r_digits - 1).join + non_zero_digit.to_s
+
         "#{l_d}.#{r_d}".to_f
       end
 

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -38,9 +38,9 @@ class TestFakerNumber < Test::Unit::TestCase
   end
 
   def test_decimal
-    assert @tester.decimal(l_digits: 1, r_digits: 1).to_s.match(/[0-9]{1}\.[0-9]{1}/)
-    assert @tester.decimal(l_digits: 2).to_s.match(/[0-9]{2}\.[0-9]{2}/)
-    assert @tester.decimal(l_digits: 4, r_digits: 5).to_s.match(/[0-9]{4}\.[0-9]{5}/)
+    assert @tester.decimal(l_digits: 1, r_digits: 1).to_s.match(/[0-9]{1}\.[1-9]{1}/)
+    assert @tester.decimal(l_digits: 2).to_s.match(/[0-9]{2}\.[0-9]{1}[1-9]{1}/)
+    assert @tester.decimal(l_digits: 4, r_digits: 5).to_s.match(/[0-9]{4}\.[0-9]{4}[1-9]{1}/)
   end
 
   def test_digit


### PR DESCRIPTION
Resolves #2045 
------
Description:
------
Right now there is a bug when generating a random decimal with `r_digits: 1` as it always ends in 0:

```
100.times.map{Faker::Number.decimal(l_digits: 1, r_digits: 1)}
=> [3.0, 4.0, 1.0, 9.0, 5.0, 9.0, 1.0, 1.0, 2.0, 1.0, 7.0, 9.0, 4.0, 0.0, 0.0, 7.0, 6.0, 0.0, 2.0, 9.0, 5.0, 9.0, 9.0, 3.0, 2.0, 8.0, 9.0, 3.0, 2.0, 8.0, 8.0, 0.0, 8.0, 4.0, 9.0, 7.0, 7.0, 1.0, 0.0, 7.0, 6.0, 0.0, 6.0, 7.0, 9.0, 5.0, 4.0, 2.0, 3.0, 3.0, 8.0, 2.0, 8.0, 5.0, 9.0, 5.0, 9.0, 3.0, 0.0, 3.0, 4.0, 6.0, 1.0, 4.0, 6.0, 3.0, 5.0, 7.0, 4.0, 0.0, 6.0, 9.0, 4.0, 1.0, 9.0, 2.0, 9.0, 3.0, 6.0, 2.0, 1.0, 5.0, 4.0, 9.0, 3.0, 9.0, 8.0, 4.0, 1.0, 5.0, 8.0, 1.0, 0.0, 8.0, 0.0, 5.0, 9.0, 1.0, 2.0, 7.0]
```

This fixes it, plus there is a small change in the behavior (I really don't know if it was intended or not) that when generating a 1 right digit, it was not checking that it was not 0. After that the comment was:
```
# Ensure the last digit is not zero
# so it does not get truncated on converting to float
```

So now it is being checked that the last digit is not 0 even if it is only one digit. 

Feel free to suggest any changes, improvements or to ask for more tests 😄 