### PR TITLE
Merge Business and Stripe methods

### DIFF
--- a/doc/default/business.md
+++ b/doc/default/business.md
@@ -1,9 +1,25 @@
 # Faker::Business
 
 ```ruby
-Faker::Business.credit_card_number #=> "1228-1221-1221-1431"
-
 Faker::Business.credit_card_expiry_date #=> <Date: 2015-11-11 ((2457338j,0s,0n),+0s,2299161j)>
 
-Faker::Business.credit_card_type #=> "visa"
+Faker::Business.card_brand #=> "visa"
+
+Faker::Business.card_type #=> "visa_debit"
+
+# Keyword arguments: card_type
+Faker::Business.valid_card_number #=> "4242424242424242"
+Faker::Business.valid_card_number(card_type: "visa_debit") #=> "4000056655665556"
+
+# Keyword arguments: card_error
+Faker::Business.invalid_card_number #=> "4000000000000002"
+Faker::Business.invalid_card_number(card_error: "addressZipFail") #=> "4000000000000010"
+
+Faker::Business.card_expiry_month #=> "10"
+
+Faker::Business.card_expiry_year #=> "2023" # This will always be a year in the future
+
+# Keyword arguments: card_type
+Faker::Business.ccv #=> "123"
+Faker::Business.ccv(card_type: "amex") #=> "1234"
 ```

--- a/doc/default/stripe.md
+++ b/doc/default/stripe.md
@@ -1,27 +1,11 @@
 # Faker::Stripe
 
-Test Stripe transactions without hardcoding card numbers and tokens
+Test Stripe transactions without hardcoding tokens
 
 ```ruby
 # Keyword arguments: card_type
-Faker::Stripe.valid_card #=> "4242424242424242"
-Faker::Stripe.valid_card(card_type: "visa_debit") #=> "4000056655665556"
-
-# Keyword arguments: card_type
 Faker::Stripe.valid_token #=> "tok_visa"
 Faker::Stripe.valid_token(card_type: "mc_debit") #=> "tok_mastercard_debit"
-
-# Keyword arguments: card_error
-Faker::Stripe.invalid_card #=> "4000000000000002"
-Faker::Stripe.invalid_card(card_error: "addressZipFail") #=> "4000000000000010"
-
-Faker::Stripe.month #=> "10"
-
-Faker::Stripe.year #=> "2018" # This will always be a year in the future
-
-# Keyword arguments: card_type
-Faker::Stripe.ccv #=> "123"
-Faker::Stripe.ccv(card_type: "amex") #=> "1234"
 ```
 
 ProTip:

--- a/lib/faker/default/business.rb
+++ b/lib/faker/default/business.rb
@@ -7,17 +7,19 @@ module Faker
     flexible :business
 
     class << self
+      extend Gem::Deprecate
+
       ##
-      # Produces a credit card number.
+      # Produces a card expiration date.
       #
-      # @return [String]
+      # @return [Date]
       #
       # @example
-      #   Faker::Business.credit_card_number #=> "1228-1221-1221-1431"
+      #   Faker::Business.card_expiry_date #=> <Date: 2015-11-11 ((2457338j,0s,0n),+0s,2299161j)>
       #
-      # @faker.version 1.2.0
-      def credit_card_number
-        fetch('business.credit_card_numbers')
+      # @faker.version 2.13.0
+      def card_expiry_date
+        ::Date.today + (365 * rand(1..4))
       end
 
       ##
@@ -28,9 +30,50 @@ module Faker
       # @example
       #   Faker::Business.credit_card_expiry_date #=> <Date: 2015-11-11 ((2457338j,0s,0n),+0s,2299161j)>
       #
+      # @deprecated Use the card_expiry_date method instead.
+      #
       # @faker.version 1.2.0
