### PR TITLE
Fix random error in music tests

### DIFF
--- a/lib/locales/en/rush.yml
+++ b/lib/locales/en/rush.yml
@@ -10,7 +10,7 @@ en:
         - Rush
         - Fly by Night
         - Caress of Steel
-        - 2112
+        - '2112'
         - A Farewell to Kings
         - Hemispheres
         - Permanent Waves


### PR DESCRIPTION
Resolves #2049 
------

A test that seems to be failing randomly. The test is:
faker/test/faker/music/test_faker_rush.rb

The error is: NoMethodError: undefined method 'match' for 2112:Integer

It comes from the fetch method in the Faker::Base, when it does:

`sample(translate("faker.#{key}"))`

where `translate("faker.#{key}")` returns:

["Rush", "Fly by Night", "Caress of Steel", 2112, "A Farewell to Kings", "Hemispheres", "Permanent Waves", "Moving Pictures", "Signals", "Grace Under Pressure", "Power Windows", "Hold Your Fire", "Presto", "Roll the Bones", "Counterparts", "Test for Echo", "Vapor Trails", "Snakes & Arrows", "Clockwork Angels", "All the World's a Stage", "Exit...Stage Left", "A Show of Hands", "Different Stages"]
So when the sample is `2112`, it tries to do `2112.match(%r{^/})`

----

I solved this by changing the input of the YAML to a string. Another way of solving this could be in 
the `fetch` method of faker make this change:

add a `fetched.respond_to?(:match)` check in the `fetch` method:
```
def fetch(key)
  fetched = sample(translate("faker.#{key}"))
  if fetched.respond_to?(:match) && fetched.match(%r{^\/}) && fetched.match(%r{\/$}) # A regex
    regexify(fetched)
  else
    fetched
  end
end
```

I am open to any suggestions or changes
