### PR TITLE
Fix a typo for `Games::DnD.species`

### DIFF
--- a/lib/faker/games/dnd.rb
+++ b/lib/faker/games/dnd.rb
@@ -10,7 +10,7 @@ module Faker
         # @return [String]
         #
         # @example
-        #   Faker::Games::DnD.race #=> "Dwarf"
+        #   Faker::Games::DnD.species #=> "Dwarf"
         #
         # @faker.version 2.13.0
         def species


### PR DESCRIPTION
Follow #2094.

This PR fixes a typo for `Games::DnD.species`.
