### PR TITLE
Remove time formats from file

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -2,9 +2,6 @@ en:
   time:
     formats:
       us: "%m/%d/%Y %I:%M %p"
-      default: '%a, %d %b %Y %H:%M:%S %z'
-      long: '%B %d, %Y %H:%M'
-      short: '%d %b %H:%M'
     am: "AM"
     pm: "PM"
   faker:


### PR DESCRIPTION
Issue# 
------
#1978


Description:
------
This PR rollbacks part of this commit: 1977088, removing the keys from time.formats to not conflict main app locales files
