### PR TITLE
Use `match?` method

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -97,7 +97,7 @@ module Faker
       # with an array of values and selecting one of them.
       def fetch(key)
         fetched = sample(translate("faker.#{key}"))
-        if fetched&.match(%r{^\/}) && fetched&.match(%r{\/$}) # A regex
+        if fetched&.match?(%r{^\/}) && fetched&.match?(%r{\/$}) # A regex
           regexify(fetched)
         else
           fetched
@@ -109,7 +109,7 @@ module Faker
       def fetch_all(key)
         fetched = translate("faker.#{key}")
         fetched = fetched.last if fetched.size <= 1
-        if !fetched.respond_to?(:sample) && fetched.match(%r{^\/}) && fetched.match(%r{\/$}) # A regex
+        if !fetched.respond_to?(:sample) && fetched.match?(%r{^\/}) && fetched.match?(%r{\/$}) # A regex
           regexify(fetched)
         else
           fetched

--- a/lib/faker/books/lovecraft.rb
+++ b/lib/faker/books/lovecraft.rb
@@ -102,7 +102,7 @@ module Faker
         # @faker.version 1.9.3
         def word
           random_word = sample(translate('faker.lovecraft.words'))
-          random_word =~ /\s/ ? word : random_word
+          /\s/.match?(random_word) ? word : random_word
         end
 
         ##
@@ -147,7 +147,7 @@ module Faker
           return shuffle(word_list)[0, resolved_num] if spaces_allowed
 
           words = shuffle(word_list)[0, resolved_num]
-          words.each_with_index { |w, i| words[i] = word if w =~ /\s/ }
+          words.each_with_index { |w, i| words[i] = word if /\s/.match?(w) }
         end
 
         ##

--- a/lib/faker/default/avatar.rb
+++ b/lib/faker/default/avatar.rb
@@ -48,7 +48,7 @@ module Faker
           keywords << :bgset if legacy_bgset != NOT_GIVEN
         end
 
-        raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
+        raise ArgumentError, 'Size should be specified in format 300x300' unless /^[0-9]+x[0-9]+$/.match?(size)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
 
         slug ||= Faker::Lorem.words.join

--- a/lib/faker/default/bank.rb
+++ b/lib/faker/default/bank.rb
@@ -156,7 +156,7 @@ module Faker
       def iban_checksum(country_code, account)
         # Converts letters to numbers according the iban rules, A=10..Z=35
         account_to_number = "#{account}#{country_code}00".upcase.chars.map do |d|
-          d =~ /[A-Z]/ ? (d.ord - 55).to_s : d
+          /[A-Z]/.match?(d) ? (d.ord - 55).to_s : d
         end.join.to_i
 
         # This is answer to (iban_to_num + checksum) % 97 == 1

--- a/lib/faker/default/fillmurray.rb
+++ b/lib/faker/default/fillmurray.rb
@@ -33,8 +33,8 @@ module Faker
           keywords << :height if legacy_height != NOT_GIVEN
         end
 
-        raise ArgumentError, 'Width should be a number' unless width.to_s =~ /^\d+$/
-        raise ArgumentError, 'Height should be a number' unless height.to_s =~ /^\d+$/
+        raise ArgumentError, 'Width should be a number' unless /^\d+$/.match?(width.to_s)
+        raise ArgumentError, 'Height should be a number' unless /^\d+$/.match?(height.to_s)
         raise ArgumentError, 'Grayscale should be a boolean' unless [true, false].include?(grayscale)
 
         "https://www.fillmurray.com#{'/g' if grayscale == true}/#{width}/#{height}"

--- a/lib/faker/default/hipster.rb
+++ b/lib/faker/default/hipster.rb
@@ -14,7 +14,7 @@ module Faker
       # @faker.version 1.6.0
       def word
         random_word = sample(translate('faker.hipster.words'))
-        random_word =~ /\s/ ? word : random_word
+        /\s/.match?(random_word) ? word : random_word
       end
 
       ##
@@ -51,7 +51,7 @@ module Faker
         return shuffle(word_list)[0, resolved_num] if spaces_allowed
 
         words = shuffle(word_list)[0, resolved_num]
-        words.each_with_index { |w, i| words[i] = word if w =~ /\s/ }
+        words.each_with_index { |w, i| words[i] = word if /\s/.match?(w) }
       end
 
       ##

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -48,7 +48,7 @@ module Faker
       def ssn_valid
         ssn = regexify(/[0-8]\d{2}-\d{2}-\d{4}/)
         # We could still have all 0s in one segment or another
-        INVALID_SSN.any? { |regex| regex =~ ssn } ? ssn_valid : ssn
+        INVALID_SSN.any? { |regex| regex.match?(ssn) } ? ssn_valid : ssn
       end
 
       ##
@@ -151,7 +151,7 @@ module Faker
           keywords << :formatted if legacy_formatted != NOT_GIVEN
         end
 
-        digits = Faker::Number.leading_zero_number(digits: 9) until digits&.match(/(\d)((?!\1)\d)+/)
+        digits = Faker::Number.leading_zero_number(digits: 9) until digits&.match?(/(\d)((?!\1)\d)+/)
         first_digit = brazilian_citizen_number_checksum_digit(digits)
         second_digit = brazilian_citizen_number_checksum_digit(digits + first_digit)
         number = [digits, first_digit, second_digit].join

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -127,7 +127,7 @@ module Faker
         if mix_case
           alpha_count = 0
           temp.chars.each_with_index do |char, index|
-            if char =~ /[[:alpha:]]/
+            if /[[:alpha:]]/.match?(char)
               temp[index] = char.upcase if alpha_count.even?
               alpha_count += 1
             end
@@ -229,7 +229,7 @@ module Faker
       end
 
       def private_net_checker
-        ->(addr) { private_nets_regex.any? { |net| net =~ addr } }
+        ->(addr) { private_nets_regex.any? { |net| net.match?(addr) } }
       end
 
       def reserved_nets_regex
@@ -245,7 +245,7 @@ module Faker
       end
 
       def reserved_net_checker
-        ->(addr) { (private_nets_regex + reserved_nets_regex).any? { |net| net =~ addr } }
+        ->(addr) { (private_nets_regex + reserved_nets_regex).any? { |net| net.match?(addr) } }
       end
 
       def ip_v4_cidr

--- a/lib/faker/default/invoice.rb
+++ b/lib/faker/default/invoice.rb
@@ -92,7 +92,7 @@ module Faker
       def iban_checksum(country_code, account)
         # Converts letters to numbers according the iban rules, A=10..Z=35
         account_to_number = "#{account}#{country_code}00".upcase.chars.map do |d|
-          d =~ /[A-Z]/ ? (d.ord - 55).to_s : d
+          /[A-Z]/.match?(d) ? (d.ord - 55).to_s : d
         end.join.to_i
 
         # This is answer to (iban_to_num + checksum) % 97 == 1

--- a/lib/faker/default/lorem_flickr.rb
+++ b/lib/faker/default/lorem_flickr.rb
@@ -129,7 +129,7 @@ module Faker
       private
 
       def build_url(size, format, search_terms, match_all)
-        raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
+        raise ArgumentError, 'Size should be specified in format 300x300' unless /^[0-9]+x[0-9]+$/.match?(size)
 
         url_parts = ['https://loremflickr.com']
         url_parts << format

--- a/lib/faker/default/lorem_pixel.rb
+++ b/lib/faker/default/lorem_pixel.rb
@@ -50,7 +50,7 @@ module Faker
           keywords << :secure if legacy_secure != NOT_GIVEN
         end
 
-        raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
+        raise ArgumentError, 'Size should be specified in format 300x300' unless /^[0-9]+x[0-9]+$/.match?(size)
         raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
         raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?
         raise ArgumentError, 'Number must be between 1 and 10' unless number.nil? || (1..10).cover?(number)

--- a/lib/faker/default/placeholdit.rb
+++ b/lib/faker/default/placeholdit.rb
@@ -40,10 +40,10 @@ module Faker
         background_color = generate_color if background_color == :random
         text_color = generate_color if text_color == :random
 
-        raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
+        raise ArgumentError, 'Size should be specified in format 300x300' unless /^[0-9]+x[0-9]+$/.match?(size)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
-        raise ArgumentError, "background_color must be a hex value without '#'" unless background_color.nil? || background_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
-        raise ArgumentError, "text_color must be a hex value without '#'" unless text_color.nil? || text_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
+        raise ArgumentError, "background_color must be a hex value without '#'" unless background_color.nil? || /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/.match?(background_color)
+        raise ArgumentError, "text_color must be a hex value without '#'" unless text_color.nil? || /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/.match?(text_color)
 
         image_url = "https://placehold.it/#{size}.#{format}"
         image_url += "/#{background_color}" if background_color

--- a/test/faker/blockchain/test_bitcoin.rb
+++ b/test/faker/blockchain/test_bitcoin.rb
@@ -4,7 +4,7 @@ require_relative '../../test_helper'
 
 class TestFakerBitcoin < Test::Unit::TestCase
   def test_address
-    assert Faker::Blockchain::Bitcoin.address.match(/^[13][1-9A-Za-z][^OIl]{20,40}/)
+    assert Faker::Blockchain::Bitcoin.address.match?(/^[13][1-9A-Za-z][^OIl]{20,40}/)
   end
 
   def test_deterministic_address

--- a/test/faker/blockchain/test_ethereum.rb
+++ b/test/faker/blockchain/test_ethereum.rb
@@ -8,6 +8,6 @@ class TestFakerEthereum < Test::Unit::TestCase
   end
 
   def test_address
-    assert @tester.address.match(/0x([a-fA-F0-9]{40})/)
+    assert @tester.address.match?(/0x([a-fA-F0-9]{40})/)
   end
 end

--- a/test/faker/blockchain/test_tezos.rb
+++ b/test/faker/blockchain/test_tezos.rb
@@ -4,23 +4,23 @@ require_relative '../../test_helper'
 
 class TestFakerTezos < Test::Unit::TestCase
   def test_contract
-    assert Faker::Blockchain::Tezos.contract.match(/^KT1[1-9A-Za-z][^OIl]{20,40}/)
+    assert Faker::Blockchain::Tezos.contract.match?(/^KT1[1-9A-Za-z][^OIl]{20,40}/)
   end
 
   def test_account
-    assert Faker::Blockchain::Tezos.account.match(/^tz1[1-9A-Za-z][^OIl]{20,40}/)
+    assert Faker::Blockchain::Tezos.account.match?(/^tz1[1-9A-Za-z][^OIl]{20,40}/)
   end
 
   def test_operation
-    assert Faker::Blockchain::Tezos.operation.match(/^o[1-9A-Za-z][^OIl]{20,40}/)
+    assert Faker::Blockchain::Tezos.operation.match?(/^o[1-9A-Za-z][^OIl]{20,40}/)
   end
 
   def test_block
-    assert Faker::Blockchain::Tezos.block.match(/^B[1-9A-Za-z][^OIl]{20,40}/)
+    assert Faker::Blockchain::Tezos.block.match?(/^B[1-9A-Za-z][^OIl]{20,40}/)
   end
 
   def test_signature
-    assert Faker::Blockchain::Tezos.signature.match(/^edsig[1-9A-Za-z][^OIl]{20,40}/)
+    assert Faker::Blockchain::Tezos.signature.match?(/^edsig[1-9A-Za-z][^OIl]{20,40}/)
   end
 
   def test_deterministic_contract

--- a/test/faker/books/test_book.rb
+++ b/test/faker/books/test_book.rb
@@ -8,18 +8,18 @@ class TestFakerBook < Test::Unit::TestCase
   end
 
   def test_title
-    assert @tester.title.match(/(\w+\.? ?){2,3}/)
+    assert @tester.title.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_author
-    assert @tester.author.match(/(\w+\.? ?){2,3}/)
+    assert @tester.author.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_publisher
-    assert @tester.publisher.match(/(\w+\.? ?){2,3}/)
+    assert @tester.publisher.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_genre
-    assert @tester.genre.match(/(\w+\.? ?){2,3}/)
+    assert @tester.genre.match?(/(\w+\.? ?){2,3}/)
   end
 end

--- a/test/faker/books/test_faker_culture_series.rb
+++ b/test/faker/books/test_faker_culture_series.rb
@@ -8,26 +8,26 @@ class TestFakerCultureSeries < Test::Unit::TestCase
   end
 
   def test_book
-    assert @tester.book.match(/\w+/)
+    assert @tester.book.match?(/\w+/)
   end
 
   def test_culture_ship
-    assert @tester.culture_ship.match(/\w+/)
+    assert @tester.culture_ship.match?(/\w+/)
   end
 
   def test_culture_ship_class
-    assert @tester.culture_ship_class.match(/\w+/)
+    assert @tester.culture_ship_class.match?(/\w+/)
   end
 
   def test_culture_ship_abv
-    assert @tester.culture_ship_class_abv.match(/\w+/)
+    assert @tester.culture_ship_class_abv.match?(/\w+/)
   end
 
   def test_civ
-    assert @tester.civ.match(/\w+/)
+    assert @tester.civ.match?(/\w+/)
   end
 
   def test_planet
-    assert @tester.planet.match(/\w+/)
+    assert @tester.planet.match?(/\w+/)
   end
 end

--- a/test/faker/books/test_faker_dune.rb
+++ b/test/faker/books/test_faker_dune.rb
@@ -8,24 +8,24 @@ class TestFakerDune < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_title
-    assert @tester.title.match(/\w+/)
+    assert @tester.title.match?(/\w+/)
   end
 
   def test_planet
-    assert @tester.planet.match(/\w+/)
+    assert @tester.planet.match?(/\w+/)
   end
 
   def test_random_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   # test good match
   def test_random_character_quote
-    assert @tester.quote(character: 'paul').match(/\w+/)
+    assert @tester.quote(character: 'paul').match?(/\w+/)
   end
 
   # test error on no match
@@ -36,12 +36,12 @@ class TestFakerDune < Test::Unit::TestCase
   end
 
   def test_random_saying
-    assert @tester.saying.match(/\w+/)
+    assert @tester.saying.match?(/\w+/)
   end
 
   # test good match
   def test_random_source_saying
-    assert @tester.saying(source: 'fremen').match(/\w+/)
+    assert @tester.saying(source: 'fremen').match?(/\w+/)
   end
 
   # test error on no match

--- a/test/faker/books/test_lovecraft.rb
+++ b/test/faker/books/test_lovecraft.rb
@@ -17,7 +17,7 @@ class TestFakerBooksLovecraft < Test::Unit::TestCase
   # Words should not return any word with spaces
   def test_words_without_spaces
     @words = @tester.words(number: 1000)
-    @words.each { |w| assert !w.match(/\s/) }
+    @words.each { |w| assert !w.match?(/\s/) }
   end
 
   # Faker::Lovecraft.word generates random word from wordlist
@@ -27,7 +27,7 @@ class TestFakerBooksLovecraft < Test::Unit::TestCase
 
   # Word should not return any word with spaces
   def test_word_without_spaces
-    1000.times { assert !@tester.word.match(/\s/) }
+    1000.times { assert !@tester.word.match?(/\s/) }
   end
 
   def test_exact_count_param
@@ -72,18 +72,18 @@ class TestFakerBooksLovecraft < Test::Unit::TestCase
   end
 
   def test_tome
-    assert @tester.tome.match(/\w/)
+    assert @tester.tome.match?(/\w/)
   end
 
   def test_location
-    assert @tester.location.match(/\w/)
+    assert @tester.location.match?(/\w/)
   end
 
   def test_deity
-    assert @tester.deity.match(/\w/)
+    assert @tester.deity.match?(/\w/)
   end
 
   def test_fhtagn
-    assert @tester.fhtagn.match(/\w/)
+    assert @tester.fhtagn.match?(/\w/)
   end
 end

--- a/test/faker/creature/test_faker_animal.rb
+++ b/test/faker/creature/test_faker_animal.rb
@@ -8,6 +8,6 @@ class TestFakerCreatureAnimal < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 end

--- a/test/faker/creature/test_faker_cat.rb
+++ b/test/faker/creature/test_faker_cat.rb
@@ -8,14 +8,14 @@ class TestFakerCat < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+\.?/)
+    assert @tester.name.match?(/\w+\.?/)
   end
 
   def test_breed
-    assert @tester.breed.match(/\w+\.?/)
+    assert @tester.breed.match?(/\w+\.?/)
   end
 
   def test_registry
-    assert @tester.registry.match(/\w+\.?/)
+    assert @tester.registry.match?(/\w+\.?/)
   end
 end

--- a/test/faker/creature/test_faker_dog.rb
+++ b/test/faker/creature/test_faker_dog.rb
@@ -8,34 +8,34 @@ class TestFakerDog < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+\.?/)
+    assert @tester.name.match?(/\w+\.?/)
   end
 
   def test_breed
-    assert @tester.breed.match(/\w+\.?/)
+    assert @tester.breed.match?(/\w+\.?/)
   end
 
   def test_sound
-    assert @tester.sound.match(/\w+\.?/)
+    assert @tester.sound.match?(/\w+\.?/)
   end
 
   def test_meme_phrase
-    assert @tester.meme_phrase.match(/\w+\.?/)
+    assert @tester.meme_phrase.match?(/\w+\.?/)
   end
 
   def test_age
-    assert @tester.age.match(/\w+\.?/)
+    assert @tester.age.match?(/\w+\.?/)
   end
 
   def test_gender
-    assert @tester.gender.match(/\w+\.?/)
+    assert @tester.gender.match?(/\w+\.?/)
   end
 
   def test_coat_length
-    assert @tester.coat_length.match(/\w+\.?/)
+    assert @tester.coat_length.match?(/\w+\.?/)
   end
 
   def test_size
-    assert @tester.size.match(/\w+\.?/)
+    assert @tester.size.match?(/\w+\.?/)
   end
 end

--- a/test/faker/creature/test_faker_horse.rb
+++ b/test/faker/creature/test_faker_horse.rb
@@ -8,10 +8,10 @@ class TestFakerHorse < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+\.?/)
+    assert @tester.name.match?(/\w+\.?/)
   end
 
   def test_breed
-    assert @tester.breed.match(/\w+\.?/)
+    assert @tester.breed.match?(/\w+\.?/)
   end
 end

--- a/test/faker/default/test_alphanum.rb
+++ b/test/faker/default/test_alphanum.rb
@@ -8,11 +8,11 @@ class TestFakerAlphanum < Test::Unit::TestCase
   end
 
   def alpha
-    assert @tester.alpha(number: 5).match(/[a-z]{5}/)
+    assert @tester.alpha(number: 5).match?(/[a-z]{5}/)
   end
 
   def alphanum
-    assert @tester.alphanumeric(number: 5).match(/[a-z0-9]{5}/)
+    assert @tester.alphanumeric(number: 5).match?(/[a-z0-9]{5}/)
   end
 
   def test_alphanumeric_invalid_min_alpha

--- a/test/faker/default/test_avatar.rb
+++ b/test/faker/default/test_avatar.rb
@@ -26,7 +26,7 @@ class TestFakerAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_supported_format
-    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg').match(%r{https:\/\/robohash\.org\/faker\.jpg})
+    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg').match?(%r{https:\/\/robohash\.org\/faker\.jpg})
   end
 
   def test_avatar_with_incorrect_format
@@ -36,10 +36,10 @@ class TestFakerAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_set
-    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg', set: 'set2').match(%r{https:\/\/robohash\.org\/faker\.jpg.*set=set2})
+    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg', set: 'set2').match?(%r{https:\/\/robohash\.org\/faker\.jpg.*set=set2})
   end
 
   def test_avatar_with_bgset
-    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg', set: 'set1', bgset: 'bg1').match(%r{https:\/\/robohash\.org\/faker\.jpg.*bgset=bg1})
+    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg', set: 'set1', bgset: 'bg1').match?(%r{https:\/\/robohash\.org\/faker\.jpg.*bgset=bg1})
   end
 end

--- a/test/faker/default/test_faker_address.rb
+++ b/test/faker/default/test_faker_address.rb
@@ -8,75 +8,75 @@ class TestFakerAddress < Test::Unit::TestCase
   end
 
   def test_city
-    assert @tester.city.match(/\w+/)
+    assert @tester.city.match?(/\w+/)
   end
 
   def test_city_with_state
-    assert @tester.city(options: { with_state: true }).match(/\w+,\s\w+/)
+    assert @tester.city(options: { with_state: true }).match?(/\w+,\s\w+/)
   end
 
   def test_street_name
-    assert @tester.street_name.match(/\w+\s\w+/)
+    assert @tester.street_name.match?(/\w+\s\w+/)
   end
 
   def test_street_address
-    assert @tester.street_address.match(/\d+\s\w+\s\w+/)
+    assert @tester.street_address.match?(/\d+\s\w+\s\w+/)
   end
 
   def test_secondary_address
-    assert @tester.secondary_address.match(/\w+\.?\s\d+/)
+    assert @tester.secondary_address.match?(/\w+\.?\s\d+/)
   end
 
   def test_building_number
-    assert @tester.building_number.match(/\d+/)
+    assert @tester.building_number.match?(/\d+/)
   end
 
   def test_mail_box
-    assert @tester.mail_box.match(/[\w ]+\d+/)
+    assert @tester.mail_box.match?(/[\w ]+\d+/)
   end
 
   def test_zip_code
-    assert @tester.zip_code.match(/^\d+-?\d*$/)
+    assert @tester.zip_code.match?(/^\d+-?\d*$/)
   end
 
   def test_time_zone
-    assert @tester.time_zone.match(%r{\w+\/\w+})
+    assert @tester.time_zone.match?(%r{\w+\/\w+})
   end
 
   def test_street_suffix
-    assert @tester.street_suffix.match(/\w+/)
+    assert @tester.street_suffix.match?(/\w+/)
   end
 
   def test_city_suffix
-    assert @tester.city_suffix.match(/\w+/)
+    assert @tester.city_suffix.match?(/\w+/)
   end
 
   def test_city_prefix