-      def credit_card_expiry_date
-        ::Date.today + (365 * rand(1..4))
+      alias credit_card_expiry_date card_expiry_date
+      deprecate :credit_card_expiry_date, :card_expiry_date, 2020, 6
+
+      ##
+      # Produces a random card expiry month in two digits format.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.card_expiry_month #=> "10"
+      #
+      # @faker.version 2.13.0
+      def card_expiry_month
+        format('%02d', rand_in_range(1, 12))
+      end
+
+      ##
+      # Produces a random card expiry year that is always in the future.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.card_expiry_year #=> "2023" # This will always be a year in the future
+      #
+      # @faker.version 2.13.0
+      def card_expiry_year
+        start_year = ::Time.new.year + 1
+        rand_in_range(start_year, start_year + 3).to_s
+      end
+
+      ##
+      # Produces a type of a card.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.card_type #=> "visa_debit"
+      #
+      # @faker.version 1.2.0
+      def card_type
+        sample(translate('faker.business.valid_cards').keys).to_s
       end
 
       ##
@@ -41,9 +84,121 @@ module Faker
       # @example
       #   Faker::Business.credit_card_type #=> "visa"
       #
+      # @deprecated Use the card_type method instead.
+      #
       # @faker.version 1.2.0
-      def credit_card_type
-        fetch('business.credit_card_types')
+      alias credit_card_type card_type
+      deprecate :credit_card_type, :card_type, 2020, 6
+
+      ##
+      # Produces a brand of a card.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.card_brand #=> "visa"
+      #
+      # @faker.version 2.13.0
+      def card_brand
+        fetch('business.card_brands')
+      end
+
+      ##
+      # Produces a random valid card number.
+      #
+      # @param card_type [String] Specific valid card type.
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.valid_card_number #=> "4242424242424242"
+      #   Faker::Business.valid_card_number(card_type: "visa_debit") #=> "4000056655665556"
+      #
+      # @faker.version 2.13.0
+      def valid_card_number(legacy_card_type = NOT_GIVEN, card_type: nil)
+        warn_for_deprecated_arguments do |keywords|
+          keywords << :card_type if legacy_card_type != NOT_GIVEN
+        end
+
+        valid_cards = translate('faker.business.valid_cards').keys
+
+        if card_type.nil?
+          card_type = sample(valid_cards).to_s
+        else
+          unless valid_cards.include?(card_type.to_sym)
+            raise ArgumentError,
+                  "Valid credit cards argument can be left blank or include #{valid_cards.join(', ')}"
+          end
+        end
+
+        fetch('business.valid_cards.' + card_type)
+      end
+
+      ##
+      # Produces a random valid card number.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.credit_card_number #=> "1228-1221-1221-1431"
+      #
+      # @deprecated Use the valid_card_number method instead.
+      #
+      # @faker.version 1.2.0
+      def credit_card_number
+        credit_card_type = Faker::Base.sample(%w[visa mc amex discover diners_club jcb])
+        credit_card_number_without_hyphens = valid_card_number(card_type: credit_card_type)
+        (1...3).reduce(credit_card_number_without_hyphens.to_s) do |card_number, index|
+          card_number.insert(index * 4, '-')
+        end
+      end
+      deprecate :credit_card_number, :valid_card_number, 2020, 6
+
+      ##
+      # Produces a random invalid card number.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.invalid_card_number #=> "4000000000000002"
+      #   Faker::Business.invalid_card_number(card_error: "addressZipFail") #=> "4000000000000010"
+      #
+      # @faker.version 2.13.0
+      def invalid_card_number(legacy_card_error = NOT_GIVEN, card_error: nil)
+        warn_for_deprecated_arguments do |keywords|
+          keywords << :card_error if legacy_card_error != NOT_GIVEN
+        end
+
+        invalid_cards = translate('faker.business.invalid_cards').keys
+
+        if card_error.nil?
+          card_error = sample(invalid_cards).to_s
+        else
+          unless invalid_cards.include?(card_error.to_sym)
+            raise ArgumentError,
+                  "Invalid credit cards argument can be left blank or include #{invalid_cards.join(', ')}"
+          end
+        end
+
+        fetch('business.invalid_cards.' + card_error)
+      end
+
+      ##
+      # Produces a random ccv number.
+      #
+      # @param card_type [String] Specific valid card type.
+      # @return [String]
+      #
+      # @example
+      #   Faker::Business.ccv #=> "123"
+      #   Faker::Business.ccv(card_type: "amex") #=> "1234"
+      #
+      # @faker.version 2.13.0
+      def ccv(legacy_card_type = NOT_GIVEN, card_type: nil)
+        warn_for_deprecated_arguments do |keywords|
+          keywords << :card_type if legacy_card_type != NOT_GIVEN
+        end
+
+        (card_type.to_s == 'amex' ? rand_in_range(1000, 9999) : rand_in_range(100, 999)).to_s
       end
     end
   end

