### PR TITLE
Update docs for Faker::Date with separate examples

### DIFF
--- a/doc/default/date.md
+++ b/doc/default/date.md
@@ -3,11 +3,15 @@
 ```ruby
 # Random date between dates
 # Keyword arguments: from, to
-Faker::Date.between(from: 2.days.ago, to: Date.today) #=> "Wed, 24 Sep 2014"
+Faker::Date.between(from: '2014-09-23', to: '2014-09-25') #=> #<Date: 2014-09-24>
+# If used with Rails (the Activesupport gem), additional options are available:
+Faker::Date.between(from: 2.days.ago, to: Date.today) #=> #<Date: 2014-09-24>
 
 # Random date between dates except for certain date
 # Keyword arguments: from, to, excepted
-Faker::Date.between_except(from: 1.year.ago, to: 1.year.from_now, excepted: Date.today) #=> "Wed, 24 Sep 2014"
+Faker::Date.between_except(from: '2014-09-23', to: '2015-09-25', excepted: '2015-01-24') #=> #<Date: 2014-10-03>
+# If used with Rails (the Activesupport gem), additional options are available:
+Faker::Date.between_except(from: 1.year.ago, to: 1.year.from_now, excepted: Date.today) #=> #<Date: 2014-10-03>
 
 # Random date in the future (up to maximum of N days)
 # Keyword arguments: days

--- a/doc/default/date.md
+++ b/doc/default/date.md
@@ -4,13 +4,13 @@
 # Random date between dates
 # Keyword arguments: from, to
 Faker::Date.between(from: '2014-09-23', to: '2014-09-25') #=> #<Date: 2014-09-24>
-# If used with Rails (the Activesupport gem), additional options are available:
+# If used with Rails (the Active Support gem), additional options are available:
 Faker::Date.between(from: 2.days.ago, to: Date.today) #=> #<Date: 2014-09-24>
 
 # Random date between dates except for certain date
 # Keyword arguments: from, to, excepted
 Faker::Date.between_except(from: '2014-09-23', to: '2015-09-25', excepted: '2015-01-24') #=> #<Date: 2014-10-03>
-# If used with Rails (the Activesupport gem), additional options are available:
+# If used with Rails (the Active Support gem), additional options are available:
 Faker::Date.between_except(from: 1.year.ago, to: 1.year.from_now, excepted: Date.today) #=> #<Date: 2014-10-03>
 
 # Random date in the future (up to maximum of N days)

--- a/lib/faker/default/date.rb
+++ b/lib/faker/default/date.rb
@@ -10,10 +10,10 @@ module Faker
       # @param to [Date, String] The end of the usable date range.
       # @return [Date]
       #
-      # @example if used with or without Rails (Activesupport)
+      # @example if used with or without Rails (Active Support)
       #   Faker::Date.between(from: '2014-09-23', to: '2014-09-25') #=> #<Date: 2014-09-24>
       #
-      # @example if used with Rails (Activesupport)
+      # @example if used with Rails (Active Support)
       #   Faker::Date.between(from: 2.days.ago, to: Date.today) #=> #<Date: 2014-09-24>
       #
       # @faker.version 1.0.0
@@ -39,10 +39,10 @@ module Faker
       # @param excepted [Date, String] A date to exclude.
       # @return [Date]
       #
-      # @example if used with or without Rails (Activesupport)
+      # @example if used with or without Rails (Active Support)
       #   Faker::Date.between_except(from: '2014-09-23', to: '2015-09-25', excepted: '2015-01-24') #=> #<Date: 2014-10-03>
       #
-      # @example if used with Rails (Activesupport)
+      # @example if used with Rails (Active Support)
       #   Faker::Date.between_except(from: 1.year.ago, to: 1.year.from_now, excepted: Date.today) #=> #<Date: 2014-10-03>
       #
       # @faker.version 1.6.2

--- a/lib/faker/default/date.rb
+++ b/lib/faker/default/date.rb
@@ -10,9 +10,11 @@ module Faker
       # @param to [Date, String] The end of the usable date range.
       # @return [Date]
       #
-      # @example
-      #   Faker::Date.between(from: 2.days.ago, to: Date.today)
-      #     #=> #<Date: 2014-09-24>
+      # @example if used with or without Rails (Activesupport)
+      #   Faker::Date.between(from: '2014-09-23', to: '2014-09-25') #=> #<Date: 2014-09-24>
+      #
+      # @example if used with Rails (Activesupport)
+      #   Faker::Date.between(from: 2.days.ago, to: Date.today) #=> #<Date: 2014-09-24>
       #
       # @faker.version 1.0.0
       def between(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from:, to:)
@@ -37,9 +39,11 @@ module Faker
       # @param excepted [Date, String] A date to exclude.
       # @return [Date]
       #
-      # @example
-      #   Faker::Date.between_except(from: 1.year.ago, to: 1.year.from_now, excepted: Date.today)
-      #     #=> #<Date: 2014-10-03>
+      # @example if used with or without Rails (Activesupport)
+      #   Faker::Date.between_except(from: '2014-09-23', to: '2015-09-25', excepted: '2015-01-24') #=> #<Date: 2014-10-03>
+      #
+      # @example if used with Rails (Activesupport)
+      #   Faker::Date.between_except(from: 1.year.ago, to: 1.year.from_now, excepted: Date.today) #=> #<Date: 2014-10-03>
       #
       # @faker.version 1.6.2
       def between_except(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, legacy_excepted = NOT_GIVEN, from:, to:, excepted:)


### PR DESCRIPTION
Issue# 
-----------------------

https://github.com/faker-ruby/faker/issues/2056

Description:
-----------------------
Updating the documentation in markdown and YARD for Faker::Date.
Some of the method arguments only work if the Activesupport gem is required - the new examples should make things clear.