### PR TITLE
Correct method name from race to species in DnD doc

### DIFF
--- a/doc/games/dnd.md
+++ b/doc/games/dnd.md
@@ -1,7 +1,7 @@
 # Faker::Games::DnD
 
 ```ruby
-Faker::Games::DnD.race #=> "Dwarf"
+Faker::Games::DnD.species #=> "Dwarf"
 
 Faker::Games::DnD.klass #=> "Warlock"
 


### PR DESCRIPTION
(No issue number, just came across this in the wild and made a quick fix.)

Description:
------
Documentation for Faker::Games::DnD had incorrect method name `race` where the actual method name in the code is `species`. Updated documentation file to show correct method name.