--- a/lib/faker/default/stripe.rb
+++ b/lib/faker/default/stripe.rb
@@ -3,6 +3,8 @@
 module Faker
   class Stripe < Base
     class << self
+      extend Gem::Deprecate
+
       ##
       # Produces a random valid card number.
       #
@@ -13,25 +15,13 @@ module Faker
       #   Faker::Stripe.valid_card #=> "4242424242424242"
       #   Faker::Stripe.valid_card(card_type: "visa_debit") #=> "4000056655665556"
       #
+      # @deprecated Use the Faker::Business.valid_card_number method instead.
+      #
       # @faker.version 1.9.0
       def valid_card(legacy_card_type = NOT_GIVEN, card_type: nil)
-        warn_for_deprecated_arguments do |keywords|
-          keywords << :card_type if legacy_card_type != NOT_GIVEN
-        end
-
-        valid_cards = translate('faker.stripe.valid_cards').keys
-
-        if card_type.nil?
-          card_type = sample(valid_cards).to_s
-        else
-          unless valid_cards.include?(card_type.to_sym)
-            raise ArgumentError,
-                  "Valid credit cards argument can be left blank or include #{valid_cards.join(', ')}"
-          end
-        end
-
-        fetch('stripe.valid_cards.' + card_type)
+        Faker::Business.valid_card_number(legacy_card_type, card_type: card_type)
       end
+      deprecate :valid_card, 'Faker::Business.valid_card_number', 2020, 6
 
       ##
       # Produces a random valid Stripe token.
@@ -72,25 +62,13 @@ module Faker
       #   Faker::Stripe.invalid_card #=> "4000000000000002"
       #   Faker::Stripe.invalid_card(card_error: "addressZipFail") #=> "4000000000000010"
       #
+      # @deprecated Use the Faker::Business.invalid_card_number method instead.
+      #
       # @faker.version 1.9.0
       def invalid_card(legacy_card_error = NOT_GIVEN, card_error: nil)
-        warn_for_deprecated_arguments do |keywords|
-          keywords << :card_error if legacy_card_error != NOT_GIVEN
-        end
-
-        invalid_cards = translate('faker.stripe.invalid_cards').keys
-
-        if card_error.nil?
-          card_error = sample(invalid_cards).to_s
-        else
-          unless invalid_cards.include?(card_error.to_sym)
-            raise ArgumentError,
-                  "Invalid credit cards argument can be left blank or include #{invalid_cards.join(', ')}"
-          end
-        end
-
-        fetch('stripe.invalid_cards.' + card_error)
+        Faker::Business.invalid_card_number(legacy_card_error, card_error: card_error)
       end
+      deprecate :invalid_card, 'Faker::Business.invalid_card_number', 2020, 6
 
       ##
       # Produces a random month in two digits format.
@@ -100,10 +78,13 @@ module Faker
       # @example
       #   Faker::Stripe.month #=> "10"
       #
+      # @deprecated Use the Faker::Business.card_expiry_month method instead.
+      #
       # @faker.version 1.9.0
       def month