-    assert @tester.city_prefix.match(/\w+/)
+    assert @tester.city_prefix.match?(/\w+/)
   end
 
   def test_state_abbr
-    assert @tester.state_abbr.match(/[A-Z]{2}/)
+    assert @tester.state_abbr.match?(/[A-Z]{2}/)
   end
 
   def test_state
-    assert @tester.state.match(/\w+/)
+    assert @tester.state.match?(/\w+/)
   end
 
   def test_country
-    assert @tester.country.match(/\w+/)
+    assert @tester.country.match?(/\w+/)
   end
 
   def test_country_by_code
-    assert @tester.country_by_code(code: 'NL').match('Netherlands')
+    assert @tester.country_by_code(code: 'NL').match?('Netherlands')
   end
 
   def test_country_name_to_code
-    assert @tester.country_name_to_code(name: 'united_states').match('US')
+    assert @tester.country_name_to_code(name: 'united_states').match?('US')
   end
 
   def test_country_code
-    assert @tester.country_code.match(/[A-Z]{2}/)
+    assert @tester.country_code.match?(/[A-Z]{2}/)
   end
 
   def test_latitude
@@ -88,7 +88,7 @@ class TestFakerAddress < Test::Unit::TestCase
   end
 
   def test_full_address
-    assert @tester.full_address.match(/\w*\.?\s?\d*\s?\d+\s\w+\s\w+,\s\w+\s?\w*,\s[A-Z]{2}\s\d+/)
+    assert @tester.full_address.match?(/\w*\.?\s?\d*\s?\d+\s\w+\s\w+,\s\w+\s?\w*,\s[A-Z]{2}\s\d+/)
   end
 
   def test_full_address_as_hash

--- a/test/faker/default/test_faker_ancient.rb
+++ b/test/faker/default/test_faker_ancient.rb
@@ -8,18 +8,18 @@ class TestFakerAncient < Test::Unit::TestCase
   end
 
   def test_god
-    assert @tester.god.match(/\w+/)
+    assert @tester.god.match?(/\w+/)
   end
 
   def test_primordial
-    assert @tester.primordial.match(/\w+/)
+    assert @tester.primordial.match?(/\w+/)
   end
 
   def test_titan
-    assert @tester.titan.match(/\w+/)
+    assert @tester.titan.match?(/\w+/)
   end
 
   def test_hero
-    assert @tester.hero.match(/\w+/)
+    assert @tester.hero.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_app.rb
+++ b/test/faker/default/test_faker_app.rb
@@ -8,55 +8,55 @@ class TestFakerApp < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.author.match(/(\w+\.? ?){2,3}/)
+    assert @tester.author.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_basic_semantic_version
     10.times do |_digits|
       test_sem_vers = @tester.semantic_version.split('.')
-      assert test_sem_vers[0].match(/[0-9]{1}/)
-      assert test_sem_vers[1].match(/[0-9]{1}/)
-      assert test_sem_vers[2].match(/[1-9]{1}/)
+      assert test_sem_vers[0].match?(/[0-9]{1}/)
+      assert test_sem_vers[1].match?(/[0-9]{1}/)
+      assert test_sem_vers[2].match?(/[1-9]{1}/)
     end
   end
 
   def test_major_semantic_version
     10.times do |_digits|
       test_sem_vers = @tester.semantic_version(major: (1000..9999)).split('.')
-      assert test_sem_vers[0].match(/[0-9]{4}/)
-      assert test_sem_vers[1].match(/[0-9]{1}/)
-      assert test_sem_vers[2].match(/[1-9]{1}/)
+      assert test_sem_vers[0].match?(/[0-9]{4}/)
+      assert test_sem_vers[1].match?(/[0-9]{1}/)
+      assert test_sem_vers[2].match?(/[1-9]{1}/)
     end
   end
 
   def test_minor_semantic_version
     10.times do |_digits|
       test_sem_vers = @tester.semantic_version(minor: (1000..9999)).split('.')
-      assert test_sem_vers[0].match(/[0-9]{1}/)
-      assert test_sem_vers[1].match(/[0-9]{4}/)
-      assert test_sem_vers[2].match(/[1-9]{1}/)
+      assert test_sem_vers[0].match?(/[0-9]{1}/)
+      assert test_sem_vers[1].match?(/[0-9]{4}/)
+      assert test_sem_vers[2].match?(/[1-9]{1}/)
     end
   end
 
   def test_patch_semantic_version
     10.times do |_digits|
       test_sem_vers = @tester.semantic_version(patch: (1000..9999)).split('.')
-      assert test_sem_vers[0].match(/[0-9]{1}/)
-      assert test_sem_vers[1].match(/[0-9]{1}/)
-      assert test_sem_vers[2].match(/[0-9]{4}/)
+      assert test_sem_vers[0].match?(/[0-9]{1}/)
+      assert test_sem_vers[1].match?(/[0-9]{1}/)
+      assert test_sem_vers[2].match?(/[0-9]{4}/)
     end
   end
 
   def test_all_semantic_version
     10.times do |_digits|
       test_sem_vers = @tester.semantic_version(major: (1000..9999), minor: (1000..9999), patch: (1000..9999)).split('.')
-      assert test_sem_vers[0].match(/[0-9]{4}/)
-      assert test_sem_vers[1].match(/[0-9]{4}/)
-      assert test_sem_vers[2].match(/[0-9]{4}/)
+      assert test_sem_vers[0].match?(/[0-9]{4}/)
+      assert test_sem_vers[1].match?(/[0-9]{4}/)
+      assert test_sem_vers[2].match?(/[0-9]{4}/)
     end
   end
 
   def test_specific_major_version
-    assert @tester.semantic_version(major: 42).match(/42\.[0-9]\.[0-9]/)
+    assert @tester.semantic_version(major: 42).match?(/42\.[0-9]\.[0-9]/)
   end
 end

--- a/test/faker/default/test_faker_appliance.rb
+++ b/test/faker/default/test_faker_appliance.rb
@@ -8,10 +8,10 @@ class TestFakerAppliance < Test::Unit::TestCase
   end
 
   def test_brand
-    assert @tester.brand.match(/\w/)
+    assert @tester.brand.match?(/\w/)
   end
 
   def test_equipment
-    assert @tester.equipment.match(/\w/)
+    assert @tester.equipment.match?(/\w/)
   end
 end

--- a/test/faker/default/test_faker_artist.rb
+++ b/test/faker/default/test_faker_artist.rb
@@ -8,6 +8,6 @@ class TestFakerArtist < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_bank.rb
+++ b/test/faker/default/test_faker_bank.rb
@@ -17,33 +17,33 @@ class TestFakerBank < Test::Unit::TestCase
         9 * (routing_number[2].to_i + routing_number[5].to_i + routing_number[8].to_i)
     ) % 10
 
-    assert routing_number.match(/\d{9}/)
+    assert routing_number.match?(/\d{9}/)
     assert_equal(checksum, 0)
   end
 
   def test_routing_number_with_format
     fraction = Faker::Bank.routing_number_with_format
-    assert fraction.match(/\d{1,2}[-]\d{1,4}[\/]\d{1,4}/)
+    assert fraction.match?(/\d{1,2}[-]\d{1,4}[\/]\d{1,4}/)
   end
 
   def test_bsb_number
-    assert Faker::Bank.bsb_number.match(/\d{6}/)
+    assert Faker::Bank.bsb_number.match?(/\d{6}/)
   end
 
   def test_account_number
-    assert Faker::Bank.account_number.match(/\d{10}/)
+    assert Faker::Bank.account_number.match?(/\d{10}/)
 
-    assert Faker::Bank.account_number(digits: 12).match(/\d{12}/)
+    assert Faker::Bank.account_number(digits: 12).match?(/\d{12}/)
 
-    assert Faker::Bank.account_number(digits: 100).match(/\d{100}/)
+    assert Faker::Bank.account_number(digits: 100).match?(/\d{100}/)
   end
 
   def test_name
-    assert @tester.name.match(/(\w+\.? ?){2,3}/)
+    assert @tester.name.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_swift_bic
-    assert @tester.swift_bic.match(/(\w+\.? ?){2,3}/)
+    assert @tester.swift_bic.match?(/(\w+\.? ?){2,3}/)
   end
 
   # This test makes sure there are no collissions in BIC number pool
@@ -56,308 +56,308 @@ class TestFakerBank < Test::Unit::TestCase
   end
 
   def test_iban_default
-    assert @tester.iban.match(/[A-Z]{4}\d{14}/)
+    assert @tester.iban.match?(/[A-Z]{4}\d{14}/)
   end
 
   # Andorra
   def test_iban_ad
     account = @tester.iban(country_code: 'ad')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{12}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{12}$/)
   end
 
   # United Arab Emirates
   def test_iban_ae
     account = @tester.iban(country_code: 'ae')
     assert account.length == 23
-    assert account.match(/^#{IBAN_HEADER}\d{19}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{19}$/)
   end
 
   # Albania
   def test_iban_al
     account = @tester.iban(country_code: 'al')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
   end
 
   # Austria
   def test_iban_at
     account = @tester.iban(country_code: 'at')
     assert account.length == 20
-    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{16}$/)
   end
 
   # Azerbaijan, Republic of
   def test_iban_az
     account = @tester.iban(country_code: 'az')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{20}$/)
   end
 
   # Bosnia
   def test_iban_ba
     account = @tester.iban(country_code: 'ba')
     assert account.length == 20
-    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{16}$/)
   end
 
   # Belgium
   def test_iban_be
     account = @tester.iban(country_code: 'be')
     assert account.length == 16
-    assert account.match(/^#{IBAN_HEADER}\d{12}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{12}$/)
   end
 
   # Bulgaria
   def test_iban_bg
     account = @tester.iban(country_code: 'bg')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{6}[A-Z0-9]{8}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{6}[A-Z0-9]{8}$/)
   end
 
   # Bahrain
   def test_iban_bh
     account = @tester.iban(country_code: 'bh')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{14}$/)
   end
 
   # Brazil
   def test_iban_br
     account = @tester.iban(country_code: 'br')
     assert account.length == 29
-    assert account.match(/^#{IBAN_HEADER}[0-9]{8}[0-9]{5}[0-9]{10}[A-Z]{1}[A-Z0-9]{1}$/)
+    assert account.match?(/^#{IBAN_HEADER}[0-9]{8}[0-9]{5}[0-9]{10}[A-Z]{1}[A-Z0-9]{1}$/)
   end
 
   # Switzerland
   def test_iban_ch
     account = @tester.iban(country_code: 'ch')
     assert account.length == 21
-    assert account.match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/)
   end
 
   # Costa Rica
   def test_iban_cr
     account = @tester.iban(country_code: 'cr')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}0\d{3}\d{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}0\d{3}\d{14}$/)
   end
 
   # Cyprus
   def test_iban_cy
     account = @tester.iban(country_code: 'cy')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
   end
 
   # Czech Republic
   def test_iban_cz
     account = @tester.iban(country_code: 'cz')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{20}$/)
   end
 
   # Germany
   def test_iban_de
     account = @tester.iban(country_code: 'de')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}\d{18}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{18}$/)
   end
 
   # Denmark
   def test_iban_dk
     account = @tester.iban(country_code: 'dk')
     assert account.length == 18
-    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{14}$/)
   end
 
   # Dominican Republic
   def test_iban_do
     account = @tester.iban(country_code: 'do')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{20}$/)
   end
 
   # Estonia
   def test_iban_ee
     account = @tester.iban(country_code: 'ee')
     assert account.length == 20
-    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{16}$/)
   end
 
   # Spain
   def test_iban_es
     account = @tester.iban(country_code: 'es')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{20}$/)
   end
 
   # Finland
   def test_iban_fi
     account = @tester.iban(country_code: 'fi')
     assert account.length == 18
-    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{14}$/)
   end
 
   # Faroe Islands
   def test_iban_fo
     account = @tester.iban(country_code: 'fo')
     assert account.length == 18
-    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{14}$/)
   end
 
   # France
   def test_iban_fr
     account = @tester.iban(country_code: 'fr')
     assert account.length == 27
-    assert account.match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/)
   end
 
   # United Kingdom
   def test_iban_gb
     account = @tester.iban(country_code: 'gb')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/)
   end
 
   # Georgia
   def test_iban_ge
     account = @tester.iban(country_code: 'ge')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{2}\d{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{2}\d{16}$/)
   end
 
   # Gibraltar
   def test_iban_gi
     account = @tester.iban(country_code: 'gi')
     assert account.length == 23
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{15}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{15}$/)
   end
 
   # Greenland
   def test_iban_gl
     account = @tester.iban(country_code: 'gl')
     assert account.length == 18
-    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{14}$/)
   end
 
   # Greece
   def test_iban_gr
     account = @tester.iban(country_code: 'gr')
     assert account.length == 27
-    assert account.match(/^#{IBAN_HEADER}\d{7}[A-Z0-9]{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{7}[A-Z0-9]{16}$/)
   end
 
   # Guatemala
   def test_iban_gt
     account = @tester.iban(country_code: 'gt')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}[A-Z0-9]{4}\d{2}\d{2}[A-Z0-9]{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z0-9]{4}\d{2}\d{2}[A-Z0-9]{16}$/)
   end
 
   # Croatia
   def test_iban_hr
     account = @tester.iban(country_code: 'hr')
     assert account.length == 21
-    assert account.match(/^#{IBAN_HEADER}\d{17}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{17}$/)
   end
 
   # Hungary
   def test_iban_hu
     account = @tester.iban(country_code: 'hu')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}\d{24}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{24}$/)
   end
 
   # Ireland
   def test_iban_ie
     account = @tester.iban(country_code: 'ie')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/)
   end
 
   # Israel
   def test_iban_il
     account = @tester.iban(country_code: 'il')
     assert account.length == 23
-    assert account.match(/^#{IBAN_HEADER}\d{19}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{19}$/)
   end
 
   # Iceland
   def test_iban_is
     account = @tester.iban(country_code: 'is')
     assert account.length == 26
-    assert account.match(/^#{IBAN_HEADER}\d{22}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{22}$/)
   end
 
   # Italy
   def test_iban_it
     account = @tester.iban(country_code: 'it')
     assert account.length == 27
-    assert account.match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/)
   end
 
   # Kuwait
   def test_iban_kw
     account = @tester.iban(country_code: 'kw')
     assert account.length == 30
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{22}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{22}$/)
   end
 
   # Kazakhstan
   def test_iban_kz
     account = @tester.iban(country_code: 'kz')
     assert account.length == 20
-    assert account.match(/^#{IBAN_HEADER}[0-9]{3}[A-Z0-9]{13}$/)
+    assert account.match?(/^#{IBAN_HEADER}[0-9]{3}[A-Z0-9]{13}$/)
   end
 
   # Lebanon
   def test_iban_lb
     account = @tester.iban(country_code: 'lb')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}\d{4}[A-Z0-9]{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{4}[A-Z0-9]{20}$/)
   end
 
   # Liechtenstein
   def test_iban_li
     account = @tester.iban(country_code: 'li')
     assert account.length == 21
-    assert account.match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/)
   end
 
   # Lithuania
   def test_iban_lt
     account = @tester.iban(country_code: 'lt')
     assert account.length == 20
-    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{16}$/)
   end
 
   # Luxembourg
   def test_iban_lu
     account = @tester.iban(country_code: 'lu')
     assert account.length == 20
-    assert account.match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{13}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{13}$/)
   end
 
   # Latvia
   def test_iban_lv
     account = @tester.iban(country_code: 'lv')
     assert account.length == 21
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{13}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{13}$/)
   end
 
   # Monaco
   def test_iban_mc
     account = @tester.iban(country_code: 'mc')
     assert account.length == 27
-    assert account.match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/)
   end
 
   # Moldova
   def test_iban_md
     account = @tester.iban(country_code: 'md')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{2}[A-Z0-9]{18}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{2}[A-Z0-9]{18}$/)
   end
 
   # Montenegro
@@ -365,175 +365,175 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'me')
 
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}\d{18}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{18}$/)
   end
 
   # Macedonia
   def test_iban_mk
     account = @tester.iban(country_code: 'mk')
     assert account.length == 19
-    assert account.match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{10}\d{2}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{10}\d{2}$/)
   end
 
   # Mauritania
   def test_iban_mr
     account = @tester.iban(country_code: 'mr')
     assert account.length == 27
-    assert account.match(/^#{IBAN_HEADER}\d{23}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{23}$/)
   end
 
   # Malta
   def test_iban_mt
     account = @tester.iban(country_code: 'mt')
     assert account.length == 31
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{5}[A-Z0-9]{18}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{5}[A-Z0-9]{18}$/)
   end
 
   # Mauritius
   def test_iban_mu
     account = @tester.iban(country_code: 'mu')
     assert account.length == 30
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{19}[A-Z]{3}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{19}[A-Z]{3}$/)
   end
 
   # Netherlands
   def test_iban_nl
     account = @tester.iban(country_code: 'nl')
     assert account.length == 18
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{10}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{10}$/)
   end
 
   # Norway
   def test_iban_no
     account = @tester.iban(country_code: 'no')
     assert account.length == 15
-    assert account.match(/^#{IBAN_HEADER}\d{11}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{11}$/)
   end
 
   # Pakistan
   def test_iban_pk
     account = @tester.iban(country_code: 'pk')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/)
   end
 
   # Poland
   def test_iban_pl
     account = @tester.iban(country_code: 'pl')
     assert account.length == 28
-    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
   end
 
   # Palestinian Territory, Occupied
   def test_iban_ps
     account = @tester.iban(country_code: 'ps')
     assert account.length == 29
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/)
   end
 
   # Portugal
   def test_iban_pt
     account = @tester.iban(country_code: 'pt')
     assert account.length == 25
-    assert account.match(/^#{IBAN_HEADER}\d{21}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{21}$/)
   end
 
   # Qatar
   def test_iban_qa
     account = @tester.iban(country_code: 'qa')
     assert account.length == 29
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/)
   end
 
   # Romania
   def test_iban_ro
     account = @tester.iban(country_code: 'ro')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/)
   end
 
   # Serbia
   def test_iban_rs
     account = @tester.iban(country_code: 'rs')
     assert account.length == 22
-    assert account.match(/^#{IBAN_HEADER}\d{18}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{18}$/)
   end
 
   # Saudi Arabia
   def test_iban_sa
     account = @tester.iban(country_code: 'sa')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}\d{2}[A-Z0-9]{18}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{2}[A-Z0-9]{18}$/)
   end
 
   # Sweden
   def test_iban_se
     account = @tester.iban(country_code: 'se')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{20}$/)
   end
 
   # Slovenia
   def test_iban_si
     account = @tester.iban(country_code: 'si')
     assert account.length == 19
-    assert account.match(/^#{IBAN_HEADER}\d{15}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{15}$/)
   end
 
   # Slovakia
   def test_iban_sk
     account = @tester.iban(country_code: 'sk')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{20}$/)
   end
 
   # San Marino
   def test_iban_sm
     account = @tester.iban(country_code: 'sm')
     assert account.length == 27
-    assert account.match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/)
   end
 
   # Timor-Leste
   def test_iban_tl
     account = @tester.iban(country_code: 'tl')
     assert account.length == 23
-    assert account.match(/^#{IBAN_HEADER}\d{19}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{19}$/)
   end
 
   # Tunisia
   def test_iban_tn
     account = @tester.iban(country_code: 'tn')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{20}$/)
   end
 
   # Turkey
   def test_iban_tr
     account = @tester.iban(country_code: 'tr')
     assert account.length == 26
-    assert account.match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{17}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{17}$/)
   end
 
   # Ukraine
   def test_iban_ua
     account = @tester.iban(country_code: 'ua')
     assert account.length == 29
-    assert account.match(/^#{IBAN_HEADER}\d{25}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{25}$/)
   end
 
   # Virgin Islands, British
   def test_iban_vg
     account = @tester.iban(country_code: 'vg')
     assert account.length == 24
-    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}[A-Z]{4}\d{16}$/)
   end
 
   # Kosovo, Republic of
   def test_iban_xk
     account = @tester.iban(country_code: 'xk')
     assert account.length == 20
