### PR TITLE
Add space between street name and building number in Finnish locale

### DIFF
--- a/lib/locales/fi-FI.yml
+++ b/lib/locales/fi-FI.yml
@@ -17,7 +17,7 @@ fi-FI:
       street_name:
         - "#{Name.last_name}#{street_suffix}"
       street_address:
-        - "#{street_name}#{building_number}"
+        - "#{street_name} #{building_number}"
       default_country: [Suomi]
 
     name:


### PR DESCRIPTION
`No-Story`

Description:
------
Finnsh addresses have a space between street name and building number.