-        format('%02d', rand_in_range(1, 12))
+        Faker::Business.card_expiry_month
       end
+      deprecate :month, 'Faker::Business.card_expiry_month', 2020, 6
 
       ##
       # Produces a random year that is always in the future.
@@ -111,13 +92,15 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Stripe.year #=> "2018" # This will always be a year in the future
+      #   Faker::Stripe.year #=> "2023" # This will always be a year in the future
+      #
+      # @deprecated Use the Faker::Business.card_expiry_year method instead.
       #
       # @faker.version 1.9.0
       def year
-        start_year = ::Time.new.year + 1
-        rand_in_range(start_year, start_year + 5).to_s
+        Faker::Business.card_expiry_year
       end
+      deprecate :year, 'Faker::Business.card_expiry_year', 2020, 6
 
       ##
       # Produces a random ccv number.
@@ -129,14 +112,13 @@ module Faker
       #   Faker::Stripe.ccv #=> "123"
       #   Faker::Stripe.ccv(card_type: "amex") #=> "1234"
       #
+      # @deprecated Use the Faker::Business.ccv method instead.
+      #
       # @faker.version 1.9.0
       def ccv(legacy_card_type = NOT_GIVEN, card_type: nil)
-        warn_for_deprecated_arguments do |keywords|
-          keywords << :card_type if legacy_card_type != NOT_GIVEN
-        end
-
-        (card_type.to_s == 'amex' ? rand_in_range(1000, 9999) : rand_in_range(100, 999)).to_s
+        Faker::Business.ccv(legacy_card_type, card_type: card_type)
       end
+      deprecate :ccv, 'Faker::Business.ccv', 2020, 6
     end
   end
 end

--- a/lib/locales/en/business.yml
+++ b/lib/locales/en/business.yml
@@ -1,5 +1,42 @@
 en:
   faker:
     business:
-      credit_card_numbers: ['1234-2121-1221-1211', '1212-1221-1121-1234', '1211-1221-1234-2201', '1228-1221-1221-1431']
-      credit_card_types: ['visa', 'mastercard', 'american_express', 'discover', 'diners_club', 'jcb', 'switch', 'solo', 'dankort', 'maestro', 'forbrugsforeningen', 'laser']
+      card_brands: ['visa', 'mc', 'amex', 'discover', 'diners_club', 'jcb']
+      valid_cards:
+        visa:          "4242424242424242"
+        visa_debit:    "4000056655665556"
+        mc:            "5555555555554444"
+        mc_2_series:   "2223003122003222"
+        mc_debit:      "5200828282828210"
+        mc_prepaid:    "5105105105105100"
+        amex:          "378282246310005"
+        amex_2:        "371449635398431"
+        discover:      "6011111111111117"
+        discover_2:    "6011000990139424"
+        diners_club:   "3056930009020004"
+        diners_club_2: "36227206271667"
+        jcb:           "3566002020360505"
+      valid_tokens:
+        visa:          "tok_visa"
+        visa_debit:    "tok_visa_debit"
+        mc:            "tok_mastercard"
+        mc_debit:      "tok_mastercard_debit"
+        mc_prepaid:    "tok_mastercard_prepaid"
+        amex:          "tok_amex"
+        discover:      "tok_discover"
+        diners_club:   "tok_diners"
+        jcb:           "tok_jcb"
+      invalid_cards:
+        addressZipFail:         "4000000000000010"  # The address_line1_check and address_zip_check verifications fail. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressFail:            "4000000000000028"  # Charge succeeds but the address_line1_check verification fails.
+        zipFail:                "4000000000000036"  # The address_zip_check verification fails. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressZipUnavailable:  "4000000000000044"  # Charge succeeds but the address_zip_check and address_line1_check verifications are both unavailable.
+        cvcFail:                "4000000000000101"  # If a CVC number is provided, the cvc_check fails. If your account is blocking payments that fail CVC code validation, the charge is declined.
+        customerChargeFail:     "4000000000000341"  # Attaching this card to a Customer object succeeds, but attempts to charge the customer fail.
+        successWithReview:      "4000000000009235"  # Charge succeeds with a risk_level of elevated and placed into review.
+        declineCard:            "4000000000000002"  # Charge is declined with a card_declined code.
+        declineFraudulentCard:  "4100000000000019"  # Results in a charge with a risk level of highest. The charge is blocked as it's considered fraudulent.
+        declineIncorrectCvc:    "4000000000000127"  # Charge is declined with an incorrect_cvc code.
+        declineExpired:         "4000000000000069"  # Charge is declined with an expired_card code.
+        declineProcessingError: "4000000000000119"  # Charge is declined with a processing_error code.
+        declineIncorrectNumber: "4242424242424241"  # Charge is declined with an incorrect_number code as the card number fails the Luhn check.

