### PR TITLE
Remove redundant condition branch for Ruby 2.4

### DIFF
--- a/test/faker/default/test_faker_color.rb
+++ b/test/faker/default/test_faker_color.rb
@@ -33,13 +33,7 @@ class TestFakerColor < Test::Unit::TestCase
     assert @result.length == 3
 
     assert @result[0].between?(0, 360)
-
-    if RUBY_VERSION < '2.4.0'
-      assert @result[0].is_a?(Fixnum)
-    else
-      assert @result[0].is_a?(Integer)
-    end
-
+    assert @result[0].is_a?(Integer)
     assert @result[1].between?(0.0, 1.0)
     assert @result[2].between?(0.0, 1.0)
   end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -69,12 +69,7 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_username_with_utf_8_arg
-    # RUBY_VERSION < '2.4.0' is not able to downcase or upcase non-ascii strings
-    if RUBY_VERSION < '2.4.0'
-      assert @tester.username(specifier: 'Łucja').match('Łucja')
-    else
-      assert @tester.username(specifier: 'Łucja').match('łucja')
-    end
+    assert @tester.username(specifier: 'Łucja').match('łucja')
   end
 
   def test_username_with_very_large_integer_arg

--- a/test/faker/default/test_faker_markdown.rb
+++ b/test/faker/default/test_faker_markdown.rb
@@ -25,11 +25,7 @@ class TestFakerMarkdown < Test::Unit::TestCase
     test_trigger = @tester.ordered_list.split("\n")
 
     test_trigger.each do |line|
-      if RUBY_VERSION < '2.4.0'
-        assert_instance_of(Fixnum, line[0].to_i)
-      else
-        assert_instance_of(Integer, line[0].to_i)
-      end
+      assert_instance_of(Integer, line[0].to_i)
     end
   end
 

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -47,24 +47,9 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal info[:email], id_info[:email]
     assert_equal 'APP_ID', id_info[:aud]
     assert_equal openid_id, id_info[:openid_id]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, credentials[:expires_at]
-    else
-      assert_instance_of Integer, credentials[:expires_at]
-    end
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, id_info[:iat]
-    else
-      assert_instance_of Integer, id_info[:iat]
-    end
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, id_info[:exp]
-    else
-      assert_instance_of Integer, id_info[:exp]
-    end
+    assert_instance_of Integer, credentials[:expires_at]
+    assert_instance_of Integer, id_info[:iat]
+    assert_instance_of Integer, id_info[:exp]
   end
 
   def test_omniauth_google_with_name
@@ -130,13 +115,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, info[:image]
     assert boolean?(info[:verified])
     assert_instance_of String, credentials[:token]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, credentials[:expires_at]
-    else
-      assert_instance_of Integer, credentials[:expires_at]
-    end
-
+    assert_instance_of Integer, credentials[:expires_at]
     assert_equal true, credentials[:expires]
     assert_equal uid, extra_raw_info[:id]
     assert_equal info[:name], extra_raw_info[:name]
@@ -148,13 +127,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, location[:name]
     assert gender?(extra_raw_info[:gender])
     assert_equal info[:email], extra_raw_info[:email]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, extra_raw_info[:timezone]
-    else
-      assert_instance_of Integer, extra_raw_info[:timezone]
-    end
-
+    assert_instance_of Integer, extra_raw_info[:timezone]
     assert_instance_of String, extra_raw_info[:locale]
     assert boolean?(extra_raw_info[:verified])
     assert_instance_of String, extra_raw_info[:updated_time]
@@ -242,23 +215,11 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, credentials[:secret]
     assert_instance_of String, access_token
     assert_equal info[:name], raw_info[:name]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, raw_info[:listed_count]
-    else
-      assert_instance_of Integer, raw_info[:listed_count]
-    end
-
+    assert_instance_of Integer, raw_info[:listed_count]
     assert_instance_of String, raw_info[:profile_sidebar_border_color]
     refute raw_info[:url]
     assert_equal 'en', raw_info[:lang]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, raw_info[:statuses_count]
-    else
-      assert_instance_of Integer, raw_info[:statuses_count]
-    end
-
+    assert_instance_of Integer, raw_info[:statuses_count]
     assert_instance_of String, raw_info[:profile_image_url]
     assert_instance_of String, raw_info[:profile_background_image_url_https]
     assert_equal info[:location], raw_info[:location]
@@ -267,40 +228,16 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal uid, raw_info[:id]
     assert boolean?(raw_info[:profile_background_tile])
     assert_instance_of String, raw_info[:profile_sidebar_fill_color]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, raw_info[:followers_count]