-    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+    assert account.match?(/^#{IBAN_HEADER}\d{16}$/)
   end
 
   def test_iban_invalid

--- a/test/faker/default/test_faker_beer.rb
+++ b/test/faker/default/test_faker_beer.rb
@@ -8,38 +8,38 @@ class TestFakerBeer < Test::Unit::TestCase
   end
 
   def test_brand
-    assert @tester.brand.match(/(\w+\.? ?){2,3}/)
+    assert @tester.brand.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_name
-    assert @tester.name.match(/(\w+\.? ?){2,3}/)
+    assert @tester.name.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_style
-    assert @tester.style.match(/(\w+\.? ?){2,3}/) # TODO
+    assert @tester.style.match?(/(\w+\.? ?){2,3}/) # TODO
   end
 
   def test_hop
-    assert @tester.hop.match(/(\w+\.? ?){2,3}/)
+    assert @tester.hop.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_yeast
-    assert @tester.yeast.match(/(\w+\.? ?){2,3}/)
+    assert @tester.yeast.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_malts
-    assert @tester.malts.match(/(\w+\.? ?){2,3}/)
+    assert @tester.malts.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_ibu
-    assert @tester.ibu.match(/(\w+\.? ?){2,3}/)
+    assert @tester.ibu.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_alcohol
-    assert @tester.alcohol.match(/(\w+\.? ?){2,3}/)
+    assert @tester.alcohol.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_blg
-    assert @tester.blg.match(/(\w+\.? ?){2,3}/)
+    assert @tester.blg.match?(/(\w+\.? ?){2,3}/)
   end
 end

--- a/test/faker/default/test_faker_blood.rb
+++ b/test/faker/default/test_faker_blood.rb
@@ -8,14 +8,14 @@ class TestFakerBlood < Test::Unit::TestCase
   end
 
   def test_type
-    assert @tester.type.match(/^(AB|A|B|O)$/)
+    assert @tester.type.match?(/^(AB|A|B|O)$/)
   end
 
   def test_rh_factor
-    assert @tester.rh_factor.match(/[+-]/)
+    assert @tester.rh_factor.match?(/[+-]/)
   end
 
   def test_group
-    assert @tester.group.match(/^(AB|A|B|O)[+-]$/)
+    assert @tester.group.match?(/^(AB|A|B|O)[+-]$/)
   end
 end

--- a/test/faker/default/test_faker_bossa_nova.rb
+++ b/test/faker/default/test_faker_bossa_nova.rb
@@ -8,10 +8,10 @@ class TestFakerBossaNova < Test::Unit::TestCase
   end
 
   def test_artists
-    assert @tester.artist.match(/\w+/)
+    assert @tester.artist.match?(/\w+/)
   end
 
   def test_songs
-    assert @tester.song.match(/\w+/)
+    assert @tester.song.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_cannabis.rb
+++ b/test/faker/default/test_faker_cannabis.rb
@@ -8,43 +8,43 @@ class TestFakerCannabis < Test::Unit::TestCase
   end
 
   def test_strain
-    10.times { assert Faker::Cannabis.strain.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.strain.match?(/[\w]+/) }
   end
 
   def test_cannabinoid_abbreviation
-    10.times { assert Faker::Cannabis.cannabinoid_abbreviation.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.cannabinoid_abbreviation.match?(/[\w]+/) }
   end
 
   def test_cannabinoid
-    10.times { assert Faker::Cannabis.cannabinoid.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.cannabinoid.match?(/[\w]+/) }
   end
 
   def test_terpene
-    10.times { assert Faker::Cannabis.terpene.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.terpene.match?(/[\w]+/) }
   end
 
   def test_medical_use
-    10.times { assert Faker::Cannabis.medical_use.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.medical_use.match?(/[\w]+/) }
   end
 
   def test_health_benefit
-    10.times { assert Faker::Cannabis.health_benefit.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.health_benefit.match?(/[\w]+/) }
   end
 
   def test_category
-    10.times { assert Faker::Cannabis.category.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.category.match?(/[\w]+/) }
   end
 
   def test_type
-    10.times { assert Faker::Cannabis.type.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.type.match?(/[\w]+/) }
   end
 
   def test_buzzword
-    10.times { assert Faker::Cannabis.buzzword.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.buzzword.match?(/[\w]+/) }
   end
 
   def test_brand
-    10.times { assert Faker::Cannabis.brand.match(/[\w]+/) }
+    10.times { assert Faker::Cannabis.brand.match?(/[\w]+/) }
   end
 
   def test_locales

--- a/test/faker/default/test_faker_chuck_norris.rb
+++ b/test/faker/default/test_faker_chuck_norris.rb
@@ -8,6 +8,6 @@ class TestFakerChuckNorris < Test::Unit::TestCase
   end
 
   def test_fact
-    assert @tester.fact.match(/.*chuck.*/i)
+    assert @tester.fact.match?(/.*chuck.*/i)
   end
 end

--- a/test/faker/default/test_faker_code.rb
+++ b/test/faker/default/test_faker_code.rb
@@ -8,7 +8,7 @@ class TestFakerCode < Test::Unit::TestCase
   end
 
   def test_npi_regexp
-    assert @tester.npi.match(/[0-9]{10}/)
+    assert @tester.npi.match?(/[0-9]{10}/)
   end
 
   def test_deterministic_npi
@@ -20,35 +20,35 @@ class TestFakerCode < Test::Unit::TestCase
   end
 
   def test_default_isbn_regexp
-    assert @tester.isbn.match(/^\d{9}-[\d|X]$/)
+    assert @tester.isbn.match?(/^\d{9}-[\d|X]$/)
   end
 
   def test_default_isbn13_regexp
-    assert @tester.isbn(base: 13).match(/^\d{12}-\d$/)
+    assert @tester.isbn(base: 13).match?(/^\d{12}-\d$/)
   end
 
   def test_default_ean_regexp
-    assert @tester.ean.match(/^\d{13}$/)
+    assert @tester.ean.match?(/^\d{13}$/)
   end
 
   def test_default_ean8_regexp
-    assert @tester.ean(base: 8).match(/^\d{8}$/)
+    assert @tester.ean(base: 8).match?(/^\d{8}$/)
   end
 
   def test_rut
-    assert @tester.rut.match(/^\d{1,8}-(\d|k)$/)
+    assert @tester.rut.match?(/^\d{1,8}-(\d|k)$/)
   end
 
   def test_asin
-    assert @tester.asin.match(/^B000([A-Z]|\d){6}$/)
+    assert @tester.asin.match?(/^B000([A-Z]|\d){6}$/)
   end
 
   def test_nric
-    assert @tester.nric.match(/^(S|T)\d{7}[A-JZ]$/)
+    assert @tester.nric.match?(/^(S|T)\d{7}[A-JZ]$/)
   end
 
   def test_imei_regexp
-    assert @tester.imei.match(/\A[\d\.\:\-\s]+\z/i)
+    assert @tester.imei.match?(/\A[\d\.\:\-\s]+\z/i)
   end
 
   def test_imei_luhn_value
@@ -56,7 +56,7 @@ class TestFakerCode < Test::Unit::TestCase
   end
 
   def test_sin
-    assert @tester.sin.match(/\d{9}/)
+    assert @tester.sin.match?(/\d{9}/)
     assert @tester.sin.length == 9
     assert luhn_checksum_valid(@tester.sin)
   end

--- a/test/faker/default/test_faker_coffee.rb
+++ b/test/faker/default/test_faker_coffee.rb
@@ -40,7 +40,7 @@ class TestFakerCoffee < Test::Unit::TestCase
   end
 
   def test_variety
-    assert @tester.variety.match(/\w+\.?/)
+    assert @tester.variety.match?(/\w+\.?/)
 
     assert @varieties.include?(@tester.variety)
   end

--- a/test/faker/default/test_faker_coin.rb
+++ b/test/faker/default/test_faker_coin.rb
@@ -8,10 +8,10 @@ class TestFakerCoin < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 
   def test_flip
-    assert @tester.flip.match(/\w+/)
+    assert @tester.flip.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_color.rb
+++ b/test/faker/default/test_faker_color.rb
@@ -8,11 +8,11 @@ class TestFakerColor < Test::Unit::TestCase
   end
 
   def test_color_name
-    assert @tester.color_name.match(/[a-z]+\.?/)
+    assert @tester.color_name.match?(/[a-z]+\.?/)
   end
 
   def test_hex_color
-    assert @tester.hex_color.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
+    assert @tester.hex_color.match?(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
   end
 
   def test_single_rgb_color

--- a/test/faker/default/test_faker_commerce.rb
+++ b/test/faker/default/test_faker_commerce.rb
@@ -8,19 +8,19 @@ class TestFakerCommerce < Test::Unit::TestCase
   end
 
   def test_color
-    assert @tester.color.match(/[a-z]+\.?/)
+    assert @tester.color.match?(/[a-z]+\.?/)
   end
 
   def test_promotion_code
-    assert @tester.promotion_code.match(/[A-Z][a-z]+[A-Z][a-z]+\d{6}/)
+    assert @tester.promotion_code.match?(/[A-Z][a-z]+[A-Z][a-z]+\d{6}/)
   end
 
   def test_promotion_code_should_have_specified_number_of_digits
-    assert @tester.promotion_code(digits: 3).match(/[A-Z][a-z]+[A-Z][a-z]+\d{3}/)
+    assert @tester.promotion_code(digits: 3).match?(/[A-Z][a-z]+[A-Z][a-z]+\d{3}/)
   end
 
   def test_department
-    assert @tester.department.match(/[A-Z][a-z]+\.?/)
+    assert @tester.department.match?(/[A-Z][a-z]+\.?/)
   end
 
   def test_single_department_should_not_contain_separators
@@ -68,11 +68,11 @@ class TestFakerCommerce < Test::Unit::TestCase
   end
 
   def test_product_name
-    assert @tester.product_name.match(/[A-Z][a-z]+\.?/)
+    assert @tester.product_name.match?(/[A-Z][a-z]+\.?/)
   end
 
   def test_material
-    assert @tester.material.match(/[A-Z][a-z]+\.?/)
+    assert @tester.material.match?(/[A-Z][a-z]+\.?/)
   end
 
   def test_price

--- a/test/faker/default/test_faker_company.rb
+++ b/test/faker/default/test_faker_company.rb
@@ -8,34 +8,34 @@ class TestFakerCompany < Test::Unit::TestCase
   end
 
   def test_ein
-    assert @tester.ein.match(/\d\d-\d\d\d\d\d\d\d/)
+    assert @tester.ein.match?(/\d\d-\d\d\d\d\d\d\d/)
   end
 
   def test_duns_number
-    assert @tester.duns_number.match(/\d\d-\d\d\d-\d\d\d\d/)
+    assert @tester.duns_number.match?(/\d\d-\d\d\d-\d\d\d\d/)
   end
 
   def test_logo
-    assert @tester.logo.match(%r{https://pigment.github.io/fake-logos/logos/medium/color/\d+\.png})
+    assert @tester.logo.match?(%r{https://pigment.github.io/fake-logos/logos/medium/color/\d+\.png})
   end
 
   def test_buzzword
-    assert @tester.buzzword.match(/\w+\.?/)
+    assert @tester.buzzword.match?(/\w+\.?/)
   end
 
   def test_type
-    assert @tester.type.match(/\w+/)
+    assert @tester.type.match?(/\w+/)
   end
 
   def test_spanish_organisation_number
     org_no = @tester.spanish_organisation_number
-    assert org_no.match(/\D\d{7}/)
+    assert org_no.match?(/\D\d{7}/)
     assert Faker::Base::ULetters.include?(org_no[0].to_s)
   end
 
   def test_swedish_organisation_number
     org_no = @tester.swedish_organisation_number
-    assert org_no.match(/\d{10}/)
+    assert org_no.match?(/\d{10}/)
     assert [1, 2, 3, 5, 6, 7, 8, 9].include?(org_no[0].to_i)
     assert org_no[2].to_i >= 2
     assert org_no[9] == @tester.send(:luhn_algorithm, org_no[0..8]).to_s
@@ -43,27 +43,27 @@ class TestFakerCompany < Test::Unit::TestCase
 
   def test_czech_organisation_number
     org_no = @tester.czech_organisation_number
-    assert org_no.match(/\d{8}/)
+    assert org_no.match?(/\d{8}/)
     assert [0, 1, 2, 3, 5, 6, 7, 8, 9].include?(org_no[0].to_i)
     assert czech_o_n_checksum(org_no) == org_no[-1].to_i
   end
 
   def test_french_siren_number
     siren = @tester.french_siren_number
-    assert siren.match(/\A\d{9}\z/)
+    assert siren.match?(/\A\d{9}\z/)
     assert siren[8] == @tester.send(:luhn_algorithm, siren[0..-2]).to_s
   end
 
   def test_french_siret_number
     siret = @tester.french_siret_number
-    assert siret.match(/\A\d{14}\z/)
+    assert siret.match?(/\A\d{14}\z/)
     assert siret[8] == @tester.send(:luhn_algorithm, siret[0..7]).to_s
     assert siret[13] == @tester.send(:luhn_algorithm, siret[0..-2]).to_s
   end
 
   def test_norwegian_organisation_number
     org_no = @tester.norwegian_organisation_number
-    assert org_no.match(/\d{9}/)
+    assert org_no.match?(/\d{9}/)
     assert [8, 9].include?(org_no[0].to_i)
     assert org_no[8] == @tester.send(:mod11, org_no[0..7]).to_s
   end
@@ -72,12 +72,12 @@ class TestFakerCompany < Test::Unit::TestCase
     abn = @tester.australian_business_number
     checksum = abn_checksum(abn)
 
-    assert abn.match(/\d{11}/)
+    assert abn.match?(/\d{11}/)
     assert((checksum % 89).zero?)
   end
 
   def test_profession
-    assert @tester.profession.match(/[a-z ]+\.?/)
+    assert @tester.profession.match?(/[a-z ]+\.?/)
   end
 
   def test_polish_taxpayer_identification_number
@@ -188,15 +188,15 @@ class TestFakerCompany < Test::Unit::TestCase
   end
 
   def test_russian_tax_number_default
-    assert @tester.russian_tax_number.match(/\d{10}/)
+    assert @tester.russian_tax_number.match?(/\d{10}/)
   end
 
   def test_russian_tax_number_individual
-    assert @tester.russian_tax_number(type: :individual).match(/\d{12}/)
+    assert @tester.russian_tax_number(type: :individual).match?(/\d{12}/)
   end
 
   def test_russian_tax_number_region
-    assert @tester.russian_tax_number(region: '77').match(/^77/)
+    assert @tester.russian_tax_number(region: '77').match?(/^77/)
   end
 
   def test_russian_tax_number_checksum
@@ -208,7 +208,7 @@ class TestFakerCompany < Test::Unit::TestCase
   end
 
   def test_sic_code
-    assert @tester.sic_code.match(/\d\d\d\d/)
+    assert @tester.sic_code.match?(/\d\d\d\d/)
   end
 
   private

--- a/test/faker/default/test_faker_compass.rb
+++ b/test/faker/default/test_faker_compass.rb
@@ -13,30 +13,30 @@ class TestFakerCompass < Test::Unit::TestCase
   end
 
   def test_cardinal
-    assert @tester.cardinal.match(@word_pattern)
+    assert @tester.cardinal.match?(@word_pattern)
   end
 
   def test_ordinal
-    assert @tester.ordinal.match(@word_pattern)
+    assert @tester.ordinal.match?(@word_pattern)
   end
 
   def test_half_wind
-    assert @tester.half_wind.match(@word_pattern)
+    assert @tester.half_wind.match?(@word_pattern)
   end
 
   def test_quarter_wind
-    assert @tester.quarter_wind.match(@multiword_pattern)
+    assert @tester.quarter_wind.match?(@multiword_pattern)
   end
 
   def test_direction
-    assert @tester.direction.match(@combined_pattern)
+    assert @tester.direction.match?(@combined_pattern)
   end
 
   def test_abbreviation
-    assert @tester.abbreviation.match(@letter_pattern)
+    assert @tester.abbreviation.match?(@letter_pattern)
   end
 
   def test_azimuth
-    assert @tester.azimuth.match(@number_pattern)
+    assert @tester.azimuth.match?(@number_pattern)
   end
 end

--- a/test/faker/default/test_faker_computer.rb
+++ b/test/faker/default/test_faker_computer.rb
@@ -9,11 +9,11 @@ class TestFakerComputer < Test::Unit::TestCase
   end
 
   def test_type
-    assert @tester.type.match(/\w+/)
+    assert @tester.type.match?(/\w+/)
   end
 
   def test_platform
-    assert @tester.platform.match(/(\w+ ?){1,3}/)
+    assert @tester.platform.match?(/(\w+ ?){1,3}/)
   end
 
   def test_stack

--- a/test/faker/default/test_faker_construction.rb
+++ b/test/faker/default/test_faker_construction.rb
@@ -8,27 +8,27 @@ class TestFakerConstruction < Test::Unit::TestCase
   end
 
   def test_material
-    assert Faker::Construction.material.match(/[\w]+/)
+    assert Faker::Construction.material.match?(/[\w]+/)
   end
 
   def test_heavy_equipment
-    assert Faker::Construction.heavy_equipment.match(/[\w]+/)
+    assert Faker::Construction.heavy_equipment.match?(/[\w]+/)
   end
 
   def test_trade
-    assert Faker::Construction.trade.match(/[\w]+/)
+    assert Faker::Construction.trade.match?(/[\w]+/)
   end
 
   def test_subcontract_category
-    assert Faker::Construction.subcontract_category.match(/[\w]+/)
+    assert Faker::Construction.subcontract_category.match?(/[\w]+/)
   end
 
   def test_standard_cost_code
-    assert Faker::Construction.standard_cost_code.match(/[\w]+/)
+    assert Faker::Construction.standard_cost_code.match?(/[\w]+/)
   end
 
   def test_role
-    assert Faker::Construction.role.match(/[\w]+/)
+    assert Faker::Construction.role.match?(/[\w]+/)
   end
 
   def test_locales

--- a/test/faker/default/test_faker_cosmere.rb
+++ b/test/faker/default/test_faker_cosmere.rb
@@ -8,38 +8,38 @@ class TestFakerCosmere < Test::Unit::TestCase
   end
 
   def test_aon
-    assert @tester.aon.match(/\w+\.?/)
+    assert @tester.aon.match?(/\w+\.?/)
   end
 
   def test_shard_world
-    assert @tester.shard_world.match(/\w+\.?/)
+    assert @tester.shard_world.match?(/\w+\.?/)
   end
 
   def test_shard
-    assert @tester.shard.match(/\w+\.?/)
+    assert @tester.shard.match?(/\w+\.?/)
   end
 
   def test_surge
-    assert @tester.surge.match(/\w+\.?/)
+    assert @tester.surge.match?(/\w+\.?/)
   end
 
   def test_knight_radiant
-    assert @tester.knight_radiant.match(/\w+\.?/)
+    assert @tester.knight_radiant.match?(/\w+\.?/)
   end
 
   def test_metal
-    assert @tester.metal.match(/\w+\.?/)
+    assert @tester.metal.match?(/\w+\.?/)
   end
 
   def test_allomancer
-    assert @tester.allomancer.match(/\w+\.?/)
+    assert @tester.allomancer.match?(/\w+\.?/)
   end
 
   def test_herald
-    assert @tester.herald.match(/\w+\.?/)
+    assert @tester.herald.match?(/\w+\.?/)
   end
 
   def test_spren
-    assert @tester.spren.match(/\w+\.?/)
+    assert @tester.spren.match?(/\w+\.?/)
   end
 end

--- a/test/faker/default/test_faker_crypto.rb
+++ b/test/faker/default/test_faker_crypto.rb
@@ -8,14 +8,14 @@ class TestFakerCrypto < Test::Unit::TestCase
   end
 
   def test_md5
-    assert @tester.md5.match(/\A[a-z0-9]{32}\z/)
+    assert @tester.md5.match?(/\A[a-z0-9]{32}\z/)
   end
 
   def test_sha1
-    assert @tester.sha1.match(/\A[a-z0-9]{40}\z/)
+    assert @tester.sha1.match?(/\A[a-z0-9]{40}\z/)
   end
 
   def test_sha256
-    assert @tester.sha256.match(/\A[a-z0-9]{64}\z/)
+    assert @tester.sha256.match?(/\A[a-z0-9]{64}\z/)
   end
 end

--- a/test/faker/default/test_faker_crypto_coin.rb
+++ b/test/faker/default/test_faker_crypto_coin.rb
@@ -16,22 +16,22 @@ class TestFakerCryptoCoin < Test::Unit::TestCase
   end
 
   def test_coin_name
-    assert @tester.coin_name.match(REGEX_COIN_NAME)
+    assert @tester.coin_name.match?(REGEX_COIN_NAME)
   end
 
   def test_acronym
-    assert @tester.acronym.match(REGEX_ACRONYM)
+    assert @tester.acronym.match?(REGEX_ACRONYM)
   end
 
   def test_url_logo
-    assert @tester.url_logo.match(REGEX_URL_LOGO)
+    assert @tester.url_logo.match?(REGEX_URL_LOGO)
   end
 
   def test_coin_array
     assert_kind_of Array, @tester.coin_array
-    assert @tester.coin_array[COIN_NAME].match(REGEX_COIN_NAME)
-    assert @tester.coin_array[ACRONYM].match(REGEX_ACRONYM)
-    assert @tester.coin_array[URL_LOGO].match(REGEX_URL_LOGO)
+    assert @tester.coin_array[COIN_NAME].match?(REGEX_COIN_NAME)
+    assert @tester.coin_array[ACRONYM].match?(REGEX_ACRONYM)
+    assert @tester.coin_array[URL_LOGO].match?(REGEX_URL_LOGO)
   end
 
   def test_coin_hash

--- a/test/faker/default/test_faker_currency.rb
+++ b/test/faker/default/test_faker_currency.rb
@@ -8,11 +8,11 @@ class TestFakerCurrency < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/[\w\' ]+/)
+    assert @tester.name.match?(/[\w\' ]+/)
   end
 
   def test_code
-    assert @tester.code.match(/[A-Z]{3}/)
+    assert @tester.code.match?(/[A-Z]{3}/)
   end
 
   def test_symbol

--- a/test/faker/default/test_faker_dc_comics.rb
+++ b/test/faker/default/test_faker_dc_comics.rb
@@ -8,22 +8,22 @@ class TestFakerDcComics < Test::Unit::TestCase
   end
 
   def test_hero
-    assert @tester.hero.match(/\w+/)
+    assert @tester.hero.match?(/\w+/)
   end
 
   def test_heroine
-    assert @tester.heroine.match(/\w+/)
+    assert @tester.heroine.match?(/\w+/)
   end
 
   def test_villain
-    assert @tester.villain.match(/\w+/)
+    assert @tester.villain.match?(/\w+/)
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 
   def test_title
-    assert @tester.title.match(/(\w+\.? ?){2,3}/)
+    assert @tester.title.match?(/(\w+\.? ?){2,3}/)
   end
 end

--- a/test/faker/default/test_faker_demographic.rb
+++ b/test/faker/default/test_faker_demographic.rb
@@ -8,19 +8,19 @@ class TestFakerDemographic < Test::Unit::TestCase
   end
 
   def test_race
-    assert @tester.race.match(/\w+/)
+    assert @tester.race.match?(/\w+/)
   end
 
   def test_educational_attainment
-    assert @tester.educational_attainment.match(/\w+/)
+    assert @tester.educational_attainment.match?(/\w+/)
   end
 
   def test_marital_status
-    assert @tester.marital_status.match(/\w+/)
+    assert @tester.marital_status.match?(/\w+/)
   end
 
   def test_demonym
-    assert @tester.demonym.match(/\w+/)
+    assert @tester.demonym.match?(/\w+/)
   end
 
   def test_sex
@@ -28,10 +28,10 @@ class TestFakerDemographic < Test::Unit::TestCase
   end
 
   def test_height_imperial
-    assert @tester.height(unit: :imperial).match(/\w+/)
+    assert @tester.height(unit: :imperial).match?(/\w+/)
   end
 
   def test_height_metric
-    assert @tester.height.match(/\w+/)
+    assert @tester.height.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_dessert.rb
+++ b/test/faker/default/test_faker_dessert.rb
@@ -8,14 +8,14 @@ class TestFakerDessert < Test::Unit::TestCase
   end
 
   def test_variety
-    assert @tester.variety.match(/\w+/)
+    assert @tester.variety.match?(/\w+/)
   end
 
   def test_topping
-    assert @tester.topping.match(/\w+/)
+    assert @tester.topping.match?(/\w+/)
   end
 
   def test_flavor
-    assert @tester.flavor.match(/\w+/)
+    assert @tester.flavor.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_device.rb
+++ b/test/faker/default/test_faker_device.rb
@@ -8,11 +8,11 @@ class TestFakerDevice < Test::Unit::TestCase
   end
 
   def test_model_name
-    assert @tester.model_name.match(/\w+/)
+    assert @tester.model_name.match?(/\w+/)
   end
 
   def test_platform
-    assert @tester.platform.match(/\w+/)
+    assert @tester.platform.match?(/\w+/)
   end
 
   def test_version
@@ -26,10 +26,10 @@ class TestFakerDevice < Test::Unit::TestCase
   end
 
   def test_manufacturer
-    assert @tester.manufacturer.match(/\w+/)
+    assert @tester.manufacturer.match?(/\w+/)
   end
 
   def test_serial
-    assert @tester.serial.match(/\w+/)
+    assert @tester.serial.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_educator.rb
+++ b/test/faker/default/test_faker_educator.rb
@@ -8,26 +8,26 @@ class TestFakerEducator < Test::Unit::TestCase
   end
 
   def test_university
-    assert @tester.university.match(/(\w+\.? ?){2,3}/)
+    assert @tester.university.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_degree
-    assert @tester.degree.match(/(\w+\.? ?\(?\)?){3,6}/)
+    assert @tester.degree.match?(/(\w+\.? ?\(?\)?){3,6}/)
   end
 
   def test_subject
-    assert @tester.subject.match(/(\w+\.? ?\(?\)?){1,3}/)
+    assert @tester.subject.match?(/(\w+\.? ?\(?\)?){1,3}/)
   end
 
   def test_course_name
-    assert @tester.course_name.match(/(\w+\.? ?\(?\)?){1,3} \d{3}/)
+    assert @tester.course_name.match?(/(\w+\.? ?\(?\)?){1,3} \d{3}/)
   end
 
   def test_secondary_school
-    assert @tester.secondary_school.match(/(\w+\.? ?){2,3}/)
+    assert @tester.secondary_school.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_campus
-    assert @tester.campus.match(/(\w+\.? ?){1,2}/)
+    assert @tester.campus.match?(/(\w+\.? ?){1,2}/)
   end
 end

--- a/test/faker/default/test_faker_electrical_components.rb
+++ b/test/faker/default/test_faker_electrical_components.rb
@@ -8,14 +8,14 @@ class TestFakerElectricalComponents < Test::Unit::TestCase
   end
 
   def test_active
-    assert @tester.active.match(/\w+/)
+    assert @tester.active.match?(/\w+/)
   end
 
   def test_passive
-    assert @tester.passive.match(/\w+/)
+    assert @tester.passive.match?(/\w+/)
   end
 
   def test_electromechanical
-    assert @tester.electromechanical.match(/\w+/)
+    assert @tester.electromechanical.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_esport.rb
+++ b/test/faker/default/test_faker_esport.rb
@@ -8,22 +8,22 @@ class TestFakerEsport < Test::Unit::TestCase
   end
 
   def test_team
-    assert @tester.team.match(/\w+/)
+    assert @tester.team.match?(/\w+/)
   end
 
   def test_league
-    assert @tester.league.match(/\w+/)
+    assert @tester.league.match?(/\w+/)
   end
 
   def test_game
-    assert @tester.game.match(/\w+/)
+    assert @tester.game.match?(/\w+/)
   end
 
   def test_player
-    assert @tester.player.match(/\w+/)
+    assert @tester.player.match?(/\w+/)
   end
 
   def test_event
-    assert @tester.event.match(/\w+/)
+    assert @tester.event.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_file.rb
+++ b/test/faker/default/test_faker_file.rb
@@ -8,26 +8,26 @@ class TestFakerFile < Test::Unit::TestCase
   end
 
   def test_extension
-    assert @tester.extension.match(/(flac|mp3|wav|bmp|gif|jpeg|jpg|png|tiff|css|csv|html|js|json|txt|mp4|avi|mov|webm|doc|docx|xls|xlsx|ppt|pptx|odt|ods|odp|pages|numbers|key|pdf)/)
+    assert @tester.extension.match?(/(flac|mp3|wav|bmp|gif|jpeg|jpg|png|tiff|css|csv|html|js|json|txt|mp4|avi|mov|webm|doc|docx|xls|xlsx|ppt|pptx|odt|ods|odp|pages|numbers|key|pdf)/)
   end
 
   def test_mime_type_format
-    assert @tester.mime_type.match(%r{(.*)\/(.*)+})
+    assert @tester.mime_type.match?(%r{(.*)\/(.*)+})
   end
 
   def test_file_name
     assert @tester
       .file_name
-      .match(%r{^([a-z\-_.]+)(\\|\/)([a-z\-_]+)\.([a-z]+)$})
+      .match?(%r{^([a-z\-_.]+)(\\|\/)([a-z\-_]+)\.([a-z]+)$})
   end
 
   def test_dir
-    assert @tester.dir.match(%r{^(([a-z\-_.]+)(\\|\/)){2}([a-z\-_.]+)$})
+    assert @tester.dir.match?(%r{^(([a-z\-_.]+)(\\|\/)){2}([a-z\-_.]+)$})
   end
 
   def test_dir_with_args
     assert @tester
       .dir(segment_count: 2, root: '\\root\\', directory_separator: '\\')
-      .match(%r{^\\root(\\([a-z\-_.]+)){2}$})
+      .match?(%r{^\\root(\\([a-z\-_.]+)){2}$})
   end
 end

--- a/test/faker/default/test_faker_fillmurray.rb
+++ b/test/faker/default/test_faker_fillmurray.rb
@@ -8,7 +8,7 @@ class TestFakerFillmurray < Test::Unit::TestCase
   end
 
   def test_fillmurray
-    assert !@tester.image(grayscale: false, width: '300', height: '300').match(%r{https:\/\/www\.fillmurray\.com\/(\d+)\/(\d+)}).nil?
+    assert @tester.image(grayscale: false, width: '300', height: '300').match?(%r{https:\/\/www\.fillmurray\.com\/(\d+)\/(\d+)})
   end
 
   def test_fillmurray_with_grayscale

--- a/test/faker/default/test_faker_finance.rb
+++ b/test/faker/default/test_faker_finance.rb
@@ -8,7 +8,7 @@ class TestFakerFinance < Test::Unit::TestCase
   end
 
   def test_vat_number
-    assert Faker::Finance.vat_number.match(/\w+/)
+    assert Faker::Finance.vat_number.match?(/\w+/)
   end
 
   def test_vat_number_with_invalid_params
@@ -19,7 +19,7 @@ class TestFakerFinance < Test::Unit::TestCase
 
   def test_vat_number_with_valid_params
     Faker::Finance.vat_number_keys.each do |country|
-      assert Faker::Finance.vat_number(country: country).match(/\w+/)
+      assert Faker::Finance.vat_number(country: country).match?(/\w+/)
     end
   end
 

--- a/test/faker/default/test_faker_food.rb
+++ b/test/faker/default/test_faker_food.rb
@@ -14,31 +14,31 @@ class TestFakerFood < Test::Unit::TestCase
   end
 
   def test_dish
-    assert @tester.dish.match(/\w+/)
+    assert @tester.dish.match?(/\w+/)
   end
 
   def test_description
-    assert @tester.description.match(/\w+/)
+    assert @tester.description.match?(/\w+/)
   end
 
   def test_ingredient
-    assert @tester.ingredient.match(/\w+/)
+    assert @tester.ingredient.match?(/\w+/)
   end
 
   def test_fruits
-    assert @tester.fruits.match(/\w+/)
+    assert @tester.fruits.match?(/\w+/)
   end
 
   def test_vegetables
-    assert @tester.vegetables.match(/\w+/)
+    assert @tester.vegetables.match?(/\w+/)
   end
 
   def test_spice
-    assert @tester.spice.match(/\w+/)
+    assert @tester.spice.match?(/\w+/)
   end
 
   def test_sushi
-    assert @tester.sushi.match(/\w+/)
+    assert @tester.sushi.match?(/\w+/)
   end
 
   def test_measurement
@@ -46,6 +46,6 @@ class TestFakerFood < Test::Unit::TestCase
   end
 
   def test_metric_measurement
-    assert @tester.metric_measurement.match(/\w+/)
+    assert @tester.metric_measurement.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_gender.rb
+++ b/test/faker/default/test_faker_gender.rb
@@ -8,14 +8,14 @@ class TestFakerGender < Test::Unit::TestCase
   end
 
   def test_type
-    assert @tester.type.match(/\w+/)
+    assert @tester.type.match?(/\w+/)
   end
 
   def test_binary_type
-    assert @tester.binary_type.match(/\w+/)
+    assert @tester.binary_type.match?(/\w+/)
   end
 
   def test_short_binary_type
-    assert @tester.short_binary_type.match(/f|m/)
+    assert @tester.short_binary_type.match?(/f|m/)
   end
 end

--- a/test/faker/default/test_faker_greek_philosophers.rb
+++ b/test/faker/default/test_faker_greek_philosophers.rb
@@ -8,10 +8,10 @@ class TestFakerGreekPhilosophers < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_hacker_talk.rb
+++ b/test/faker/default/test_faker_hacker_talk.rb
@@ -16,22 +16,22 @@ class TestFakerHacker < Test::Unit::TestCase
   end
 
   def test_noun
-    assert @hacker.noun.match(/\w+/)
+    assert @hacker.noun.match?(/\w+/)
   end
 
   def test_abbreviation
-    assert @hacker.abbreviation.match(/\w+/)
+    assert @hacker.abbreviation.match?(/\w+/)
   end
 
   def test_adjective
-    assert @hacker.adjective.match(/\w+/)
+    assert @hacker.adjective.match?(/\w+/)
   end
 
   def test_verb
-    assert @hacker.verb.match(/\w+/)
+    assert @hacker.verb.match?(/\w+/)
   end
 
   def test_ingverb
-    assert @hacker.ingverb.match(/\w+/)
+    assert @hacker.ingverb.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_hipster.rb
+++ b/test/faker/default/test_faker_hipster.rb
@@ -19,7 +19,7 @@ class TestFakerHipster < Test::Unit::TestCase
   # Words should not return any word with spaces
   def test_words_without_spaces
     @words = @tester.words(number: 1000)
-    @words.each { |w| assert !w.match(/\s/) }
+    @words.each { |w| assert !w.match?(/\s/) }
   end
 
   # Words requested from the supplemental list should all be in that list.
@@ -38,7 +38,7 @@ class TestFakerHipster < Test::Unit::TestCase
   # Word should not return any word with spaces
   def test_word_without_spaces
     @tester = Faker::Hipster
-    1000.times { assert !@tester.word.match(/\s/) }
+    1000.times { assert !@tester.word.match?(/\s/) }
   end
 
   def test_exact_count_param

--- a/test/faker/default/test_faker_house.rb
+++ b/test/faker/default/test_faker_house.rb
@@ -8,10 +8,10 @@ class TestFakerHouse < Test::Unit::TestCase
   end
 
   def test_furniture
-    assert @tester.furniture.match(/\w+/)
+    assert @tester.furniture.match?(/\w+/)
   end
 
   def test_room
-    assert @tester.room.match(/\w+/)
+    assert @tester.room.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_industry_segments.rb
+++ b/test/faker/default/test_faker_industry_segments.rb
@@ -8,18 +8,18 @@ class TestFakerIndustrySegments < Test::Unit::TestCase
   end
 
   def test_industry
-    assert @tester.industry.match(/(\w+\.? ?){2,3}/)
+    assert @tester.industry.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_super_sector
-    assert @tester.super_sector.match(/(\w+\.? ?){2,3}/)
+    assert @tester.super_sector.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_sector
-    assert @tester.sector.match(/(\w+\.? ?){2,3}/)
+    assert @tester.sector.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_sub_sector
-    assert @tester.sub_sector.match(/(\w+\.? ?){2,3}/)
+    assert @tester.sub_sector.match?(/(\w+\.? ?){2,3}/)
   end
 end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -8,44 +8,44 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_email
-    assert @tester.email.match(/.+@.+\.\w+/)
+    assert @tester.email.match?(/.+@.+\.\w+/)
   end
 
   def test_email_with_non_permitted_characters
-    assert @tester.email(name: 'martín').match(/mart#n@.+\.\w+/)
+    assert @tester.email(name: 'martín').match?(/mart#n@.+\.\w+/)
   end
 
   def test_email_with_separators
-    assert @tester.email(name: 'jane doe', separators: '+').match(/.+\+.+@.+\.\w+/)
+    assert @tester.email(name: 'jane doe', separators: '+').match?(/.+\+.+@.+\.\w+/)
   end
 
   def test_email_with_domain_option_given
-    assert @tester.email(name: 'jane doe', domain: 'customdomain').match(/.+@customdomain\.\w+/)
+    assert @tester.email(name: 'jane doe', domain: 'customdomain').match?(/.+@customdomain\.\w+/)
   end
 
   def test_email_with_domain_option_given_with_domain_suffix
-    assert @tester.email(name: 'jane doe', domain: 'customdomain.customdomainsuffix').match(/.+@customdomain\.customdomainsuffix/)
+    assert @tester.email(name: 'jane doe', domain: 'customdomain.customdomainsuffix').match?(/.+@customdomain\.customdomainsuffix/)
   end
 
   def test_free_email
-    assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
+    assert @tester.free_email.match?(/.+@(gmail|hotmail|yahoo)\.com/)
   end
 
   def test_free_email_with_non_permitted_characters
-    assert @tester.free_email(name: 'martín').match(/mart#n@.+\.\w+/)
+    assert @tester.free_email(name: 'martín').match?(/mart#n@.+\.\w+/)
   end
 
   def test_safe_email
-    assert @tester.safe_email.match(/.+@example.(com|net|org)/)
+    assert @tester.safe_email.match?(/.+@example.(com|net|org)/)
   end
 
   def test_safe_email_with_non_permitted_characters
-    assert @tester.safe_email(name: 'martín').match(/mart#n@.+\.\w+/)
+    assert @tester.safe_email(name: 'martín').match?(/mart#n@.+\.\w+/)
   end
 
   def test_username
-    assert @tester.username(specifier: 0..3).match(/[a-z]+((_|\.)[a-z]+)?/)
-    assert @tester.username.match(/[a-z]+((_|\.)[a-z]+)?/)
+    assert @tester.username(specifier: 0..3).match?(/[a-z]+((_|\.)[a-z]+)?/)
+    assert @tester.username.match?(/[a-z]+((_|\.)[a-z]+)?/)
   end
 
   def test_user_name_alias
@@ -53,12 +53,12 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_username_with_string_arg
-    assert @tester.username(specifier: 'bo peep').match(/(bo(_|\.)peep|peep(_|\.)bo)/)
+    assert @tester.username(specifier: 'bo peep').match?(/(bo(_|\.)peep|peep(_|\.)bo)/)
   end
 
   def test_username_with_string_arg_determinism
     deterministically_verify -> { @tester.username(specifier: 'bo peep') }, depth: 4 do |subject|
-      assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
+      assert subject.match?(/(bo(_|\.)peep|peep(_|\.)bo)/)
     end
   end
 
@@ -69,7 +69,7 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_username_with_utf_8_arg
-    assert @tester.username(specifier: 'Łucja').match('łucja')
+    assert @tester.username(specifier: 'Łucja').match?('łucja')
   end
 
   def test_username_with_very_large_integer_arg
@@ -102,13 +102,13 @@ class TestFakerInternet < Test::Unit::TestCase
       (min_length + 1..33).each do |max_length|
         u = @tester.username(specifier: (min_length...max_length), separators: %w[=])
         assert u.length.between? min_length, max_length - 1
-        assert u.match(/\A[a-z]+((=)?[a-z]*)*\z/)
+        assert u.match?(/\A[a-z]+((=)?[a-z]*)*\z/)
       end
     end
   end
 
   def test_password
-    assert @tester.password.match(/\w{3}/)
+    assert @tester.password.match?(/\w{3}/)
   end
 
   def test_password_with_integer_arg
@@ -137,7 +137,7 @@ class TestFakerInternet < Test::Unit::TestCase
     upcase_count = 0
     downcase_count = 0
     password.chars.each do |char|
-      if char =~ /[[:alpha:]]/
+      if /[[:alpha:]]/.match?(char)
         char.capitalize == char ? upcase_count += 1 : downcase_count += 1
       end
     end
@@ -146,39 +146,39 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_password_without_mixed_case
-    assert @tester.password(min_length: 8, max_length: 12, mix_case: false).match(/[^A-Z]+/)
+    assert @tester.password(min_length: 8, max_length: 12, mix_case: false).match?(/[^A-Z]+/)
   end
 
   def test_password_with_special_chars
-    assert @tester.password(min_length: 8, max_length: 12, mix_case: true, special_characters: true).match(/[!@#\$%\^&\*]+/)
+    assert @tester.password(min_length: 8, max_length: 12, mix_case: true, special_characters: true).match?(/[!@#\$%\^&\*]+/)
   end
 
   def test_password_without_special_chars
-    assert @tester.password(min_length: 8, max_length: 12, mix_case: true).match(/[^!@#\$%\^&\*]+/)
+    assert @tester.password(min_length: 8, max_length: 12, mix_case: true).match?(/[^!@#\$%\^&\*]+/)
   end
 
   def test_domain_name_without_subdomain
-    assert @tester.domain_name.match(/[\w-]+\.\w+/)
+    assert @tester.domain_name.match?(/[\w-]+\.\w+/)
   end
 
   def test_domain_name_with_subdomain
-    assert @tester.domain_name(subdomain: true).match(/[\w-]+\.[\w-]+\.\w+/)
+    assert @tester.domain_name(subdomain: true).match?(/[\w-]+\.[\w-]+\.\w+/)
   end
 
   def test_domain_name_with_subdomain_and_with_domain_option_given
-    assert @tester.domain_name(subdomain: true, domain: 'customdomain').match(/customdomain\.\w+/)
+    assert @tester.domain_name(subdomain: true, domain: 'customdomain').match?(/customdomain\.\w+/)
   end
 
   def test_domain_name_with_subdomain_and_with_domain_option_given_with_domain_suffix
-    assert @tester.domain_name(subdomain: true, domain: 'customdomain.customdomainsuffix').match(/customdomain\.customdomainsuffix/)
+    assert @tester.domain_name(subdomain: true, domain: 'customdomain.customdomainsuffix').match?(/customdomain\.customdomainsuffix/)
   end
 
   def test_domain_word
-    assert @tester.domain_word.match(/^[\w-]+$/)
+    assert @tester.domain_word.match?(/^[\w-]+$/)
   end
 
   def test_domain_suffix
-    assert @tester.domain_suffix.match(/^\w+(\.\w+)?/)
+    assert @tester.domain_suffix.match?(/^\w+(\.\w+)?/)
   end
 
   def test_ip_v4_address
@@ -239,7 +239,7 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_ip_v4_cidr
-    assert @tester.ip_v4_cidr.match(%r(\/\d{1,2}$))
+    assert @tester.ip_v4_cidr.match?(%r(\/\d{1,2}$))
 
     1000.times do
       assert((1..32).cover?(@tester.ip_v4_cidr.split('/').last.to_i))
@@ -267,7 +267,7 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_ip_v6_cidr
-    assert @tester.ip_v6_cidr.match(%r{\/\d{1,3}$})
+    assert @tester.ip_v6_cidr.match?(%r{\/\d{1,3}$})
 
     1000.times do
       assert((1..128).cover?(@tester.ip_v6_cidr.split('/').last.to_i))
@@ -275,23 +275,23 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_slug
-    assert @tester.slug.match(/^[a-z]+(_|\-)[a-z]+$/)
+    assert @tester.slug.match?(/^[a-z]+(_|\-)[a-z]+$/)
   end
 
   def test_slug_with_content_arg
-    assert @tester.slug(words: 'Foo bAr baZ').match(/^foo(_|\.|\-)bar(_|\.|\-)baz$/)
+    assert @tester.slug(words: 'Foo bAr baZ').match?(/^foo(_|\.|\-)bar(_|\.|\-)baz$/)
   end
 
   def test_slug_with_unwanted_content_arg
-    assert @tester.slug(words: 'Foo.. bAr., baZ,,').match(/^foo(_|\.|\-)bar(_|\.|\-)baz$/)
+    assert @tester.slug(words: 'Foo.. bAr., baZ,,').match?(/^foo(_|\.|\-)bar(_|\.|\-)baz$/)
   end
 
   def test_slug_with_glue_arg
-    assert @tester.slug(words: nil, glue: '+').match(/^[a-z]+\+[a-z]+$/)
+    assert @tester.slug(words: nil, glue: '+').match?(/^[a-z]+\+[a-z]+$/)
   end
 
   def test_url
-    assert @tester.url(host: 'domain.com', path: '/username', scheme: 'https').match(%r{^https:\/\/domain\.com\/username$})
+    assert @tester.url(host: 'domain.com', path: '/username', scheme: 'https').match?(%r{^https:\/\/domain\.com\/username$})
   end
 
   def test_device_token
@@ -299,18 +299,18 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_user_agent_with_no_argument
-    assert @tester.user_agent.match(/Mozilla|Opera/)
+    assert @tester.user_agent.match?(/Mozilla|Opera/)
   end
 
   def test_user_agent_with_valid_argument
-    assert @tester.user_agent(vendor: :opera).match(/Opera/)
-    assert @tester.user_agent(vendor: 'opera').match(/Opera/)
+    assert @tester.user_agent(vendor: :opera).match?(/Opera/)
+    assert @tester.user_agent(vendor: 'opera').match?(/Opera/)
   end
 
   def test_user_agent_with_invalid_argument
-    assert @tester.user_agent(vendor: :ie).match(/Mozilla|Opera/)
-    assert @tester.user_agent(vendor: nil).match(/Mozilla|Opera/)
-    assert @tester.user_agent(vendor: 1).match(/Mozilla|Opera/)
+    assert @tester.user_agent(vendor: :ie).match?(/Mozilla|Opera/)
+    assert @tester.user_agent(vendor: nil).match?(/Mozilla|Opera/)
+    assert @tester.user_agent(vendor: 1).match?(/Mozilla|Opera/)
   end
 
   def test_uuid

--- a/test/faker/default/test_faker_internet_http.rb
+++ b/test/faker/default/test_faker_internet_http.rb
@@ -8,27 +8,27 @@ class TestFakerInternetHTTP < Test::Unit::TestCase
   end
 
   def test_status_code
-    assert @tester.status_code.to_s.match(/^[1-5]\d{2}$/)
+    assert @tester.status_code.to_s.match?(/^[1-5]\d{2}$/)
   end
 
   def test_information_status_code
-    assert @tester.status_code(group: :information).to_s.match(/^1\d{2}$/)
+    assert @tester.status_code(group: :information).to_s.match?(/^1\d{2}$/)
   end
 
   def test_successful_status_code
-    assert @tester.status_code(group: :successful).to_s.match(/^2\d{2}$/)
+    assert @tester.status_code(group: :successful).to_s.match?(/^2\d{2}$/)
   end
 
   def test_redirect_status_code
-    assert @tester.status_code(group: :redirect).to_s.match(/^3\d{2}$/)
+    assert @tester.status_code(group: :redirect).to_s.match?(/^3\d{2}$/)
   end
 
   def test_client_error_status_code
-    assert @tester.status_code(group: :client_error).to_s.match(/^4\d{2}$/)
+    assert @tester.status_code(group: :client_error).to_s.match?(/^4\d{2}$/)
   end
 
   def test_server_error_status_code
-    assert @tester.status_code(group: :server_error).to_s.match(/^5\d{2}$/)
+    assert @tester.status_code(group: :server_error).to_s.match?(/^5\d{2}$/)
   end
 
   def test_invalid_http_status_code_group

--- a/test/faker/default/test_faker_job.rb
+++ b/test/faker/default/test_faker_job.rb
@@ -8,18 +8,18 @@ class TestFakerJob < Test::Unit::TestCase
   end
 
   def test_title
-    assert @tester.title.match(/(\w+\.? ?){2,3}/)
+    assert @tester.title.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_field
-    assert @tester.field.match(/(\w+\.? ?)/)
+    assert @tester.field.match?(/(\w+\.? ?)/)
   end
 
   def test_key_skill
-    assert @tester.key_skill.match(/(\w+\.? ?)/)
+    assert @tester.key_skill.match?(/(\w+\.? ?)/)
   end
 
   def test_position
-    assert @tester.position.match(/(\w+\.? ?)/)
+    assert @tester.position.match?(/(\w+\.? ?)/)
   end
 end

--- a/test/faker/default/test_faker_job_locale.rb
+++ b/test/faker/default/test_faker_job_locale.rb
@@ -13,6 +13,6 @@ class TestFakerJobLocale < Test::Unit::TestCase
   end
 
   def test_locale_without_jobs_defaults_to_en
-    assert @tester.position.match(/(\w+\.? ?)/)
+    assert @tester.position.match?(/(\w+\.? ?)/)
   end
 end

--- a/test/faker/default/test_faker_kpop.rb
+++ b/test/faker/default/test_faker_kpop.rb
@@ -8,26 +8,26 @@ class TestFakerKpop < Test::Unit::TestCase
   end
 
   def test_i_groups
-    assert @tester.i_groups.match(/\w+/)
+    assert @tester.i_groups.match?(/\w+/)
   end
 
   def test_ii_groups
-    assert @tester.ii_groups.match(/\w+/)
+    assert @tester.ii_groups.match?(/\w+/)
   end
 
   def test_iii_groups
-    assert @tester.iii_groups.match(/\w+/)
+    assert @tester.iii_groups.match?(/\w+/)
   end
 
   def test_girl_groups
-    assert @tester.girl_groups.match(/\w+/)
+    assert @tester.girl_groups.match?(/\w+/)
   end
 
   def test_boy_bands
-    assert @tester.boy_bands.match(/\w+/)
+    assert @tester.boy_bands.match?(/\w+/)
   end
 
   def test_solo
-    assert @tester.solo.match(/\w+/)
+    assert @tester.solo.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_marketing.rb
+++ b/test/faker/default/test_faker_marketing.rb
@@ -8,6 +8,6 @@ class TestFakerMarketing < Test::Unit::TestCase
   end
 
   def test_buzzwords
-    assert @tester.buzzwords.match(/\w+/)
+    assert @tester.buzzwords.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_measurement.rb
+++ b/test/faker/default/test_faker_measurement.rb
@@ -8,11 +8,11 @@ class TestFakerMeasurement < Test::Unit::TestCase
   end
 
   def test_height
-    assert @tester.height.match(/\d\s[a-z]/)
+    assert @tester.height.match?(/\d\s[a-z]/)
   end
 
   def length
-    assert @tester.length(0).match(/\d\s[a-z]/)
+    assert @tester.length(0).match?(/\d\s[a-z]/)
   end
 
   def volume
@@ -21,32 +21,32 @@ class TestFakerMeasurement < Test::Unit::TestCase
     custom_amount_float = @tester.volume(1.5)
     custom_amount_integer = @tester.volume(276)
 
-    assert singular_unit.match(/\A\D+[^s]\z/)
-    assert plural_unit.match(/\A\D+[s]\z/)
-    assert @tester.volume.match(/\d\s[a-z]/)
-    assert custom_amount_float.match(/\d\s[a-z]+[s]\z/)
-    assert custom_amount_integer.match(/\d\s[a-z]+[s]\z/)
+    assert singular_unit.match?(/\A\D+[^s]\z/)
+    assert plural_unit.match?(/\A\D+[s]\z/)
+    assert @tester.volume.match?(/\d\s[a-z]/)
+    assert custom_amount_float.match?(/\d\s[a-z]+[s]\z/)
+    assert custom_amount_integer.match?(/\d\s[a-z]+[s]\z/)
   end
 
   def weight
-    assert @tester.weight.match(/\d\s[a-z]/)
+    assert @tester.weight.match?(/\d\s[a-z]/)
   end
 
   def metric_height
-    assert @tester.metric_height.match(/\d\s[a-z]/)
+    assert @tester.metric_height.match?(/\d\s[a-z]/)
   end
 
   def metric_length
-    assert @tester.metric_length.match(/\d\s[a-z]/)
+    assert @tester.metric_length.match?(/\d\s[a-z]/)
   end
 
   def metric_volume
-    assert @tester.metric_volume.match(/\d\s[a-z]/)
+    assert @tester.metric_volume.match?(/\d\s[a-z]/)
   end
 
   def metric_weight
-    assert @tester.metric_weight.match(/\d\s[a-z]/)
-    assert @tester.metric_weight(1).match(/\d\s[a-z]/)
+    assert @tester.metric_weight.match?(/\d\s[a-z]/)
+    assert @tester.metric_weight(1).match?(/\d\s[a-z]/)
   end
 
   def test_invalid_amount_error

--- a/test/faker/default/test_faker_military.rb
+++ b/test/faker/default/test_faker_military.rb
@@ -8,22 +8,22 @@ class TestFakerMilitary < Test::Unit::TestCase
   end
 
   def test_army_rank
-    assert @tester.army_rank.match(/\w/)
+    assert @tester.army_rank.match?(/\w/)
   end
 
   def test_marines_rank
-    assert @tester.marines_rank.match(/\w/)
+    assert @tester.marines_rank.match?(/\w/)
   end
 
   def test_navy_rank
-    assert @tester.navy_rank.match(/\w/)
+    assert @tester.navy_rank.match?(/\w/)
   end
 
   def test_air_force_rank
-    assert @tester.air_force_rank.match(/\w/)
+    assert @tester.air_force_rank.match?(/\w/)
   end
 
   def test_dod_paygrade
-    assert @tester.dod_paygrade.match(/\w/)
+    assert @tester.dod_paygrade.match?(/\w/)
   end
 end

--- a/test/faker/default/test_faker_name.rb
+++ b/test/faker/default/test_faker_name.rb
@@ -8,15 +8,15 @@ class TestFakerName < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/(\w+\.? ?){2,3}/)
+    assert @tester.name.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_name_with_middle
-    assert @tester.name_with_middle.match(/(\w+\.? ?){3,4}/)
+    assert @tester.name_with_middle.match?(/(\w+\.? ?){3,4}/)
   end
 
   def test_first_name
-    assert @tester.first_name.match(/(\w+\.? ?){3,4}/)
+    assert @tester.first_name.match?(/(\w+\.? ?){3,4}/)
   end
 
   def test_male_first_name
@@ -32,23 +32,23 @@ class TestFakerName < Test::Unit::TestCase
   end
 
   def test_middle_name
-    assert @tester.middle_name.match(/(\w+\.? ?){3,4}/)
+    assert @tester.middle_name.match?(/(\w+\.? ?){3,4}/)
   end
 
   def test_last_name
-    assert @tester.last_name.match(/(\w+\.? ?){3,4}/)
+    assert @tester.last_name.match?(/(\w+\.? ?){3,4}/)
   end
 
   def test_prefix
-    assert @tester.prefix.match(/[A-Z][a-z]+\.?/)
+    assert @tester.prefix.match?(/[A-Z][a-z]+\.?/)
   end
 
   def test_suffix
-    assert @tester.suffix.match(/[A-Z][a-z]*\.?/)
+    assert @tester.suffix.match?(/[A-Z][a-z]*\.?/)
   end
 
   def test_initials
-    assert @tester.initials.match(/[A-Z]{3}/)
-    assert @tester.initials(number: 2).match(/[A-Z]{2}/)
+    assert @tester.initials.match?(/[A-Z]{3}/)
+    assert @tester.initials(number: 2).match?(/[A-Z]{2}/)
   end
 end

--- a/test/faker/default/test_faker_nation.rb
+++ b/test/faker/default/test_faker_nation.rb
@@ -8,22 +8,22 @@ class TestFakerNation < Test::Unit::TestCase
   end
 
   def test_flag
-    assert @tester.flag.match(/\p{M}*+/)
+    assert @tester.flag.match?(/\p{M}*+/)
   end
 
   def test_nationality
-    assert @tester.nationality.match(/(\w+\.? ?){2,3}/)
+    assert @tester.nationality.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_language
-    assert @tester.language.match(/[A-Z][a-z]+\.?/)
+    assert @tester.language.match?(/[A-Z][a-z]+\.?/)
   end
 
   def test_capital_city
-    assert @tester.capital_city.match(/(\w+\.? ?){2,3}/)
+    assert @tester.capital_city.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_national_sport
-    assert @tester.national_sport.match(/(\w+\.? ?){2,3}/)
+    assert @tester.national_sport.match?(/(\w+\.? ?){2,3}/)
   end
 end

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -14,11 +14,11 @@ class TestFakerNumber < Test::Unit::TestCase
   end
 
   def test_number
-    assert @tester.number(digits: 10).to_s.match(/[0-9]{10}/)
+    assert @tester.number(digits: 10).to_s.match?(/[0-9]{10}/)
 
     10.times do |digits|
       digits += 1
-      assert @tester.number(digits: digits).to_s.match(/^[0-9]{#{digits}}$/)
+      assert @tester.number(digits: digits).to_s.match?(/^[0-9]{#{digits}}$/)
     end
 
     assert @tester.number(digits: 10).to_s.length == 10
@@ -38,13 +38,13 @@ class TestFakerNumber < Test::Unit::TestCase
   end
 
   def test_decimal
-    assert @tester.decimal(l_digits: 1, r_digits: 1).to_s.match(/[0-9]{1}\.[1-9]{1}/)
-    assert @tester.decimal(l_digits: 2).to_s.match(/[0-9]{2}\.[0-9]{1}[1-9]{1}/)
-    assert @tester.decimal(l_digits: 4, r_digits: 5).to_s.match(/[0-9]{4}\.[0-9]{4}[1-9]{1}/)
+    assert @tester.decimal(l_digits: 1, r_digits: 1).to_s.match?(/[0-9]{1}\.[1-9]{1}/)
+    assert @tester.decimal(l_digits: 2).to_s.match?(/[0-9]{2}\.[0-9]{1}[1-9]{1}/)
+    assert @tester.decimal(l_digits: 4, r_digits: 5).to_s.match?(/[0-9]{4}\.[0-9]{4}[1-9]{1}/)
   end
 
   def test_digit
-    assert @tester.digit.to_s.match(/[0-9]{1}/)
+    assert @tester.digit.to_s.match?(/[0-9]{1}/)
     assert((1..1000).collect { |_i| @tester.digit == 9 }.include?(true))
   end
 
@@ -125,7 +125,7 @@ class TestFakerNumber < Test::Unit::TestCase
   end
 
   def test_hexadecimal
-    assert @tester.hexadecimal(digits: 4).match(/[0-9a-f]{4}/)
-    assert @tester.hexadecimal(digits: 7).match(/[0-9a-f]{7}/)
+    assert @tester.hexadecimal(digits: 4).match?(/[0-9a-f]{4}/)
+    assert @tester.hexadecimal(digits: 7).match?(/[0-9a-f]{7}/)
   end
 end

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -20,7 +20,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'google_oauth2', provider
     assert_equal 9, auth[:uid].length
     assert_equal 2, word_count(info[:name])
-    assert info[:email].match safe_email_regex(info[:first_name], info[:last_name])
+    assert info[:email].match? safe_email_regex(info[:first_name], info[:last_name])
     assert_equal info[:name].split(' ').first, info[:first_name]
     assert_equal info[:name].split(' ').last, info[:last_name]
     assert_instance_of String, info[:image]
@@ -62,7 +62,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, info[:name]
     assert_equal 2, word_count(info[:name])
     assert_equal custom_name, info[:name]
-    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert info[:email].match? safe_email_regex(first_name, last_name)
     assert_equal first_name, info[:first_name]
     assert_equal last_name, info[:last_name]
     assert_equal custom_name, extra_raw_info[:name]
@@ -108,7 +108,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
 
     assert_equal 'facebook', provider
     assert_equal 7, uid.length
-    assert info[:email].match safe_email_regex(info[:first_name], info[:last_name])
+    assert info[:email].match? safe_email_regex(info[:first_name], info[:last_name])
     assert_equal 2, word_count(info[:name])
     assert_instance_of String, info[:first_name]
     assert_instance_of String, info[:last_name]
@@ -154,7 +154,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal last_name, info[:last_name]
     assert_equal last_name, extra_raw_info[:last_name]
 
-    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert info[:email].match? safe_email_regex(first_name, last_name)
 
     assert_equal url, extra_raw_info[:link]
     assert_equal username, extra_raw_info[:username]
@@ -308,7 +308,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'linkedin', auth[:provider]
     assert_equal 6, auth[:uid].length
     assert_equal 2, word_count(info[:name])
-    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert info[:email].match? safe_email_regex(first_name, last_name)
     assert_equal info[:name], info[:nickname]
     assert_instance_of String, info[:first_name]
     assert_instance_of String, info[:last_name]
@@ -349,7 +349,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 2, word_count(info[:name])
     assert_instance_of String, info[:name]
     assert_equal custom_name, info[:name]
-    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert info[:email].match? safe_email_regex(first_name, last_name)
     assert_equal custom_name, info[:nickname]
     assert_equal first_name, info[:first_name]
     assert_equal last_name, info[:last_name]
@@ -388,7 +388,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'github', provider
     assert_equal 8, uid.length
     assert_equal uid, extra_raw_info[:id]
-    assert info[:email].match safe_email_regex(info[:first_name], info[:last_name])
+    assert info[:email].match? safe_email_regex(info[:first_name], info[:last_name])
     assert_equal info[:email], extra_raw_info[:email]
     assert_equal 2, word_count(name)
     assert_instance_of String, name
@@ -444,8 +444,8 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 2, word_count(info[:name])
     assert_instance_of String, info[:name]
     assert_equal custom_name, extra_raw_info[:name]
-    assert info[:email].match safe_email_re
-    assert extra_raw_info[:email].match safe_email_re
+    assert info[:email].match? safe_email_re
+    assert extra_raw_info[:email].match? safe_email_re
     assert_equal login, info[:nickname]
   end
 
@@ -482,7 +482,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'apple', auth[:provider]
     assert_instance_of String, auth[:uid]
     assert_equal 44, auth[:uid].length
-    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert info[:email].match? safe_email_regex(first_name, last_name)
     assert_equal auth[:uid], info[:sub]
     assert_instance_of String, info[:first_name]
     assert_instance_of String, info[:last_name]

--- a/test/faker/default/test_faker_phone_number.rb
+++ b/test/faker/default/test_faker_phone_number.rb
@@ -9,18 +9,18 @@ class TestFakerPhone < Test::Unit::TestCase
   end
 
   def test_country_code
-    assert @tester.country_code.match(/\A\+[\d|-]+\z/)
+    assert @tester.country_code.match?(/\A\+[\d|-]+\z/)
   end
 
   def test_phone_number_with_country_code
-    assert @tester.phone_number_with_country_code.match(@phone_with_country_code_regex)
+    assert @tester.phone_number_with_country_code.match?(@phone_with_country_code_regex)
   end
 
   def test_cell_phone_with_country_code
-    assert @tester.cell_phone_with_country_code.match(@phone_with_country_code_regex)
+    assert @tester.cell_phone_with_country_code.match?(@phone_with_country_code_regex)
   end
 
   def test_cell_phone_in_e164
-    assert @tester.cell_phone_in_e164.match(@phone_with_country_code_regex)
+    assert @tester.cell_phone_in_e164.match?(@phone_with_country_code_regex)
   end
 end

--- a/test/faker/default/test_faker_programming_language.rb
+++ b/test/faker/default/test_faker_programming_language.rb
@@ -8,10 +8,10 @@ class TestFakerProgrammingLanguage < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w/)
+    assert @tester.name.match?(/\w/)
   end
 
   def test_creator
-    assert @tester.creator.match(/\w/)
+    assert @tester.creator.match?(/\w/)
   end
 end

--- a/test/faker/default/test_faker_relationship.rb
+++ b/test/faker/default/test_faker_relationship.rb
@@ -8,15 +8,15 @@ class TestFakerRelationship < Test::Unit::TestCase
   end
 
   def test_random_familial
-    assert @tester.familial.match(/\w+/)
+    assert @tester.familial.match?(/\w+/)
   end
 
   def test_familial_direct
-    assert @tester.familial(connection: 'direct').match(/\w+/)
+    assert @tester.familial(connection: 'direct').match?(/\w+/)
   end
 
   def test_familial_extended
-    assert @tester.familial(connection: 'extended').match(/\w+/)
+    assert @tester.familial(connection: 'extended').match?(/\w+/)
   end
 
   # test error on no match
@@ -27,18 +27,18 @@ class TestFakerRelationship < Test::Unit::TestCase
   end
 
   def test_in_law
-    assert @tester.in_law.match(/\w+/)
+    assert @tester.in_law.match?(/\w+/)
   end
 
   def test_spouse
-    assert @tester.spouse.match(/\w+/)
+    assert @tester.spouse.match?(/\w+/)
   end
 
   def test_parent
-    assert @tester.parent.match(/\w+/)
+    assert @tester.parent.match?(/\w+/)
   end
 
   def test_sibling
-    assert @tester.sibling.match(/\w+/)
+    assert @tester.sibling.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_science.rb
+++ b/test/faker/default/test_faker_science.rb
@@ -8,14 +8,14 @@ class TestFakerScience < Test::Unit::TestCase
   end
 
   def test_element
-    assert @tester.element.match(/\w+/)
+    assert @tester.element.match?(/\w+/)
   end
 
   def test_element_symbol
-    assert @tester.element.match(/\w{1,2}/)
+    assert @tester.element.match?(/\w{1,2}/)
   end
 
   def test_scientist
-    assert @tester.scientist.match(/\w+/)
+    assert @tester.scientist.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_slack_emoji.rb
+++ b/test/faker/default/test_faker_slack_emoji.rb
@@ -9,38 +9,38 @@ class TestFakerSlackEmoji < Test::Unit::TestCase
   end
 
   def test_people
-    assert @tester.people.match(@emoticon_regex)
+    assert @tester.people.match?(@emoticon_regex)
   end
 
   def test_nature
-    assert @tester.nature.match(@emoticon_regex)
+    assert @tester.nature.match?(@emoticon_regex)
   end
 
   def test_food_and_drink
-    assert @tester.food_and_drink.match(@emoticon_regex)
+    assert @tester.food_and_drink.match?(@emoticon_regex)
   end
 
   def test_celebration
-    assert @tester.celebration.match(@emoticon_regex)
+    assert @tester.celebration.match?(@emoticon_regex)
   end
 
   def test_activity
-    assert @tester.activity.match(@emoticon_regex)
+    assert @tester.activity.match?(@emoticon_regex)
   end
 
   def test_travel_and_places
-    assert @tester.travel_and_places.match(@emoticon_regex)
+    assert @tester.travel_and_places.match?(@emoticon_regex)
   end
 
   def test_objects_and_symbols
-    assert @tester.objects_and_symbols.match(@emoticon_regex)
+    assert @tester.objects_and_symbols.match?(@emoticon_regex)
   end
 
   def test_custom
-    assert @tester.custom.match(@emoticon_regex)
+    assert @tester.custom.match?(@emoticon_regex)
   end
 
   def test_emoji
-    assert @tester.emoji.match(@emoticon_regex)
+    assert @tester.emoji.match?(@emoticon_regex)
   end
 end

--- a/test/faker/default/test_faker_space.rb
+++ b/test/faker/default/test_faker_space.rb
@@ -8,58 +8,58 @@ class TestFakerSpace < Test::Unit::TestCase
   end
 
   def test_planet
-    assert @tester.planet.match(/(\w+\.? ?){2,3}/)
+    assert @tester.planet.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_moon
-    assert @tester.moon.match(/(\w+\.? ?){2,3}/)
+    assert @tester.moon.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_galaxy
-    assert @tester.galaxy.match(/(\w+\.? ?){2,3}/)
+    assert @tester.galaxy.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_nebula
-    assert @tester.nebula.match(/(\w+\.? ?){2,3}/)
+    assert @tester.nebula.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_star_cluster
-    assert @tester.star_cluster.match(/(\w+\.? ?){2,3}/)
+    assert @tester.star_cluster.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_constellation
-    assert @tester.constellation.match(/(\w+\.? ?){2,3}/)
+    assert @tester.constellation.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_star
-    assert @tester.star.match(/(\w+\.? ?){2,3}/)
+    assert @tester.star.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_agency
-    assert @tester.agency.match(/(\w+\.? ?){2,3}/)
+    assert @tester.agency.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_agency_abv
-    assert @tester.agency_abv.match(/(\w+\.? ?){2,3}/)
+    assert @tester.agency_abv.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_nasa_space_craft
-    assert @tester.nasa_space_craft.match(/(\w+\.? ?){2,3}/)
+    assert @tester.nasa_space_craft.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_company
-    assert @tester.company.match(/(\w+\.? ?){2,3}/)
+    assert @tester.company.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_distance_measurement
-    assert @tester.distance_measurement.match(/(\w+\.? ?){2,3}/)
+    assert @tester.distance_measurement.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_meteorite
-    assert @tester.meteorite.match(/(\w+\.? ?){2,3}/)
+    assert @tester.meteorite.match?(/(\w+\.? ?){2,3}/)
   end
 
   def test_launch_vehicle
-    assert @tester.launch_vehicle.match(/(\w+\.? ?){2,3}/)
+    assert @tester.launch_vehicle.match?(/(\w+\.? ?){2,3}/)
   end
 end

--- a/test/faker/default/test_faker_stripe.rb
+++ b/test/faker/default/test_faker_stripe.rb
@@ -8,7 +8,7 @@ class TestFakerStripe < Test::Unit::TestCase
   end
 
   def test_valid_card
-    assert @tester.valid_card.match(/\A\d{14,16}\z/)
+    assert @tester.valid_card.match?(/\A\d{14,16}\z/)
   end
 
   def test_valid_card_error
@@ -20,19 +20,19 @@ class TestFakerStripe < Test::Unit::TestCase
   end
 
   def test_specific_valid_card
-    assert @tester.valid_card(card_type: 'visa').match(/\A\d{16}\z/)
+    assert @tester.valid_card(card_type: 'visa').match?(/\A\d{16}\z/)
   end
 
   def test_valid_token
-    assert @tester.valid_token.match(/\w+/)
+    assert @tester.valid_token.match?(/\w+/)
   end
 
   def test_specific_valid_token
-    assert @tester.valid_token(card_type: 'visa').match(/\Atok_visa\z/)
+    assert @tester.valid_token(card_type: 'visa').match?(/\Atok_visa\z/)
   end
 
   def test_invalid_card
-    assert @tester.invalid_card.match(/\A\d{16}\z/)
+    assert @tester.invalid_card.match?(/\A\d{16}\z/)
   end
 
   def test_invalid_card_error
@@ -44,22 +44,22 @@ class TestFakerStripe < Test::Unit::TestCase
   end
 
   def test_specific_error_invalid_card
-    assert @tester.invalid_card(card_error: 'zipFail').match(/\w+/)
+    assert @tester.invalid_card(card_error: 'zipFail').match?(/\w+/)
   end
 
   def test_valid_exp_mo
-    assert @tester.month.match(/\A\d{2}\z/)
+    assert @tester.month.match?(/\A\d{2}\z/)
   end
 
   def test_valid_exp_yr
-    assert @tester.year.match(/\A\d{4}\z/)
+    assert @tester.year.match?(/\A\d{4}\z/)
   end
 
   def test_valid_ccv
-    assert @tester.ccv.match(/\A\d{3}\z/)
+    assert @tester.ccv.match?(/\A\d{3}\z/)
   end
 
   def test_valid_amex_ccv
-    assert @tester.ccv(card_type: 'amex').match(/\A\d{4}\z/)
+    assert @tester.ccv(card_type: 'amex').match?(/\A\d{4}\z/)
   end
 end

--- a/test/faker/default/test_faker_subscription.rb
+++ b/test/faker/default/test_faker_subscription.rb
@@ -8,22 +8,22 @@ class TestFakerSubscription < Test::Unit::TestCase
   end
 
   def test_plan
-    assert @tester.plan.match(/\w+/)
+    assert @tester.plan.match?(/\w+/)
   end
 
   def test_status
-    assert @tester.status.match(/\w+/)
+    assert @tester.status.match?(/\w+/)
   end
 
   def test_payment_method
-    assert @tester.payment_method.match(/\w+/)
+    assert @tester.payment_method.match?(/\w+/)
   end
 
   def test_subscription_term
-    assert @tester.subscription_term.match(/\w+/)
+    assert @tester.subscription_term.match?(/\w+/)
   end
 
   def test_payment_term
-    assert @tester.payment_term.match(/\w+/)
+    assert @tester.payment_term.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_superhero.rb
+++ b/test/faker/default/test_faker_superhero.rb
@@ -8,10 +8,10 @@ class TestFakerSuperhero < Test::Unit::TestCase
   end
 
   def test_power
-    assert @tester.power.match(/\w+\.?/)
+    assert @tester.power.match?(/\w+\.?/)
   end
 
   def test_name
-    assert @tester.name.match(/\w+\.?/)
+    assert @tester.name.match?(/\w+\.?/)
   end
 end

--- a/test/faker/default/test_faker_team.rb
+++ b/test/faker/default/test_faker_team.rb
@@ -8,18 +8,18 @@ class TestFakerTeam < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/(\w+\.? ?){2}/)
+    assert @tester.name.match?(/(\w+\.? ?){2}/)
   end
 
   def test_creature
-    assert @tester.creature.match(/(\w+){1}/)
+    assert @tester.creature.match?(/(\w+){1}/)
   end
 
   def test_state
-    assert @tester.state.match(/(\w+){1}/)
+    assert @tester.state.match?(/(\w+){1}/)
   end
 
   def test_sport
-    assert @tester.sport.match(/(\w+){1}/)
+    assert @tester.sport.match?(/(\w+){1}/)
   end
 end

--- a/test/faker/default/test_faker_university.rb
+++ b/test/faker/default/test_faker_university.rb
@@ -9,15 +9,15 @@ class TestFakerUniversity < Test::Unit::TestCase
   end
 
   def test_prefix
-    assert @tester.prefix.match(/\w+\.?/)
+    assert @tester.prefix.match?(/\w+\.?/)
   end
 
   def test_suffix
-    assert @tester.suffix.match(/\w+\.?/)
+    assert @tester.suffix.match?(/\w+\.?/)
   end
 
   def test_name
-    assert @tester.name.match(/\w+\.?/)
+    assert @tester.name.match?(/\w+\.?/)
   end
 
   def test_greek_alphabet_has_24_characters
@@ -25,7 +25,7 @@ class TestFakerUniversity < Test::Unit::TestCase
   end
 
   def test_greek_organization
-    assert @tester.greek_organization.match(/\p{Greek}|\w+/)
+    assert @tester.greek_organization.match?(/\p{Greek}|\w+/)
     assert @tester.greek_organization.length == 3
   end
 

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -52,7 +52,7 @@ class TestFakerVehicle < Test::Unit::TestCase
   end
 
   def test_engine
-    assert @tester.engine.match(/\d Cylinder Engine/)
+    assert @tester.engine.match?(/\d Cylinder Engine/)
   end
 
   def test_mileage

--- a/test/faker/default/test_faker_verb.rb
+++ b/test/faker/default/test_faker_verb.rb
@@ -8,22 +8,22 @@ class TestFakerVerb < Test::Unit::TestCase
   end
 
   def test_base
-    assert @tester.base.match(/\w+/)
+    assert @tester.base.match?(/\w+/)
   end
 
   def test_past
-    assert @tester.past.match(/\w+/)
+    assert @tester.past.match?(/\w+/)
   end
 
   def test_past_participle
-    assert @tester.past_participle.match(/\w+/)
+    assert @tester.past_participle.match?(/\w+/)
   end
 
   def test_simple_present
-    assert @tester.simple_present.match(/\w+/)
+    assert @tester.simple_present.match?(/\w+/)
   end
 
   def test_ing_form
-    assert @tester.ing_form.match(/\w+/)
+    assert @tester.ing_form.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_faker_world_cup.rb
+++ b/test/faker/default/test_faker_world_cup.rb
@@ -8,22 +8,22 @@ class TestFakerWorldCup < Test::Unit::TestCase
   end
 
   def test_team
-    assert @tester.team.match(/\w+/)
+    assert @tester.team.match?(/\w+/)
   end
 
   def test_stadium
-    assert @tester.stadium.match(/\w+/)
+    assert @tester.stadium.match?(/\w+/)
   end
 
   def test_city
-    assert @tester.city.match(/\w+/)
+    assert @tester.city.match?(/\w+/)
   end
 
   def test_group
-    assert @tester.group.match(/\w+/)
+    assert @tester.group.match?(/\w+/)
   end
 
   def test_roster
-    assert @tester.roster.match(/\w+/)
+    assert @tester.roster.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_half_life.rb
+++ b/test/faker/default/test_half_life.rb
@@ -8,14 +8,14 @@ class TestFakerGamesHalfLife < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_enemy
-    assert @tester.enemy.match(/\w+/)
+    assert @tester.enemy.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_invoice.rb
+++ b/test/faker/default/test_invoice.rb
@@ -21,13 +21,13 @@ class TestFakerInvoice < Test::Unit::TestCase
   def test_creditor_reference
     reference = @tester.creditor_reference
 
-    assert reference.match(/RF\d{2}\d{4,20}/)
+    assert reference.match?(/RF\d{2}\d{4,20}/)
   end
 
   def test_reference
     reference = @tester.reference
 
-    assert reference.match(/\d{4,20}/)
+    assert reference.match?(/\d{4,20}/)
   end
 
   def test_reference_checksum

--- a/test/faker/default/test_lorem_pixel.rb
+++ b/test/faker/default/test_lorem_pixel.rb
@@ -26,7 +26,7 @@ class TestLoremPixel < Test::Unit::TestCase
   end
 
   def test_image_gray
-    assert @tester.image(size: '300x300', is_gray: true).match(%r{https:\/\/lorempixel\.com\/g\/\d+\/\d+})
+    assert @tester.image(size: '300x300', is_gray: true).match?(%r{https:\/\/lorempixel\.com\/g\/\d+\/\d+})
   end
 
   def test_image_with_supported_category

--- a/test/faker/default/test_nato_phonetic_alphabet.rb
+++ b/test/faker/default/test_nato_phonetic_alphabet.rb
@@ -8,6 +8,6 @@ class TestFakerNatoPhoneticAlphabet < Test::Unit::TestCase
   end
 
   def test_code_word
-    assert @tester.code_word.match(/\w+/)
+    assert @tester.code_word.match?(/\w+/)
   end
 end

--- a/test/faker/default/test_placeholdit.rb
+++ b/test/faker/default/test_placeholdit.rb
@@ -22,7 +22,7 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_with_supported_format
-    assert @tester.image(size: '300x300', format: 'jpg').match(%r{https:\/\/placehold\.it\/(.+)(jpg?)})
+    assert @tester.image(size: '300x300', format: 'jpg').match?(%r{https:\/\/placehold\.it\/(.+)(jpg?)})
   end
 
   def test_avatar_with_incorrect_format
@@ -32,15 +32,15 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_background_with_correct_six_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff').match(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff').match?(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff})
   end
 
   def test_avatar_background_with_correct_three_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff').match(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/fff})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff').match?(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/fff})
   end
 
   def test_avatar_background_with_random_color
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: :random).match(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/[a-f0-9]{6}})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: :random).match?(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/[a-f0-9]{6}})
   end
 
   def test_avatar_background_with_wrong_six_char_hex
@@ -62,15 +62,15 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_font_color_with_correct_six_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '000000').match(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff\/000000})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '000000').match?(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff\/000000})
   end
 
   def test_avatar_font_color_with_correct_three_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/fff})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match?(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/fff})
   end
 
   def test_avatar_font_color_with_random_color
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: :random).match(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/fff\/[a-f0-9]{6}})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: :random).match?(%r{https:\/\/placehold\.it\/(.+)(jpg?)\/fff\/[a-f0-9]{6}})
   end
 
   def test_avatar_font_color_with_wrong_six_char_hex
@@ -92,10 +92,10 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_text_not_present
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(%r{https:\/\/placehold\.it\/[^\\?]+$})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match?(%r{https:\/\/placehold\.it\/[^\\?]+$})
   end
 
   def test_text_present
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000', text: 'hello').match(%r{https:\/\/placehold\.it\/(.+)\?text=hello})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000', text: 'hello').match?(%r{https:\/\/placehold\.it\/(.+)\?text=hello})
   end
 end

--- a/test/faker/games/test_faker_control.rb
+++ b/test/faker/games/test_faker_control.rb
@@ -8,34 +8,34 @@ class TestFakerGameControl < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_object_of_power
-    assert @tester.object_of_power.match(/\w+/)
+    assert @tester.object_of_power.match?(/\w+/)
   end
 
   def test_altered_item
-    assert @tester.altered_item.match(/\w+/)
+    assert @tester.altered_item.match?(/\w+/)
   end
 
   def test_altered_world_event
-    assert @tester.altered_world_event.match(/\w+/)
+    assert @tester.altered_world_event.match?(/\w+/)
   end
 
   def test_hiss
-    assert @tester.hiss.match(/\w+/)
+    assert @tester.hiss.match?(/\w+/)
   end
 
   def test_the_board
-    assert @tester.the_board.match(/\w+/)
+    assert @tester.the_board.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_dnd.rb
+++ b/test/faker/games/test_faker_dnd.rb
@@ -8,18 +8,18 @@ class TestFakerDnD < Test::Unit::TestCase
   end
 
   def test_species
-    assert @tester.species.match(/\w+/)
+    assert @tester.species.match?(/\w+/)
   end
 
   def test_klass
-    assert @tester.klass.match(/\w+/)
+    assert @tester.klass.match?(/\w+/)
   end
 
   def test_background
-    assert @tester.background.match(/\w+/)
+    assert @tester.background.match?(/\w+/)
   end
 
   def test_alignment
-    assert @tester.alignment.match(/\w+/)
+    assert @tester.alignment.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_dota.rb
+++ b/test/faker/games/test_faker_dota.rb
@@ -14,19 +14,19 @@ class TestFakerDota < Test::Unit::TestCase
   end
 
   def test_hero
-    assert @tester.hero.match(/\w+/)
+    assert @tester.hero.match?(/\w+/)
   end
 
   def test_item
-    assert @tester.item.match(/\w+/)
+    assert @tester.item.match?(/\w+/)
   end
 
   def test_team
-    assert @tester.team.match(/\w+/)
+    assert @tester.team.match?(/\w+/)
   end
 
   def test_player
-    assert @tester.player.match(/\w+/)
+    assert @tester.player.match?(/\w+/)
   end
 
   def test_heroes_quotes

--- a/test/faker/games/test_faker_elder_scrolls.rb
+++ b/test/faker/games/test_faker_elder_scrolls.rb
@@ -8,34 +8,34 @@ class TestFakerElderScrolls < Test::Unit::TestCase
   end
 
   def test_race
-    assert @tester.race.match(/\w+/)
+    assert @tester.race.match?(/\w+/)
   end
 
   def test_region
-    assert @tester.region.match(/\w+/)
+    assert @tester.region.match?(/\w+/)
   end
 
   def test_city
-    assert @tester.city.match(/\w+/)
+    assert @tester.city.match?(/\w+/)
   end
 
   def test_dragon
-    assert @tester.dragon.match(/\w+/)
+    assert @tester.dragon.match?(/\w+/)
   end
 
   def test_creature
-    assert @tester.creature.match(/\w+/)
+    assert @tester.creature.match?(/\w+/)
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 
   def test_first_name
-    assert @tester.first_name.match(/\w+/)
+    assert @tester.first_name.match?(/\w+/)
   end
 
   def test_last_name
-    assert @tester.last_name.match(/\w+/)
+    assert @tester.last_name.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_fallout.rb
+++ b/test/faker/games/test_faker_fallout.rb
@@ -8,18 +8,18 @@ class TestFakerFallout < Test::Unit::TestCase
   end
 
   def test_hero
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_faction
-    assert @tester.faction.match(/\w+/)
+    assert @tester.faction.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_game.rb
+++ b/test/faker/games/test_faker_game.rb
@@ -8,14 +8,14 @@ class TestFakerGame < Test::Unit::TestCase
   end
 
   def test_title
-    assert @tester.title.match(/\w+/)
+    assert @tester.title.match?(/\w+/)
   end
 
   def test_genre
-    assert @tester.genre.match(/\w+/)
+    assert @tester.genre.match?(/\w+/)
   end
 
   def test_platform
-    assert @tester.platform.match(/\w+/)
+    assert @tester.platform.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_heroes.rb
+++ b/test/faker/games/test_faker_heroes.rb
@@ -8,14 +8,14 @@ class TestFakerHeroes < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 
   def test_specialty
-    assert @tester.specialty.match(/\w+/)
+    assert @tester.specialty.match?(/\w+/)
   end
 
   def test_klass
-    assert @tester.klass.match(/\w+/)
+    assert @tester.klass.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_heroes_of_the_storm.rb
+++ b/test/faker/games/test_faker_heroes_of_the_storm.rb
@@ -8,18 +8,18 @@ class TestFakerHeroesOfTheStorm < Test::Unit::TestCase
   end
 
   def test_battleground
-    assert @tester.battleground.match(/\w+/)
+    assert @tester.battleground.match?(/\w+/)
   end
 
   def test_class_name
-    assert @tester.class_name.match(/\w+/)
+    assert @tester.class_name.match?(/\w+/)
   end
 
   def test_hero
-    assert @tester.hero.match(/\w+/)
+    assert @tester.hero.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_minecraft.rb
+++ b/test/faker/games/test_faker_minecraft.rb
@@ -8,14 +8,14 @@ class TestFakerMinecraft < Test::Unit::TestCase
   end
 
   def test_block
-    assert @minecraft.block.match(/\w+/)
+    assert @minecraft.block.match?(/\w+/)
   end
 
   def test_item
-    assert @minecraft.item.match(/\w+/)
+    assert @minecraft.item.match?(/\w+/)
   end
 
   def test_mob
-    assert @minecraft.mob.match(/\w+/)
+    assert @minecraft.mob.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_myst.rb
+++ b/test/faker/games/test_faker_myst.rb
@@ -8,22 +8,22 @@ class TestFakerMyst < Test::Unit::TestCase
   end
 
   def test_game
-    assert @tester.game.match(/\w+/)
+    assert @tester.game.match?(/\w+/)
   end
 
   def test_creature
-    assert @tester.creature.match(/\w+/)
+    assert @tester.creature.match?(/\w+/)
   end
 
   def test_age
-    assert @tester.age.match(/\w+/)
+    assert @tester.age.match?(/\w+/)
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_overwatch.rb
+++ b/test/faker/games/test_faker_overwatch.rb
@@ -8,14 +8,14 @@ class TestFakerOverwatch < Test::Unit::TestCase
   end
 
   def test_hero
-    assert @tester.hero.match(/\w+/)
+    assert @tester.hero.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_pokemon.rb
+++ b/test/faker/games/test_faker_pokemon.rb
@@ -8,14 +8,14 @@ class TestFakerPokemon < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_move
-    assert @tester.move.match(/\w+/)
+    assert @tester.move.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_sonic_the_hedgehog.rb
+++ b/test/faker/games/test_faker_sonic_the_hedgehog.rb
@@ -8,14 +8,14 @@ class TestFakerGamesSonicTheHedgehog < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_zone
-    assert @tester.zone.match(/\w+/)
+    assert @tester.zone.match?(/\w+/)
   end
 
   def test_game
-    assert @tester.game.match(/\w+/)
+    assert @tester.game.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_super_smash_bros.rb
+++ b/test/faker/games/test_faker_super_smash_bros.rb
@@ -8,10 +8,10 @@ class TestFakerGamesSuperSmashBros < Test::Unit::TestCase
   end
 
   def test_fighter
-    assert @tester.fighter.match(/\w+/)
+    assert @tester.fighter.match?(/\w+/)
   end
 
   def test_stage
-    assert @tester.stage.match(/\w+/)
+    assert @tester.stage.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_warhammer_fantasy.rb
+++ b/test/faker/games/test_faker_warhammer_fantasy.rb
@@ -8,22 +8,22 @@ class TestWarhammerFantasy < Test::Unit::TestCase
   end
 
   def test_heroes
-    assert @tester.hero.match(/\w+/)
+    assert @tester.hero.match?(/\w+/)
   end
 
   def test_quotes
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_locations
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_factions
-    assert @tester.faction.match(/\w+/)
+    assert @tester.faction.match?(/\w+/)
   end
 
   def test_creatures
-    assert @tester.creature.match(/\w+/)
+    assert @tester.creature.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_witcher.rb
+++ b/test/faker/games/test_faker_witcher.rb
@@ -8,26 +8,26 @@ class TestFakerWitcher < Test::Unit::TestCase
   end
 
   def test_character
-    assert @witcher.character.match(/\w+/)
+    assert @witcher.character.match?(/\w+/)
   end
 
   def test_location
-    assert @witcher.location.match(/\w+/)
+    assert @witcher.location.match?(/\w+/)
   end
 
   def test_school
-    assert @witcher.school.match(/\w+/)
+    assert @witcher.school.match?(/\w+/)
   end
 
   def test_witcher
-    assert @witcher.witcher.match(/\w+/)
+    assert @witcher.witcher.match?(/\w+/)
   end
 
   def test_monster
-    assert @witcher.monster.match(/\w+/)
+    assert @witcher.monster.match?(/\w+/)
   end
 
   def test_quote
-    assert @witcher.quote.match(/\w+/)
+    assert @witcher.quote.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_world_of_warcraft.rb
+++ b/test/faker/games/test_faker_world_of_warcraft.rb
@@ -8,10 +8,10 @@ class TestWorldOfWarcraft < Test::Unit::TestCase
   end
 
   def test_heroes
-    assert @tester.hero.match(/\w+/)
+    assert @tester.hero.match?(/\w+/)
   end
 
   def test_quotes
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_zelda.rb
+++ b/test/faker/games/test_faker_zelda.rb
@@ -8,18 +8,18 @@ class TestFakerZelda < Test::Unit::TestCase
   end
 
   def test_game
-    assert @tester.game.match(/\w+\.?/)
+    assert @tester.game.match?(/\w+\.?/)
   end
 
   def test_character
-    assert @tester.character.match(/\w+\.?/)
+    assert @tester.character.match?(/\w+\.?/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+\.?/)
+    assert @tester.location.match?(/\w+\.?/)
   end
 
   def test_item
-    assert @tester.item.match(/\w+\.?/)
+    assert @tester.item.match?(/\w+\.?/)
   end
 end

--- a/test/faker/japanese_media/test_faker_dragon_ball.rb
+++ b/test/faker/japanese_media/test_faker_dragon_ball.rb
@@ -8,6 +8,6 @@ class TestFakerJapaneseMediaDragonBall < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 end

--- a/test/faker/japanese_media/test_faker_one_piece.rb
+++ b/test/faker/japanese_media/test_faker_one_piece.rb
@@ -8,26 +8,26 @@ class TestFakerJapaneseOnePiece < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_sea
-    assert @tester.sea.match(/\w+/)
+    assert @tester.sea.match?(/\w+/)
   end
 
   def test_island
-    assert @tester.island.match(/\w+/)
+    assert @tester.island.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_akuma_no_mi
-    assert @tester.akuma_no_mi.match(/\w+/)
+    assert @tester.akuma_no_mi.match?(/\w+/)
   end
 end

--- a/test/faker/japanese_media/test_faker_sword_art_online.rb
+++ b/test/faker/japanese_media/test_faker_sword_art_online.rb
@@ -8,18 +8,18 @@ class TestFakerJapaneseSwordArtOnline < Test::Unit::TestCase
   end
 
   def test_real_name
-    assert @tester.real_name.match(/\w+\.?/)
+    assert @tester.real_name.match?(/\w+\.?/)
   end
 
   def test_game_name
-    assert @tester.game_name.match(/\w+\.?/)
+    assert @tester.game_name.match?(/\w+\.?/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+\.?/)
+    assert @tester.location.match?(/\w+\.?/)
   end
 
   def test_item
-    assert @tester.item.match(/\w+\.?/)
+    assert @tester.item.match?(/\w+\.?/)
   end
 end

--- a/test/faker/movies/test_faker_back_to_the_future.rb
+++ b/test/faker/movies/test_faker_back_to_the_future.rb
@@ -8,14 +8,14 @@ class TestFakerBackToTheFuture < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_date
-    assert @tester.date.match(/\w+/)
+    assert @tester.date.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_departed.rb
+++ b/test/faker/movies/test_faker_departed.rb
@@ -8,14 +8,14 @@ class TestFakerDeparted < Test::Unit::TestCase
   end
 
   def test_actor
-    assert @tester.actor.match(/\w+/)
+    assert @tester.actor.match?(/\w+/)
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_harry_potter.rb
+++ b/test/faker/movies/test_faker_harry_potter.rb
@@ -8,26 +8,26 @@ class TestFakerHarryPotter < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_book
-    assert @tester.book.match(/\w+/)
+    assert @tester.book.match?(/\w+/)
   end
 
   def test_house
-    assert @tester.house.match(/\w+/)
+    assert @tester.house.match?(/\w+/)
   end
 
   def test_spell
-    assert @tester.spell.match(/\w+/)
+    assert @tester.spell.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_hitchhikers_guide_to_the_galaxy.rb
+++ b/test/faker/movies/test_faker_hitchhikers_guide_to_the_galaxy.rb
@@ -8,30 +8,30 @@ class TestFakerHitchhikersGuideToTheGalaxy < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_marvin_quote
-    assert @tester.marvin_quote.match(/\w+/)
+    assert @tester.marvin_quote.match?(/\w+/)
   end
 
   def test_planet
-    assert @tester.planet.match(/\w+/)
+    assert @tester.planet.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_specie
-    assert @tester.specie.match(/\w+/)
+    assert @tester.specie.match?(/\w+/)
   end
 
   def test_starship
-    assert @tester.starship.match(/\w+/)
+    assert @tester.starship.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_hobbit.rb
+++ b/test/faker/movies/test_faker_hobbit.rb
@@ -8,18 +8,18 @@ class TestFakerMoviesHobbit < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_thorins_company
-    assert @tester.thorins_company.match(/\w+/)
+    assert @tester.thorins_company.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_lebowski.rb
+++ b/test/faker/movies/test_faker_lebowski.rb
@@ -8,14 +8,14 @@ class TestFakerLebowski < Test::Unit::TestCase
   end
 
   def test_actor
-    assert @tester.actor.match(/\w+/)
+    assert @tester.actor.match?(/\w+/)
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_lord_of_the_rings.rb
+++ b/test/faker/movies/test_faker_lord_of_the_rings.rb
@@ -8,14 +8,14 @@ class TestFakerLordOfTheRings < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_movie.rb
+++ b/test/faker/movies/test_faker_movie.rb
@@ -8,10 +8,10 @@ class TestFakerMovie < Test::Unit::TestCase
   end
 
   def test_title
-    assert @tester.title.match(/\w+/)
+    assert @tester.title.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_movies_ghostbusters.rb
+++ b/test/faker/movies/test_faker_movies_ghostbusters.rb
@@ -8,14 +8,14 @@ class TestFakerMoviesGhostbusters < Test::Unit::TestCase
   end
 
   def test_actor
-    assert @tester.actor.match(/\w+/)
+    assert @tester.actor.match?(/\w+/)
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_princess_bride.rb
+++ b/test/faker/movies/test_faker_princess_bride.rb
@@ -8,10 +8,10 @@ class TestFakerPrincessBride < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/movies/test_faker_star_wars.rb
+++ b/test/faker/movies/test_faker_star_wars.rb
@@ -8,33 +8,33 @@ class TestFakerStarWars < Test::Unit::TestCase
   end
 
   def test_call_sign
-    assert @tester.call_sign.match(/\w+/)
+    assert @tester.call_sign.match?(/\w+/)
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_droid
-    assert @tester.droid.match(/\w+/)
+    assert @tester.droid.match?(/\w+/)
   end
 
   def test_planet
-    assert @tester.planet.match(/\w+/)
+    assert @tester.planet.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   # test good match
   def test_random_character_quote
-    assert @tester.quote(character: 'admiral_ackbar').match(/\w+/)
+    assert @tester.quote(character: 'admiral_ackbar').match?(/\w+/)
   end
 
   # test good alternate spelling match
   def test_random_character_alt_spelling_quote
-    assert @tester.quote(character: 'ackbar').match(/\w+/)
+    assert @tester.quote(character: 'ackbar').match?(/\w+/)
   end
 
   # test error on no match
@@ -45,15 +45,15 @@ class TestFakerStarWars < Test::Unit::TestCase
   end
 
   def test_specie
-    assert @tester.specie.match(/\w+/)
+    assert @tester.specie.match?(/\w+/)
   end
 
   def test_vehicle
-    assert @tester.vehicle.match(/\w+/)
+    assert @tester.vehicle.match?(/\w+/)
   end
 
   def test_wookiee_sentence
-    assert @tester.wookiee_sentence.match(/\w+/)
+    assert @tester.wookiee_sentence.match?(/\w+/)
   end
 
   def test_call_numbers

--- a/test/faker/movies/test_faker_v_for_vendetta.rb
+++ b/test/faker/movies/test_faker_v_for_vendetta.rb
@@ -8,14 +8,14 @@ class TestFakerVForVendetta < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_speech
-    assert @tester.speech.match(/\w+/)
+    assert @tester.speech.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/music/test_faker_grateful_dead.rb
+++ b/test/faker/music/test_faker_grateful_dead.rb
@@ -8,10 +8,10 @@ class TestFakerGratefulDead < Test::Unit::TestCase
   end
 
   def test_player
-    assert @tester.player.match(/\w/)
+    assert @tester.player.match?(/\w/)
   end
 
   def test_song
-    assert @tester.song.match(/\w/)
+    assert @tester.song.match?(/\w/)
   end
 end

--- a/test/faker/music/test_faker_music.rb
+++ b/test/faker/music/test_faker_music.rb
@@ -36,26 +36,26 @@ class TestFakerMusic < Test::Unit::TestCase
   end
 
   def test_key
-    assert @tester.name.match(/([A-Z])\s*(b|#){0,1}\s*(m){0,1}/)
+    assert @tester.name.match?(/([A-Z])\s*(b|#){0,1}\s*(m){0,1}/)
   end
 
   def test_instrument
-    assert @tester.instrument.match(/\w+/)
+    assert @tester.instrument.match?(/\w+/)
   end
 
   def test_chord
-    assert @tester.name.match(/([A-Z])\s*(b|#){0,1}\s*([a-zA-Z0-9]{0,4})/)
+    assert @tester.name.match?(/([A-Z])\s*(b|#){0,1}\s*([a-zA-Z0-9]{0,4})/)
   end
 
   def test_band
-    assert @tester.band.match(/\w+/)
+    assert @tester.band.match?(/\w+/)
   end
 
   def test_album
-    assert @tester.album.match(/\w+/)
+    assert @tester.album.match?(/\w+/)
   end
 
   def test_genre
-    assert @tester.genre.match(/\w+/)
+    assert @tester.genre.match?(/\w+/)
   end
 end

--- a/test/faker/music/test_faker_opera.rb
+++ b/test/faker/music/test_faker_opera.rb
@@ -8,18 +8,18 @@ class TestFakerOpera < Test::Unit::TestCase
   end
 
   def verdi
-    assert @tester.verdi.match(/\w+/i)
+    assert @tester.verdi.match?(/\w+/i)
   end
 
   def rossini
-    assert @tester.rossini.match(/\w+/i)
+    assert @tester.rossini.match?(/\w+/i)
   end
 
   def donizetti
-    assert @tester.donizetti.match(/\w+/i)
+    assert @tester.donizetti.match?(/\w+/i)
   end
 
   def bellini
-    assert @tester.bellini.match(/\w+/i)
+    assert @tester.bellini.match?(/\w+/i)
   end
 end

--- a/test/faker/music/test_faker_pearl_jam.rb
+++ b/test/faker/music/test_faker_pearl_jam.rb
@@ -8,14 +8,14 @@ class TestFakerPearlJam < Test::Unit::TestCase
   end
 
   def test_musician
-    assert @tester.musician.match(/\w/)
+    assert @tester.musician.match?(/\w/)
   end
 
   def test_album
-    assert @tester.album.match(/\w/)
+    assert @tester.album.match?(/\w/)
   end
 
   def test_song
-    assert @tester.song.match(/\w/)
+    assert @tester.song.match?(/\w/)
   end
 end

--- a/test/faker/music/test_faker_phish.rb
+++ b/test/faker/music/test_faker_phish.rb
@@ -8,14 +8,14 @@ class TestFakerPhish < Test::Unit::TestCase
   end
 
   def test_album
-    assert @tester.album.match(/\w+/)
+    assert @tester.album.match?(/\w+/)
   end
 
   def test_musician
-    assert @tester.musician.match(/\w+/)
+    assert @tester.musician.match?(/\w+/)
   end
 
   def test_song
-    assert @tester.song.match(/\w+/)
+    assert @tester.song.match?(/\w+/)
   end
 end

--- a/test/faker/music/test_faker_prince.rb
+++ b/test/faker/music/test_faker_prince.rb
@@ -8,18 +8,18 @@ class TestFakerPRince < Test::Unit::TestCase
   end
 
   def test_song
-    assert @tester.song.match(/\w+/)
+    assert @tester.song.match?(/\w+/)
   end
 
   def test_lyric
-    assert @tester.lyric.match(/\w+/)
+    assert @tester.lyric.match?(/\w+/)
   end
 
   def test_album
-    assert @tester.album.match(/\w+/)
+    assert @tester.album.match?(/\w+/)
   end
 
   def test_band
-    assert @tester.band.match(/\w+/)
+    assert @tester.band.match?(/\w+/)
   end
 end

--- a/test/faker/music/test_faker_rock_band.rb
+++ b/test/faker/music/test_faker_rock_band.rb
@@ -8,6 +8,6 @@ class TestFakerRockBand < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/\w+/)
+    assert @tester.name.match?(/\w+/)
   end
 end

--- a/test/faker/music/test_faker_rush.rb
+++ b/test/faker/music/test_faker_rush.rb
@@ -8,10 +8,10 @@ class TestFakerRush < Test::Unit::TestCase
   end
 
   def test_player
-    assert @tester.player.match(/\w+/)
+    assert @tester.player.match?(/\w+/)
   end
 
   def test_album
-    assert @tester.album.match(/\w+/)
+    assert @tester.album.match?(/\w+/)
   end
 end

--- a/test/faker/music/test_faker_show.rb
+++ b/test/faker/music/test_faker_show.rb
@@ -4,14 +4,14 @@ require_relative '../../test_helper'
 
 class TestFakerShow < Test::Unit::TestCase
   def test_adult_musical
-    assert Faker::Show.adult_musical.match(/\w+/)
+    assert Faker::Show.adult_musical.match?(/\w+/)
   end
 
   def test_kids_musical
-    assert Faker::Show.kids_musical.match(/\w+/)
+    assert Faker::Show.kids_musical.match?(/\w+/)
   end
 
   def test_play
-    assert Faker::Show.play.match(/\w+/)
+    assert Faker::Show.play.match?(/\w+/)
   end
 end

--- a/test/faker/music/test_faker_umphreys_mcgee.rb
+++ b/test/faker/music/test_faker_umphreys_mcgee.rb
@@ -8,6 +8,6 @@ class TestFakerUmphreysMcgee < Test::Unit::TestCase
   end
 
   def test_song
-    assert @tester.song.match(/\w+/)
+    assert @tester.song.match?(/\w+/)
   end
 end

--- a/test/faker/quotes/test_faker_chiquito.rb
+++ b/test/faker/quotes/test_faker_chiquito.rb
@@ -8,18 +8,18 @@ class TestFakerChiquito < Test::Unit::TestCase
   end
 
   def test_expression
-    assert @tester.expression.match(/\w+/)
+    assert @tester.expression.match?(/\w+/)
   end
 
   def test_term
-    assert @tester.term.match(/\w+/)
+    assert @tester.term.match?(/\w+/)
   end
 
   def test_joke
-    assert @tester.joke.match(/\w+/)
+    assert @tester.joke.match?(/\w+/)
   end
 
   def test_sentence
-    assert @tester.sentence.match(/\w+/)
+    assert @tester.sentence.match?(/\w+/)
   end
 end

--- a/test/faker/quotes/test_faker_quote.rb
+++ b/test/faker/quotes/test_faker_quote.rb
@@ -8,26 +8,26 @@ class TestFakerYoda < Test::Unit::TestCase
   end
 
   def test_famous_last_words
-    assert @tester.famous_last_words.match(/\w+/)
+    assert @tester.famous_last_words.match?(/\w+/)
   end
 
   def test_matz
-    assert @tester.matz.match(/\w+/)
+    assert @tester.matz.match?(/\w+/)
   end
 
   def test_most_interesting_man_in_the_world
-    assert @tester.most_interesting_man_in_the_world.match(/\w+/)
+    assert @tester.most_interesting_man_in_the_world.match?(/\w+/)
   end
 
   def test_robin
-    assert @tester.robin.match(/\w+/)
+    assert @tester.robin.match?(/\w+/)
   end
 
   def test_singular_siegler
-    assert @tester.singular_siegler.match(/\w+/)
+    assert @tester.singular_siegler.match?(/\w+/)
   end
 
   def test_yoda
-    assert @tester.yoda.match(/\w+/)
+    assert @tester.yoda.match?(/\w+/)
   end
 end

--- a/test/faker/quotes/test_faker_rajnikanth.rb
+++ b/test/faker/quotes/test_faker_rajnikanth.rb
@@ -8,6 +8,6 @@ class TestFakerRajnikanth < Test::Unit::TestCase
   end
 
   def test_jokes
-    assert @tester.joke.match(/\w+/)
+    assert @tester.joke.match?(/\w+/)
   end
 end

--- a/test/faker/quotes/test_faker_shakespeare.rb
+++ b/test/faker/quotes/test_faker_shakespeare.rb
@@ -8,18 +8,18 @@ class TestFakerShakespeare < Test::Unit::TestCase
   end
 
   def test_as_you_like_it_quote
-    assert @tester.as_you_like_it_quote.match(/\w+/)
+    assert @tester.as_you_like_it_quote.match?(/\w+/)
   end
 
   def test_king_richard_iii_quote
-    assert @tester.king_richard_iii_quote.match(/\w+/)
+    assert @tester.king_richard_iii_quote.match?(/\w+/)
   end
 
   def test_romeo_and_juliet_quote
-    assert @tester.romeo_and_juliet_quote.match(/\w+/)
+    assert @tester.romeo_and_juliet_quote.match?(/\w+/)
   end
 
   def test_hamlet_quote
-    assert @tester.hamlet_quote.match(/\w+/)
+    assert @tester.hamlet_quote.match?(/\w+/)
   end
 end

--- a/test/faker/sports/test_faker_basketball.rb
+++ b/test/faker/sports/test_faker_basketball.rb
@@ -8,18 +8,18 @@ class TestFakerBasketball < Test::Unit::TestCase
   end
 
   def test_team
-    assert @tester.team.match(/\w+/)
+    assert @tester.team.match?(/\w+/)
   end
 
   def test_player
-    assert @tester.player.match(/\w+/)
+    assert @tester.player.match?(/\w+/)
   end
 
   def test_coach
-    assert @tester.coach.match(/\w+/)
+    assert @tester.coach.match?(/\w+/)
   end
 
   def test_position
-    assert @tester.position.match(/\w+/)
+    assert @tester.position.match?(/\w+/)
   end
 end

--- a/test/faker/sports/test_faker_football.rb
+++ b/test/faker/sports/test_faker_football.rb
@@ -8,22 +8,22 @@ class TestFakerFootball < Test::Unit::TestCase
   end
 
   def test_team
-    assert @tester.team.match(/\w+/)
+    assert @tester.team.match?(/\w+/)
   end
 
   def test_player
-    assert @tester.player.match(/\w+/)
+    assert @tester.player.match?(/\w+/)
   end
 
   def test_coach
-    assert @tester.coach.match(/\w+/)
+    assert @tester.coach.match?(/\w+/)
   end
 
   def test_competition
-    assert @tester.competition.match(/\w+/)
+    assert @tester.competition.match?(/\w+/)
   end
 
   def test_position
-    assert @tester.position.match(/\w+/)
+    assert @tester.position.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_aqua_teen_hunger_force.rb
+++ b/test/faker/tv_shows/test_aqua_teen_hunger_force.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsAquaTeenHungerForce < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w/)
+    assert @tester.character.match?(/\w/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w/)
+    assert @tester.quote.match?(/\w/)
   end
 end

--- a/test/faker/tv_shows/test_big_bang_theory.rb
+++ b/test/faker/tv_shows/test_big_bang_theory.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsBigBangTheory < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_bojack_horseman.rb
+++ b/test/faker/tv_shows/test_bojack_horseman.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsBojackHorseman < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_tongue_twister
-    assert @tester.tongue_twister.match(/\w+/)
+    assert @tester.tongue_twister.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_breaking_bad.rb
+++ b/test/faker/tv_shows/test_breaking_bad.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsBreakingBad < Test::Unit::TestCase
   end
 
   def test_character
-    10.times { assert @tester.character.match(/[\w]+/) }
+    10.times { assert @tester.character.match?(/[\w]+/) }
   end
 
   def test_episode
-    10.times { assert @tester.episode.match(/[\w]+/) }
+    10.times { assert @tester.episode.match?(/[\w]+/) }
   end
 end

--- a/test/faker/tv_shows/test_buffy.rb
+++ b/test/faker/tv_shows/test_buffy.rb
@@ -8,22 +8,22 @@ class TestFakerTvShowsBuffy < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_celebrity
-    assert @tester.celebrity.match(/\w+/)
+    assert @tester.celebrity.match?(/\w+/)
   end
 
   def test_big_bad
-    assert @tester.big_bad.match(/\w+/)
+    assert @tester.big_bad.match?(/\w+/)
   end
 
   def test_episode
-    assert @tester.episode.match(/\w+/)
+    assert @tester.episode.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_community.rb
+++ b/test/faker/tv_shows/test_community.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsCommunity < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.characters.match(/\w/)
+    assert @tester.characters.match?(/\w/)
   end
 
   def test_quote
-    assert @tester.quotes.match(/\w/)
+    assert @tester.quotes.match?(/\w/)
   end
 end

--- a/test/faker/tv_shows/test_dr_who.rb
+++ b/test/faker/tv_shows/test_dr_who.rb
@@ -9,36 +9,36 @@ class TestFakerTvShowsDrWho < Test::Unit::TestCase
   end
 
   def test_character
-    10.times { assert @tester.character.match(/[\w]+/) }
+    10.times { assert @tester.character.match?(/[\w]+/) }
   end
 
   def test_the_doctor
-    10.times { assert @tester.the_doctor.match(/[\w]+/) }
+    10.times { assert @tester.the_doctor.match?(/[\w]+/) }
   end
 
   def test_actor
-    10.times { assert @tester.actor.match(/[\w]+/) }
+    10.times { assert @tester.actor.match?(/[\w]+/) }
   end
 
   def test_catch_phrase
-    10.times { assert @tester.catch_phrase.match(/[\w]+/) }
+    10.times { assert @tester.catch_phrase.match?(/[\w]+/) }
   end
 
   def test_quote
-    10.times { assert @tester.quote.match(/[\w]+/) }
+    10.times { assert @tester.quote.match?(/[\w]+/) }
   end
 
   # deprecated
   def test_villian
-    10.times { assert @tester.villian.match(/[\w]+/) }
+    10.times { assert @tester.villian.match?(/[\w]+/) }
   end
 
   def test_villain
-    10.times { assert @tester.villain.match(/[\w]+/) }
+    10.times { assert @tester.villain.match?(/[\w]+/) }
   end
 
   def test_specie
-    10.times { assert @tester.specie.match(/[\w]+/) }
+    10.times { assert @tester.specie.match?(/[\w]+/) }
   end
 
   def test_locales

--- a/test/faker/tv_shows/test_dumb_and_dumber.rb
+++ b/test/faker/tv_shows/test_dumb_and_dumber.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsDumbAndDumber < Test::Unit::TestCase
   end
 
   def test_actor
-    assert @tester.actor.match(/\w+/)
+    assert @tester.actor.match?(/\w+/)
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_family_guy.rb
+++ b/test/faker/tv_shows/test_family_guy.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsFamilyGuy < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w/)
+    assert @tester.character.match?(/\w/)
   end
 
   def test_location
-    assert @tester.location.match(/\w/)
+    assert @tester.location.match?(/\w/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w/)
+    assert @tester.quote.match?(/\w/)
   end
 end

--- a/test/faker/tv_shows/test_friends.rb
+++ b/test/faker/tv_shows/test_friends.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsFriends < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_futurama.rb
+++ b/test/faker/tv_shows/test_futurama.rb
@@ -8,18 +8,18 @@ class TestFakerTvShowsFuturama < Test::Unit::TestCase
   end
 
   def test_characters
-    10.times { assert @tester.character.match(/[\w]+/) }
+    10.times { assert @tester.character.match?(/[\w]+/) }
   end
 
   def test_locations
-    10.times { assert @tester.location.match(/[\w]+/) }
+    10.times { assert @tester.location.match?(/[\w]+/) }
   end
 
   def test_quote
-    10.times { assert @tester.quote.match(/[\w]+/) }
+    10.times { assert @tester.quote.match?(/[\w]+/) }
   end
 
   def test_hermes_catchphrases
-    10.times { assert @tester.hermes_catchphrase.match(/[\w]+/) }
+    10.times { assert @tester.hermes_catchphrase.match?(/[\w]+/) }
   end
 end

--- a/test/faker/tv_shows/test_game_of_thrones.rb
+++ b/test/faker/tv_shows/test_game_of_thrones.rb
@@ -8,22 +8,22 @@ class TestFakerTvShowsGameOfThrones < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_house
-    assert @tester.house.match(/\w+/)
+    assert @tester.house.match?(/\w+/)
   end
 
   def test_city
-    assert @tester.city.match(/\w+/)
+    assert @tester.city.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_dragon
-    assert @tester.dragon.match(/\w+/)
+    assert @tester.dragon.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_hey_arnold.rb
+++ b/test/faker/tv_shows/test_hey_arnold.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsHeyArnold < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_how_i_met_your_mother.rb
+++ b/test/faker/tv_shows/test_how_i_met_your_mother.rb
@@ -8,18 +8,18 @@ class TestFakerTvShowsHowIMetYourMother < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_catch_phrase
-    assert @tester.catch_phrase.match(/\w+/)
+    assert @tester.catch_phrase.match?(/\w+/)
   end
 
   def test_high_five
-    assert @tester.high_five.match(/\w+/)
+    assert @tester.high_five.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_michael_scott.rb
+++ b/test/faker/tv_shows/test_michael_scott.rb
@@ -8,6 +8,6 @@ class TestFakerMichaelScott < Test::Unit::TestCase
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_new_girl.rb
+++ b/test/faker/tv_shows/test_new_girl.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsNewGirl < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_parks_and_rec.rb
+++ b/test/faker/tv_shows/test_parks_and_rec.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsParksAndRec < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_city
-    assert @tester.city.match(/\w+/)
+    assert @tester.city.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_rick_and_morty.rb
+++ b/test/faker/tv_shows/test_rick_and_morty.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsRickAndMorty < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_ru_paul.rb
+++ b/test/faker/tv_shows/test_ru_paul.rb
@@ -8,10 +8,10 @@ class TestFakerRuPaul < Test::Unit::TestCase
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/i)
+    assert @tester.quote.match?(/\w+/i)
   end
 
   def test_queen
-    assert @tester.queen.match(/\w+/i)
+    assert @tester.queen.match?(/\w+/i)
   end
 end

--- a/test/faker/tv_shows/test_seinfeld.rb
+++ b/test/faker/tv_shows/test_seinfeld.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsSeinfeld < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_business
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_silicon_valley.rb
+++ b/test/faker/tv_shows/test_silicon_valley.rb
@@ -8,34 +8,34 @@ class TestFakerTvShowsSiliconValley < Test::Unit::TestCase
   end
 
   def test_characters
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_companies
-    assert @tester.company.match(/\w+/)
+    assert @tester.company.match?(/\w+/)
   end
 
   def test_quotes
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_apps
-    assert @tester.app.match(/\w+/)
+    assert @tester.app.match?(/\w+/)
   end
 
   def test_inventions
-    assert @tester.invention.match(/\w+/)
+    assert @tester.invention.match?(/\w+/)
   end
 
   def test_mottos
-    assert @tester.motto.match(/\w+/)
+    assert @tester.motto.match?(/\w+/)
   end
 
   def test_urls
-    assert @tester.url.match(/\w+/)
+    assert @tester.url.match?(/\w+/)
   end
 
   def test_email
-    assert @tester.email.match(/\w+/)
+    assert @tester.email.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_simpsons.rb
+++ b/test/faker/tv_shows/test_simpsons.rb
@@ -9,19 +9,19 @@ class TestFakerTvShowsSimpsons < Test::Unit::TestCase
   end
 
   def test_characters
-    10.times { assert @tester.character.match(/[\w]+/) }
+    10.times { assert @tester.character.match?(/[\w]+/) }
   end
 
   def test_locations
-    10.times { assert @tester.location.match(/[\w]+/) }
+    10.times { assert @tester.location.match?(/[\w]+/) }
   end
 
   def test_quote
-    10.times { assert @tester.quote.match(/[\w]+/) }
+    10.times { assert @tester.quote.match?(/[\w]+/) }
   end
 
   def test_episode_titles
-    10.times { assert @tester.episode_title.match(/[\w]+/) }
+    10.times { assert @tester.episode_title.match?(/[\w]+/) }
   end
 
   def test_locales

--- a/test/faker/tv_shows/test_south_park.rb
+++ b/test/faker/tv_shows/test_south_park.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsSouthPark < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_star_trek.rb
+++ b/test/faker/tv_shows/test_star_trek.rb
@@ -8,18 +8,18 @@ class TestFakerTvShowsStarTrek < Test::Unit::TestCase
   end
 
   def test_characters
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_locations
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_species
-    assert @tester.specie.match(/\w+/)
+    assert @tester.specie.match?(/\w+/)
   end
 
   def test_villains
-    assert @tester.villain.match(/\w+/)
+    assert @tester.villain.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_stargate.rb
+++ b/test/faker/tv_shows/test_stargate.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsStargate < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_planet
-    assert @tester.planet.match(/\w+/)
+    assert @tester.planet.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_stranger_things.rb
+++ b/test/faker/tv_shows/test_stranger_things.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsThings < Test::Unit::TestCase
   end
 
   def test_characters
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quotes
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_suits.rb
+++ b/test/faker/tv_shows/test_suits.rb
@@ -8,10 +8,10 @@ class TestFakerTvShowsSuits < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_the_expanse.rb
+++ b/test/faker/tv_shows/test_the_expanse.rb
@@ -8,18 +8,18 @@ class TestFakerTvShowsTheExpanse < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 
   def test_ship
-    assert @tester.ship.match(/\w+/)
+    assert @tester.ship.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_the_fresh_prince_of_bel_air.rb
+++ b/test/faker/tv_shows/test_the_fresh_prince_of_bel_air.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsTheFreshPrinceOfBelAir < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_celebrity
-    assert @tester.celebrity.match(/\w+/)
+    assert @tester.celebrity.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_the_it_crowd.rb
+++ b/test/faker/tv_shows/test_the_it_crowd.rb
@@ -8,18 +8,18 @@ class TestFakerTvShowsTheItCrowd < Test::Unit::TestCase
   end
 
   def test_actors
-    assert @tester.actor.match(/\w+/)
+    assert @tester.actor.match?(/\w+/)
   end
 
   def test_characters
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_emails
-    assert @tester.email.match(/\w+/)
+    assert @tester.email.match?(/\w+/)
   end
 
   def test_quotes
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_the_thick_of_it.rb
+++ b/test/faker/tv_shows/test_the_thick_of_it.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsTheThickOfIt < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_department
-    assert @tester.department.match(/\w+/)
+    assert @tester.department.match?(/\w+/)
   end
 
   def test_position
-    assert @tester.position.match(/\w+/)
+    assert @tester.position.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_twin_peaks.rb
+++ b/test/faker/tv_shows/test_twin_peaks.rb
@@ -8,14 +8,14 @@ class TestFakerTvShowsTwinPeaks < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_location
-    assert @tester.location.match(/\w+/)
+    assert @tester.location.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/faker/tv_shows/test_venture_bros.rb
+++ b/test/faker/tv_shows/test_venture_bros.rb
@@ -8,18 +8,18 @@ class TestFakerTvShowsVentureBros < Test::Unit::TestCase
   end
 
   def test_character
-    assert @tester.character.match(/\w+/)
+    assert @tester.character.match?(/\w+/)
   end
 
   def test_vehicle
-    assert @tester.vehicle.match(/\w+/)
+    assert @tester.vehicle.match?(/\w+/)
   end
 
   def test_organization
-    assert @tester.organization.match(/\w+/)
+    assert @tester.organization.match?(/\w+/)
   end
 
   def test_quote
-    assert @tester.quote.match(/\w+/)
+    assert @tester.quote.match?(/\w+/)
   end
 end

--- a/test/test_en_locale.rb
+++ b/test/test_en_locale.rb
@@ -23,12 +23,12 @@ class TestEnLocale < Test::Unit::TestCase
 
   def test_valid_id_number
     id_num = Faker::IDNumber.valid
-    assert(Faker::IDNumber::INVALID_SSN.none? { |regex| id_num =~ regex })
+    assert(Faker::IDNumber::INVALID_SSN.none? { |regex| regex.match?(id_num) })
   end
 
   def test_invalid_id_number
     id_num = Faker::IDNumber.invalid
-    assert(Faker::IDNumber::INVALID_SSN.any? { |regex| id_num =~ regex })
+    assert(Faker::IDNumber::INVALID_SSN.any? { |regex| regex.match?(id_num) })
   end
 
   def test_values_trimmed

--- a/test/test_en_us_locale.rb
+++ b/test/test_en_us_locale.rb
@@ -85,11 +85,11 @@ class TestEnUsLocale < Test::Unit::TestCase
 
   def test_en_us_valid_id_number
     id_num = Faker::IDNumber.valid
-    assert(Faker::IDNumber::INVALID_SSN.none? { |regex| id_num =~ regex })
+    assert(Faker::IDNumber::INVALID_SSN.none? { |regex| regex.match?(id_num) })
   end
 
   def test_en_us_invalid_id_number
     id_num = Faker::IDNumber.invalid
-    assert(Faker::IDNumber::INVALID_SSN.any? { |regex| id_num =~ regex })
+    assert(Faker::IDNumber::INVALID_SSN.any? { |regex| regex.match?(id_num) })
   end
 end

--- a/test/test_es_locale.rb
+++ b/test/test_es_locale.rb
@@ -17,7 +17,7 @@ class TestEsLocale < Test::Unit::TestCase
 
   def test_locale_separate_from_i18n
     I18n.locale = :en
-    assert Faker::Address.street_name.match(//)
+    assert Faker::Address.street_name.match?(//)
   end
 
   def test_configured_locale_translation
@@ -85,8 +85,8 @@ class TestEsLocale < Test::Unit::TestCase
     assert Faker::Name.male_first_name.is_a? String
     assert Faker::Name.female_first_name.is_a? String
     assert Faker::Name.name.is_a? String
-    assert Faker::Name.initials.match(/[A-Z]{3}/)
-    assert Faker::Name.initials(number: 2).match(/[A-Z]{2}/)
+    assert Faker::Name.initials.match?(/[A-Z]{3}/)
+    assert Faker::Name.initials(number: 2).match?(/[A-Z]{2}/)
   end
 
   def test_es_vehicle_methods

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -15,12 +15,12 @@ class TestFaker < Test::Unit::TestCase
 
   def test_numerify
     100.times do
-      assert Faker::Base.numerify('###').match(/[1-9]\d{2}/)
+      assert Faker::Base.numerify('###').match?(/[1-9]\d{2}/)
     end
   end
 
   def test_letterify
-    assert Faker::Base.letterify('???').match(/[A-Z]{3}/)
+    assert Faker::Base.letterify('???').match?(/[A-Z]{3}/)
   end
 
   def test_regexify
@@ -29,7 +29,7 @@ class TestFaker < Test::Unit::TestCase
       'us phone' => /^(1-?)[2-8][0-1][0-9]-\d{3}-\d{4}$/
     }.each do |label, re|
       10.times do
-        assert re.match(result = Faker::Base.regexify(re)), "#{result} is not a match for #{label}"
+        assert re.match?(result = Faker::Base.regexify(re)), "#{result} is not a match for #{label}"
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ end
 #
 # @example
 #   deterministically_verify ->{ @tester.username('bo peep') } do |subject|
-#     assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
+#     assert subject.match?(/(bo(_|\.)peep|peep(_|\.)bo)/)
 #   end
 #
 def deterministically_verify(subject_proc, depth: 2, random: nil)

--- a/test/test_locale.rb
+++ b/test/test_locale.rb
@@ -14,10 +14,10 @@ class TestLocale < Test::Unit::TestCase
   def test_locale_separate_from_i18n
     I18n.locale = :en
     Faker::Config.locale = :de
-    assert Faker::PhoneNumber.phone_number.match(/\(0\d+\) \d+|\+49-\d+-\d+/)
-    assert Faker::Address.street_name.match(//)
+    assert Faker::PhoneNumber.phone_number.match?(/\(0\d+\) \d+|\+49-\d+-\d+/)
+    assert Faker::Address.street_name.match?(//)
     Faker::Config.locale = :ru
-    assert Faker::Internet.domain_name.match(/([\da-z\.-]+)\.([a-z\.]{2,6})/)
+    assert Faker::Internet.domain_name.match?(/([\da-z\.-]+)\.([a-z\.]{2,6})/)
   end
 
   def test_configured_locale_translation
@@ -72,7 +72,7 @@ class TestLocale < Test::Unit::TestCase
   def test_regex
     Faker::Config.locale = 'en-GB'
     re = /[A-PR-UWYZ]([A-HK-Y][0-9][ABEHMNPRVWXY0-9]?|[0-9][ABCDEFGHJKPSTUW0-9]?) [0-9][ABD-HJLNP-UW-Z]{2}/
-    assert re.match(result = Faker::Address.postcode), "#{result} didn't match #{re}"
+    assert re.match?(result = Faker::Address.postcode), "#{result} didn't match #{re}"
   end
 
   def test_available_locales

--- a/test/test_pt_br_locale.rb
+++ b/test/test_pt_br_locale.rb
@@ -15,20 +15,20 @@ class TestPtBrLocale < Test::Unit::TestCase
     assert Faker::Address.city.is_a? String
 
     assert Faker::Address.state_abbr.is_a? String
-    assert Faker::Address.state_abbr.match(/^[A-Z]{2}$/)
+    assert Faker::Address.state_abbr.match?(/^[A-Z]{2}$/)
 
     assert Faker::Address.country.is_a? String
 
     assert Faker::Address.building_number.is_a? String
-    assert Faker::Address.building_number.match(/^([0-9]+)|(s\/n)$/)
+    assert Faker::Address.building_number.match?(/^([0-9]+)|(s\/n)$/)
 
     assert Faker::Address.street_suffix.is_a? String
 
     assert Faker::Address.secondary_address.is_a? String
-    assert Faker::Address.secondary_address.match(/^[a-zA-Z\.]+\s[0-9]+$/)
+    assert Faker::Address.secondary_address.match?(/^[a-zA-Z\.]+\s[0-9]+$/)
 
     assert Faker::Address.postcode.is_a? String
-    assert Faker::Address.postcode.match(/^[0-9]{5}\-[0-9]{3}$/)
+    assert Faker::Address.postcode.match?(/^[0-9]{5}\-[0-9]{3}$/)
 
     assert Faker::Address.state.is_a? String
     assert Faker::Address.city.is_a? String
@@ -38,7 +38,7 @@ class TestPtBrLocale < Test::Unit::TestCase
 
   def test_pt_br_color_methods
     assert Faker::Color.hex_color.is_a? String
-    assert Faker::Color.hex_color.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
+    assert Faker::Color.hex_color.match?(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
 
     assert Faker::Color.color_name.is_a? String
 
@@ -84,7 +84,7 @@ class TestPtBrLocale < Test::Unit::TestCase
 
   def test_pt_br_internet_methods
     assert Faker::Internet.free_email.is_a? String
-    assert Faker::Internet.free_email.match(/^[a-z0-9._\-]+@[a-z0-9]+.[a-z]+.([a-z]+)?$/i)
+    assert Faker::Internet.free_email.match?(/^[a-z0-9._\-]+@[a-z0-9]+.[a-z]+.([a-z]+)?$/i)
 
     assert Faker::Internet.domain_suffix.is_a? String
   end
@@ -108,8 +108,8 @@ class TestPtBrLocale < Test::Unit::TestCase
     assert Faker::Name.male_first_name.is_a? String
     assert Faker::Name.female_first_name.is_a? String
     assert Faker::Name.name.is_a? String
-    assert Faker::Name.initials.match(/[A-Z]{3}/)
-    assert Faker::Name.initials(number: 2).match(/[A-Z]{2}/)
+    assert Faker::Name.initials.match?(/[A-Z]{3}/)
+    assert Faker::Name.initials(number: 2).match?(/[A-Z]{2}/)
   end
 
   def test_pt_br_team_methods
@@ -129,10 +129,10 @@ class TestPtBrLocale < Test::Unit::TestCase
 
   def test_pt_br_vehicle_methods
     assert Faker::Vehicle.license_plate.is_a? String
-    assert Faker::Vehicle.license_plate.match(/^[A-Z]{3}\-[0-9]{4}/)
+    assert Faker::Vehicle.license_plate.match?(/^[A-Z]{3}\-[0-9]{4}/)
 
     assert Faker::Vehicle.license_plate(state_abbreviation: 'RJ').is_a? String
-    assert Faker::Vehicle.license_plate(state_abbreviation: 'RJ').match(/^[A-Z]{3}\-[0-9]{4}/)
+    assert Faker::Vehicle.license_plate(state_abbreviation: 'RJ').match?(/^[A-Z]{3}\-[0-9]{4}/)
   end
 
   def test_pt_br_gender_methods

--- a/test/test_sv_locale.rb
+++ b/test/test_sv_locale.rb
@@ -12,7 +12,7 @@ class TestSVLocale < Test::Unit::TestCase
   end
 
   def test_address_methods
-    assert Faker::Address.postcode.match(/^[\d]{5}$/)
+    assert Faker::Address.postcode.match?(/^[\d]{5}$/)
     assert Faker::Address.city_suffix.is_a? String
     assert Faker::Address.city_prefix.is_a? String
     assert Faker::Address.country.is_a? String
@@ -55,8 +55,8 @@ class TestSVLocale < Test::Unit::TestCase
   end
 
   def test_sv_phone_number_methods
-    assert Faker::PhoneNumber.cell_phone.match(/^07[036]{1}[\-\s]?\d{3}[\-\s]?\d{4}$/)
-    assert Faker::PhoneNumber.phone_number.match(/^\d{4}[\s\-]?\d{4,6}$/)
+    assert Faker::PhoneNumber.cell_phone.match?(/^07[036]{1}[\-\s]?\d{3}[\-\s]?\d{4}$/)
+    assert Faker::PhoneNumber.phone_number.match?(/^\d{4}[\s\-]?\d{4,6}$/)
   end
 
   def test_sv_team_methods

--- a/test/test_uk_locale.rb
+++ b/test/test_uk_locale.rb
@@ -13,7 +13,7 @@ class TestUkLocale < Test::Unit::TestCase
   end
 
   def test_uk_zipcode_length
-    assert Faker::Address.zip_code.match(/^\d{5}$/)
+    assert Faker::Address.zip_code.match?(/^\d{5}$/)
     assert_send([Faker::Address, :street_prefix])
   end
 
@@ -38,8 +38,8 @@ class TestUkLocale < Test::Unit::TestCase
   end
 
   def test_uk_internet_methods
-    assert Faker::Internet.email.match(/.+@[^.].+\.\w+/)
-    assert Faker::Internet.domain_word.match(/^[\w-]+$/)
+    assert Faker::Internet.email.match?(/.+@[^.].+\.\w+/)
+    assert Faker::Internet.domain_word.match?(/^[\w-]+$/)
   end
 
   def test_uk_name_methods


### PR DESCRIPTION
Follow up #2038.

This PR uses `match?`. Since Ruby 2.4, `match?` method has been introduced.
If `MatchData` is not captured, it is faster to use `match?`.