--- a/lib/locales/en/stripe.yml
+++ b/lib/locales/en/stripe.yml
@@ -2,20 +2,6 @@
 en:
   faker:
     stripe:
-      valid_cards:
-        visa:          "4242424242424242"
-        visa_debit:    "4000056655665556"
-        mc:            "5555555555554444"
-        mc_2_series:   "2223003122003222"
-        mc_debit:      "5200828282828210"
-        mc_prepaid:    "5105105105105100"
-        amex:          "378282246310005"
-        amex_2:        "371449635398431"
-        discover:      "6011111111111117"
-        discover_2:    "6011000990139424"
-        diners_club:   "3056930009020004"
-        diners_club_2: "36227206271667"
-        jcb:           "3566002020360505"
       valid_tokens:
         visa:          "tok_visa"
         visa_debit:    "tok_visa_debit"
@@ -26,17 +12,3 @@ en:
         discover:      "tok_discover"
         diners_club:   "tok_diners"
         jcb:           "tok_jcb"
-      invalid_cards:
-        addressZipFail:         "4000000000000010"  # The address_line1_check and address_zip_check verifications fail. If your account is blocking payments that fail ZIP code validation, the charge is declined.
-        addressFail:            "4000000000000028"  # Charge succeeds but the address_line1_check verification fails.
-        zipFail:                "4000000000000036"  # The address_zip_check verification fails. If your account is blocking payments that fail ZIP code validation, the charge is declined.
-        addressZipUnavailable:  "4000000000000044"  # Charge succeeds but the address_zip_check and address_line1_check verifications are both unavailable.
-        cvcFail:                "4000000000000101"  # If a CVC number is provided, the cvc_check fails. If your account is blocking payments that fail CVC code validation, the charge is declined.
-        customerChargeFail:     "4000000000000341"  # Attaching this card to a Customer object succeeds, but attempts to charge the customer fail.
-        successWithReview:      "4000000000009235"  # Charge succeeds with a risk_level of elevated and placed into review.
-        declineCard:            "4000000000000002"  # Charge is declined with a card_declined code.
-        declineFraudulentCard:  "4100000000000019"  # Results in a charge with a risk level of highest. The charge is blocked as it's considered fraudulent.
-        declineIncorrectCvc:    "4000000000000127"  # Charge is declined with an incorrect_cvc code.
-        declineExpired:         "4000000000000069"  # Charge is declined with an expired_card code.
-        declineProcessingError: "4000000000000119"  # Charge is declined with a processing_error code.
-        declineIncorrectNumber: "4242424242424241"  # Charge is declined with an incorrect_number code as the card number fails the Luhn check.

--- a/test/faker/default/test_faker_business.rb
+++ b/test/faker/default/test_faker_business.rb
@@ -6,18 +6,86 @@ class TestFakerBusiness < Test::Unit::TestCase
   def setup
     @tester = Faker::Business
     @credit_card_number_list = I18n.translate('faker.business.credit_card_numbers')
