### PR TITLE
Fix regression in Faker::Base58.encode (works in 2.12.0, breaks in 2.13.0)

### DIFF
--- a/lib/helpers/base58.rb
+++ b/lib/helpers/base58.rb
@@ -7,7 +7,7 @@ module Faker
       base = alphabet.size
 
       lv = 0
-      str.split('').reverse.each_with_index { |v, i| lv += v.unpack('C') * 256**i }
+      str.split('').reverse.each_with_index { |v, i| lv += v.unpack1('C') * 256**i }
 
       ret = +''
       while lv.positive?


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------

https://github.com/faker-ruby/faker/pull/2038/commits/0216e7d06537fbd32a4e05a1af0f298edb5ac0c3 from #2038 fixed the rubocop offense in a wrong way — it should've migrated to .unpack1 instead.
https://docs.rubocop.org/rubocop/0.85/cops_style.html#styleunpackfirst

This in turn breaks e.g. generation of bitcoin addresses:

```
irb(main):001:0> require 'faker'
=> true
irb(main):002:0> Faker::Blockchain::Bitcoin.address
Traceback (most recent call last):
       11: from /Users/vesa/.rbenv/versions/2.6.5/bin/irb:23:in `<main>'
       10: from /Users/vesa/.rbenv/versions/2.6.5/bin/irb:23:in `load'
        9: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        8: from (irb):2
        7: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/faker-2.13.0/lib/faker/blockchain/bitcoin.rb:27:in `address'
        6: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/faker-2.13.0/lib/faker/blockchain/bitcoin.rb:55:in `address_for'
        5: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/faker-2.13.0/lib/helpers/base58.rb:10:in `encode'
        4: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/faker-2.13.0/lib/helpers/base58.rb:10:in `each_with_index'
        3: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/faker-2.13.0/lib/helpers/base58.rb:10:in `each'
        2: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/faker-2.13.0/lib/helpers/base58.rb:10:in `block in encode'
        1: from /Users/vesa/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/faker-2.13.0/lib/helpers/base58.rb:10:in `+'
TypeError (Array can't be coerced into Integer)
```

This used to work in Faker 2.12.0 but got broken in 2.13.0.