-    else
-      assert_instance_of Integer, raw_info[:followers_count]
-    end
-
+    assert_instance_of Integer, raw_info[:followers_count]
     assert boolean?(raw_info[:default_profile_image])
     assert_equal '', raw_info[:screen_name]
     assert boolean?(raw_info[:following])
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, raw_info[:utc_offset]
-    else
-      assert_instance_of Integer, raw_info[:utc_offset]
-    end
-
+    assert_instance_of Integer, raw_info[:utc_offset]
     assert boolean?(raw_info[:verified])
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, raw_info[:favourites_count]
-    else
-      assert_instance_of Integer, raw_info[:favourites_count]
-    end
-
+    assert_instance_of Integer, raw_info[:favourites_count]
     assert_instance_of String, raw_info[:profile_background_color]
     assert boolean?(raw_info[:is_translator])
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, raw_info[:friends_count]
-    else
-      assert_instance_of Integer, raw_info[:friends_count]
-    end
-
+    assert_instance_of Integer, raw_info[:friends_count]
     assert boolean?(raw_info[:notifications])
     assert boolean?(raw_info[:geo_enabled])
     assert_instance_of String, raw_info[:profile_background_image_url]
@@ -389,15 +326,8 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     refute access_token[:consumer]
     assert_equal credentials[:token], params[:oauth_token]
     assert_equal credentials[:secret], params[:oauth_token_secret]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, params[:oauth_expires_in]
-      assert_instance_of Fixnum, params[:oauth_authorization_expires_in]
-    else
-      assert_instance_of Integer, params[:oauth_expires_in]
-      assert_instance_of Integer, params[:oauth_authorization_expires_in]
-    end
-
+    assert_instance_of Integer, params[:oauth_expires_in]
+    assert_instance_of Integer, params[:oauth_authorization_expires_in]
     refute access_token[:response]
     assert_equal info[:first_name], raw_info[:firstName]
     assert_equal info[:headline], raw_info[:headline]
@@ -494,19 +424,10 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, extra_raw_info[:location]
     assert_equal nil, extra_raw_info[:hireable]
     assert_equal nil, extra_raw_info[:bio]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, extra_raw_info[:public_repos]
-      assert_instance_of Fixnum, extra_raw_info[:public_gists]
-      assert_instance_of Fixnum, extra_raw_info[:followers]
-      assert_instance_of Fixnum, extra_raw_info[:following]
-    else
-      assert_instance_of Integer, extra_raw_info[:public_repos]
-      assert_instance_of Integer, extra_raw_info[:public_gists]
-      assert_instance_of Integer, extra_raw_info[:followers]
-      assert_instance_of Integer, extra_raw_info[:following]
-    end
-
+    assert_instance_of Integer, extra_raw_info[:public_repos]
+    assert_instance_of Integer, extra_raw_info[:public_gists]
+    assert_instance_of Integer, extra_raw_info[:followers]
+    assert_instance_of Integer, extra_raw_info[:following]
     assert_instance_of String, extra_raw_info[:created_at]
     assert_instance_of String, extra_raw_info[:updated_at]
   end
@@ -567,19 +488,10 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, info[:last_name]
     assert_instance_of String, credentials[:token]
     assert_instance_of String, credentials[:refresh_token]
-
-    if RUBY_VERSION < '2.4.0'
-      assert_instance_of Fixnum, credentials[:expires_at]
-      assert_instance_of Fixnum, raw_info[:exp]
-      assert_instance_of Fixnum, raw_info[:iat]
-      assert_instance_of Fixnum, raw_info[:auth_time]
-    else
-      assert_instance_of Integer, credentials[:expires_at]
-      assert_instance_of Integer, raw_info[:exp]
-      assert_instance_of Integer, raw_info[:iat]
-      assert_instance_of Integer, raw_info[:auth_time]
-    end
-
+    assert_instance_of Integer, credentials[:expires_at]
+    assert_instance_of Integer, raw_info[:exp]
+    assert_instance_of Integer, raw_info[:iat]
+    assert_instance_of Integer, raw_info[:auth_time]
     assert_equal 'https://appleid.apple.com', raw_info[:iss]
     assert_instance_of String, raw_info[:aud]
     assert_equal auth[:uid], raw_info[:sub]

--- a/test/faker/default/test_faker_types.rb
+++ b/test/faker/default/test_faker_types.rb
@@ -25,11 +25,7 @@ class TestFakerTypes < Test::Unit::TestCase
   end
 
   def test_integer
-    if RUBY_VERSION < '2.4.0'
-      assert @tester.rb_integer.class == Fixnum
-    else
-      assert @tester.rb_integer.class == Integer
-    end
+    assert @tester.rb_integer.class == Integer
   end
 
   def test_rb_integer_between


### PR DESCRIPTION
Follow up #2038.

Faker has been dropped support for Ruby 2.4.