-    @credit_card_types = I18n.translate('faker.business.credit_card_types')
-    @minimum_expiry_date = ::Date.today + 365
+    @card_types = I18n.translate('faker.business.valid_cards').keys
+    @card_brands = I18n.translate('faker.business.card_brands')
+    @minimum_expiry_date = ::Date.today
     @maximum_expiry_date = ::Date.today + (365 * 4)
   end
 
-  def test_credit_card_number
-    number1 = @tester.credit_card_number
-    number2 = @tester.credit_card_number
-    assert @credit_card_number_list.include?(number1)
-    assert @credit_card_number_list.include?(number2)
+  def test_card_expiry_date
+    date1 = @tester.card_expiry_date
+    date2 = @tester.card_expiry_date
+    assert date1.between?(@minimum_expiry_date, @maximum_expiry_date)
+    assert date2.between?(@minimum_expiry_date, @maximum_expiry_date)
   end
 
+  def test_card_type
+    type1 = @tester.card_type
+    type2 = @tester.card_type
+    assert @card_types.include?(type1.to_sym)
+    assert @card_types.include?(type2.to_sym)
+  end
+
+  def test_card_brand
+    brand1 = @tester.card_brand
+    brand2 = @tester.card_brand
+    assert @card_brands.include?(brand1)
+    assert @card_brands.include?(brand2)
+  end
+
+  def test_valid_card_expiry_month
+    assert @tester.card_expiry_month.match(/\A\d{2}\z/)
+  end
+
+  def test_valid_card_expiry_year
+    assert @tester.card_expiry_year.match(/\A\d{4}\z/)
+    assert @tester.card_expiry_year.to_i.between?(
+      @minimum_expiry_date.year + 1,
+      @maximum_expiry_date.year
+    )
+  end
+
+  def test_valid_card_number
+    assert @tester.valid_card_number.match(/\A\d{14,16}\z/)
+  end
+
+  def test_valid_card_error
+    e = assert_raise ArgumentError do
+      assert @tester.valid_card_number(card_type: Faker::Lorem.word)
+    end
+
+    assert_match(/\AValid credit cards argument can be left blank or include/, e.message)
+  end
+
+  def test_specific_valid_card_number
+    assert @tester.valid_card_number(card_type: 'visa').match(/\A\d{16}\z/)
+  end
+
+  def test_invalid_card_number
+    assert @tester.invalid_card_number.match(/\A\d{16}\z/)
+  end
+
+  def test_invalid_card_error
+    e = assert_raise ArgumentError do
+      assert @tester.invalid_card_number(card_error: Faker::Lorem.word)
+    end
+
+    assert_match(/\AInvalid credit cards argument can be left blank or include/, e.message)
+  end
+
+  def test_specific_error_invalid_card
+    assert @tester.invalid_card_number(card_error: 'zipFail').match(/\w+/)
+  end
+
+  def test_valid_ccv
+    assert @tester.ccv.match(/\A\d{3}\z/)
+  end
+
+  def test_valid_amex_ccv
+    assert @tester.ccv(card_type: 'amex').match(/\A\d{4}\z/)
+  end
+
+  # deprecated
   def test_credit_card_expiry_date
     date1 = @tester.credit_card_expiry_date
     date2 = @tester.credit_card_expiry_date
@@ -25,10 +93,16 @@ class TestFakerBusiness < Test::Unit::TestCase
     assert date2.between?(@minimum_expiry_date, @maximum_expiry_date)
   end
 
+  # deprecated
   def test_credit_card_type
     type1 = @tester.credit_card_type
     type2 = @tester.credit_card_type
-    assert @credit_card_types.include?(type1)
-    assert @credit_card_types.include?(type2)
+    assert @card_types.include?(type1.to_sym)
+    assert @card_types.include?(type2.to_sym)
+  end
+
+  # deprecated
+  def test_credit_card_number
+    @tester.credit_card_number.match(/\A(\d{4}\-){3}\d{4}\z/)
   end
 end

--- a/test/faker/default/test_faker_stripe.rb
+++ b/test/faker/default/test_faker_stripe.rb
@@ -7,10 +7,12 @@ class TestFakerStripe < Test::Unit::TestCase
     @tester = Faker::Stripe
   end
 
+  # deprecated
   def test_valid_card
     assert @tester.valid_card.match(/\A\d{14,16}\z/)
   end
 
+  # deprecated
   def test_valid_card_error
     e = assert_raise ArgumentError do
       assert @tester.valid_card(card_type: Faker::Lorem.word)
@@ -19,6 +21,7 @@ class TestFakerStripe < Test::Unit::TestCase
     assert_match(/\AValid credit cards argument can be left blank or include/, e.message)
   end
 
+  # deprecated
   def test_specific_valid_card
     assert @tester.valid_card(card_type: 'visa').match(/\A\d{16}\z/)
   end
@@ -31,10 +34,12 @@ class TestFakerStripe < Test::Unit::TestCase
     assert @tester.valid_token(card_type: 'visa').match(/\Atok_visa\z/)
   end
 
+  # deprecated
   def test_invalid_card
     assert @tester.invalid_card.match(/\A\d{16}\z/)
   end
 
+  # deprecated
   def test_invalid_card_error
     e = assert_raise ArgumentError do
       assert @tester.invalid_card(card_error: Faker::Lorem.word)
@@ -43,22 +48,27 @@ class TestFakerStripe < Test::Unit::TestCase
     assert_match(/\AInvalid credit cards argument can be left blank or include/, e.message)
   end
 
+  # deprecated
   def test_specific_error_invalid_card
     assert @tester.invalid_card(card_error: 'zipFail').match(/\w+/)
   end
 
+  # deprecated
   def test_valid_exp_mo
     assert @tester.month.match(/\A\d{2}\z/)
   end
 
+  # deprecated
   def test_valid_exp_yr
     assert @tester.year.match(/\A\d{4}\z/)
   end
 
+  # deprecated
   def test_valid_ccv
     assert @tester.ccv.match(/\A\d{3}\z/)
   end
 
+  # deprecated
   def test_valid_amex_ccv
     assert @tester.ccv(card_type: 'amex').match(/\A\d{4}\z/)
   end


### PR DESCRIPTION
Resolves https://github.com/faker-ruby/faker/issues/1977
------

Description:
------

This PR was made in order to address some methods of credit card generators that could be [moved to the `Business` class ](https://github.com/faker-ruby/faker/issues/1977#issuecomment-628551653)

*One of the main goals is to achieve some sort of consistency between the two classes and so that the methods are easily found. Most of the methods from the `Stripe` class were moved to the `Business` class as they were methods that didn't depend on the integration service.*

-----

Considerations:

 - As there were two methods for card number generation and the `Stripe` one was more "complete", then I thought that maybe we could keep it. However, there is a small difference between both methods, which is that the `Stripe`'s one returns the card number in the format `XXXXXXXXXXXXXXX` whereas the `Business` method returns it as `XXXX-XXXX-XXXX-XXXX`. One option to be considered is to pass the `format_type` in the parameters, but maybe that shouldn't be `Faker`'s job. I'd really appreciate your opinion on this 🙏 .

 - As the `Stripe` class manages `card_types` (for example `visa_debit`), and the `Business` class uses the term `card_type` for `visa`, `amex`, `master_card` and so on, then in this PR there are two different methods: one for the `card_brand` and one for the `card_type`. Again, I'd really appreciate your opinion on this 🙏 .

 - Finally, I didn't know exactly the version to put in the comments for moved / created / updated methods, I wrote in all of them `# @faker.version 2.13.0` but willing to change that if someone could give me some insight on how to change it.

-----

I am more than willing to refactor this, change it, and are more tests to it, thanks!
