### PR TITLE
Update DnD generator

### DIFF
--- a/doc/games/dnd.md
+++ b/doc/games/dnd.md
@@ -1,11 +1,11 @@
 # Faker::Games::DnD
 
 ```ruby
-Faker::Games::DnD.species #=> "Dwarf"
-
-Faker::Games::DnD.klass #=> "Warlock"
+Faker::Games::DnD.alignment #=> "Lawful Neutral"
 
 Faker::Games::DnD.background #=> "Urchin"
 
-Faker::Games::DnD.alignment #=> "Lawful Neutral"
+Faker::Games::DnD.klass #=> "Warlock"
+
+Faker::Games::DnD.race #=> "Dwarf"
 ```

--- a/doc/games/dnd.md
+++ b/doc/games/dnd.md
@@ -5,7 +5,17 @@ Faker::Games::DnD.alignment #=> "Lawful Neutral"
 
 Faker::Games::DnD.background #=> "Urchin"
 
+Faker::Games::DnD.city #=> "Earthfast"
+
 Faker::Games::DnD.klass #=> "Warlock"
 
+Faker::Games::DnD.language #=> "Gnomish"
+
+Faker::Games::DnD.melee_weapon #=> "Handaxe"
+
+Faker::Games::DnD.monster #=> "Manticore"
+
 Faker::Games::DnD.race #=> "Dwarf"
+
+Faker::Games::DnD.ranged_weapon #=> "Shortbow"
 ```

--- a/lib/faker/games/dnd.rb
+++ b/lib/faker/games/dnd.rb
@@ -31,6 +31,19 @@ module Faker
         end
 
         ##
+        # Produces the name of a city from Dungeons and Dragons.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Games::DnD.city #=> "Earthfast"
+        #
+        # @faker.version next
+        def city
+          fetch('dnd.cities')
+        end
+
+        ##
         # Produces the name of a class from Dungeons and Dragons (PHB).
         #
         # @return [String]
@@ -41,6 +54,45 @@ module Faker
         # @faker.version 2.13.0
         def klass
           fetch('dnd.klasses')
+        end
+
+        ##
+        # Produces the name of a language from Dungeons and Dragons.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Games::DnD.language #=> "Gnomish"
+        #
+        # @faker.version next
+        def language
+          fetch('dnd.languages')
+        end
+
+        ##
+        # Produces the name of a melee weapon from Dungeons and Dragons.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Games::DnD.melee_weapon #=> "Handaxe"
+        #
+        # @faker.version next
+        def melee_weapon
+          fetch('dnd.melee_weapons')
+        end
+
+        ##
+        # Produces the name of a monster from Dungeons and Dragons.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Games::DnD.monster #=> "Manticore"
+        #
+        # @faker.version next
+        def monster
+          fetch('dnd.monsters')
         end
 
         ##
@@ -57,6 +109,18 @@ module Faker
         end
 
         ##
+        # Produces the name of a ranged weapon from Dungeons and Dragons.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Games::DnD.ranged_weapon #=> "Shortbow"
+        #
+        # @faker.version next
+        def ranged_weapon
+          fetch('dnd.ranged_weapons')
+        end
+
         # This method is deprecated. The implementation will be removed in a near future release.
         # Use `DnD.race` instead.
         #

--- a/lib/faker/games/dnd.rb
+++ b/lib/faker/games/dnd.rb
@@ -5,29 +5,16 @@ module Faker
     class DnD < Base
       class << self
         ##
-        # Produces the name of a race from Dungeons and Dragons (PHB).
+        # Produces the name of an alignment from Dungeons and Dragons.
         #
         # @return [String]
         #
         # @example
-        #   Faker::Games::DnD.species #=> "Dwarf"
+        #   Faker::Games::DnD.alignment #=> "Lawful Neutral"
         #
         # @faker.version 2.13.0
-        def species
-          fetch('dnd.species')
-        end
-
-        ##
-        # Produces the name of a class from Dungeons and Dragons (PHB).
-        #
-        # @return [String]
-        #
-        # @example
-        #   Faker::Games::DnD.klass #=> "Warlock"
-        #
-        # @faker.version 2.13.0
-        def klass
-          fetch('dnd.klasses')
+        def alignment
+          fetch('dnd.alignments')
         end
 
         ##
@@ -44,16 +31,40 @@ module Faker
         end
 
         ##
-        # Produces the name of an alignment from Dungeons and Dragons.
+        # Produces the name of a class from Dungeons and Dragons (PHB).
         #
         # @return [String]
         #
         # @example
-        #   Faker::Games::DnD.alignment #=> "Lawful Neutral"
+        #   Faker::Games::DnD.klass #=> "Warlock"
         #
         # @faker.version 2.13.0
-        def alignment
-          fetch('dnd.alignments')
+        def klass
+          fetch('dnd.klasses')
+        end
+
+        ##
+        # Produces the name of a race from Dungeons and Dragons (PHB).
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Games::DnD.races #=> "Dwarf"
+        #
+        # @faker.version next
+        def race
+          fetch('dnd.races')
+        end
+
+        ##
+        # This method is deprecated. The implementation will be removed in a near future release.
+        # Use `DnD.race` instead.
+        #
+        # @deprecated Use {#race} instead.
+        def species
+          warn '`DnD.species` is deprecated. Use `DnD.race` instead.'
+
+          super
         end
       end
     end

--- a/lib/locales/en/dnd.yml
+++ b/lib/locales/en/dnd.yml
@@ -67,6 +67,64 @@ en:
         - Uthgardt Tribe Member
         - Vizier
         - Waterdhavian Noble
+      cities:
+        - Almraiven
+        - Berdusk
+        - Bildoobaris
+        - Chethel
+        - Citadel Adbar
+        - Citadel of Ten Thousand Pearls
+        - Crimmor
+        - Derlusk
+        - Dhaztanar
+        - Drik Hargunen
+        - Earthfast
+        - Elbulder
+        - Elturel
+        - Escalant
+        - Eshpurta
+        - Esmeltaran
+        - Everlund
+        - Fireshear
+        - Hlammach
+        - Hlath
+        - Iljak
+        - Immilmar
+        - Iriaebor
+        - Keltar
+        - Kuda
+        - Lushpool
+        - Luskan
+        - Mintar
+        - Nathlekh
+        - Neverwinter
+        - Nimpeth
+        - Ormpur
+        - Orvyltar
+        - Phsant
+        - Procampur
+        - Proskur
+        - Reth
+        - Sammaresh
+        - Scornubel
+        - Sloopdilmonpolop
+        - Sundabar
+        - Tamanokuni
+        - Tantras
+        - Telflamm
+        - Telos
+        - Teshburl
+        - Trailsend
+        - Tsurlagol
+        - Tukan
+        - Ubar
+        - Ulatos
+        - Urmlaspyr
+        - Vilkstead
+        - Waterdeep
+        - Yeshpek
+        - Yhaunn
+        - Zhentil Keep
       klasses:
         - Artificer
         - Barbarian
@@ -82,6 +140,267 @@ en:
         - Sorcerer
         - Warlock
         - Wizard
+      languages:
+        - Abyssal
+        - Celestial
+        - Common
+        - Deep Speech
+        - Draconic
+        - Dwarvish
+        - Elvish
+        - Giant
+        - Gnomish
+        - Goblin
+        - Halfling
+        - Infernal
+        - Orc
+        - Primordial
+        - Sylvan
+        - Undercommon
+      melee_weapons:
+        - Battleaxe
+        - Club
+        - Dagger
+        - Flail
+        - Glaive
+        - Greatclub
+        - Greatsword
+        - Halberd
+        - Handaxe
+        - Javelin
+        - Lance
+        - Light hammer
+        - Longsword
+        - Mace
+        - Maul
+        - Morningstar
+        - Pike
+        - Quarterstaff
+        - Rapier
+        - Scimitar
+        - Shortsword
+        - Sickle
+        - Spear
+        - Trident
+        - War Pick
+        - Warhammer
+        - Whip
+      monsters:
+        - Aarakocra
+        - Aboleth
+        - Adult Black Dragon
+        - Adult Blue Dragon
+        - Adult Brass Dragon
+        - Adult Bronze Dragon
+        - Adult Copper Dragon
+        - Adult Gold Dragon
+        - Adult Green Dragon
+        - Adult Red Dragon
+        - Adult Silver Dragon
+        - Adult White Dragon
+        - Air Elemental
+        - Allosaurus
+        - Ancient Black Dragon
+        - Ancient Blue Dragon
+        - Ancient Brass Dragon
+        - Ancient Bronze Dragon
+        - Ancient Copper Dragon
+        - Ancient Gold Dragon
+        - Ancient Green Dragon
+        - Ancient Red Dragon
+        - Ancient Silver Dragon
+        - Ancient White Dragon
+        - Androsphinx
+        - Animated Armor
+        - Animated Objects
+        - Ankheg
+        - Ankylosaurus
+        - Azer
+        - Balor
+        - Barbed Devil
+        - Basilisk
+        - Bearded Devil
+        - Behir
+        - Black Dragon Wyrmling
+        - Black Pudding
+        - Blue Dragon Wyrmling
+        - Bone Devil
+        - Brass Dragon Wyrmling
+        - Bronze Dragon Wyrmling
+        - Bugbear
+        - Bulette
+        - Bullywug
+        - Centaur
+        - Chain Devil
+        - Chimera
+        - Chuul
+        - Clay Golem
+        - Cloaker
+        - Cloud Giant
+        - Cockatrice
+        - Copper Dragon Wyrmling
+        - Couatl
+        - Darkmantle
+        - Deck of Many Things
+        - Demons
+        - Deva
+        - Dinosaurs
+        - Djinni
+        - Doppelganger
+        - Dragon Turtle
+        - Dretch
+        - Drider
+        - Drow
+        - Dryad
+        - Duergar
+        - Dust Mephit
+        - Earth Elemental
+        - Efreeti
+        - Elf
+        - Erinyes
+        - Ettercap
+        - Ettin
+        - Figurine of Wondrous Power
+        - Fire Elemental
+        - Fire Giant
+        - Flesh Golem
+        - Flying Sword
+        - Frost Giant
+        - Fungi
+        - Gargoyle
+        - Gelatinous Cube
+        - Ghast
+        - Ghost
+        - Ghoul
+        - Gibbering Mouther
+        - Glabrezu
+        - Gnoll
+        - Goblin
+        - Gold Dragon Wyrmling
+        - Gorgon
+        - Gray Ooze
+        - Green Dragon Wyrmling
+        - Green Hag
+        - Grick
+        - Griffon
+        - Grimlock
+        - Guardian Naga
+        - Gynosphinx
+        - Half-Red Dragon Veteran
+        - Harpy
+        - Hell Hound
+        - Hezrou
+        - Hill Giant
+        - Hippogriff
+        - Hobgoblin
+        - Homunculus
+        - Horned Devil
+        - Hydra
+        - Ice Devil
+        - Ice Mephit
+        - Imp
+        - Invisible Stalker
+        - Iron Golem
+        - Kobold
+        - Kraken
+        - Lamia
+        - Lemure
+        - Lich
+        - Lizardfolk
+        - Lycanthropes
+        - Magma Mephit
+        - Magmin
+        - Manticore
+        - Marilith
+        - Medusa
+        - Merfolk
+        - Merrow
+        - Mimic
+        - Minotaur
+        - Minotaur Skeleton
+        - Mummy
+        - Mummy Lord
+        - Nagas
+        - Nalfeshnee
+        - Night Hag
+        - Nightmare
+        - Ochre Jelly
+        - Ogre
+        - Ogre Zombie
+        - Oni
+        - Orc
+        - Otyugh
+        - Owlbear
+        - Pegasus
+        - Pit Fiend
+        - Planetar
+        - Plesiosaurus
+        - Pseudodragon
+        - Pteranodon
+        - Purple Worm
+        - Quasit
+        - Rakshasa
+        - Red Dragon Wyrmling
+        - Remorhaz
+        - Roc
+        - Roper
+        - Rug of Smothering
+        - Rust Monster
+        - Sahuagin
+        - Salamander
+        - Satyr
+        - Sea Hag
+        - Shadow
+        - Shambling Mound
+        - Shield Guardian
+        - Shrieker
+        - Silver Dragon Wyrmling
+        - Skeleton
+        - Solar
+        - Specter
+        - Sphinxes
+        - Spirit Naga
+        - Sprite
+        - Steam Mephit
+        - Stirge
+        - Stone Giant
+        - Stone Golem
+        - Storm Giant
+        - Succubus/Incubus
+        - Tarrasque
+        - Treant
+        - Triceratops
+        - Troll
+        - Tyrannosaurus Rex
+        - Unicorn
+        - Vampire
+        - Vampire Spawn
+        - Violet Fungus
+        - Vrock
+        - Warhorse Skeleton
+        - Water Elemental
+        - Werebear
+        - Wereboar
+        - Wererat
+        - Weretiger
+        - Werewolf
+        - White Dragon Wyrmling
+        - Wight
+        - Will-o'-Wisp
+        - Wraith
+        - Wyvern
+        - Xorn
+        - Young Black Dragon
+        - Young Blue Dragon
+        - Young Brass Dragon
+        - Young Bronze Dragon
+        - Young Copper Dragon
+        - Young Gold Dragon
+        - Young Green Dragon
+        - Young Red Dragon
+        - Young Silver Dragon
+        - Young White Dragon
+        - Zombie
       races:
         - Aarakocra
         - Aasimar
@@ -121,3 +440,12 @@ en:
         - Verdan
         - Warforged
         - Yuan-Ti
+      ranged_weapons:
+        - Blowgun
+        - Boomerang
+        - Crossbow
+        - Dart
+        - Longbow
+        - Net
+        - Shortbow
+        - Sling

--- a/lib/locales/en/dnd.yml
+++ b/lib/locales/en/dnd.yml
@@ -13,25 +13,65 @@ en:
         - True Neutral
       backgrounds:
         - Acolyte
+        - Anthropologist
+        - Archaeologist
+        - Black Fist Double Agent
+        - Caravan Specialist
         - Charlatan
+        - City Watch
+        - Clan Crafter
+        - Cloistered Scholar
+        - Cormanthor Refugee
+        - Courtier
         - Criminal
+        - Dragon Casualty
+        - Earthspur Miner
         - Entertainer
+        - Faction Agent
+        - Far Traveler
         - Folk Hero
+        - Gate Urchin
         - Gladiator
         - Guild Artisan
         - Guild Merchant
+        - Harborfolk
+        - Haunted One
+        - Heretic
         - Hermit
+        - Hillsfar Merchant
+        - Hillsfar Smuggler
+        - Initiate
+        - Inquisitor
+        - Investigator
+        - Iron Route Bandit
+        - Knight
+        - Knight of the Order
+        - Mercenary Veteran
+        - Mulmaster Aristocrat
         - Noble
         - Outlander
+        - Phlan Insurgent
+        - Phlan Refugee
         - Pirate
         - Sage
         - Sailor
+        - Secret Identity
+        - Shade Fanatic
         - Soldier
         - Spy
+        - Stojanow Prisoner
+        - Ticklebelly Nomad
+        - Trade Sheriff
+        - Urban Bounty Hunter
         - Urchin
+        - Uthgardt Tribe Member
+        - Vizier
+        - Waterdhavian Noble
       klasses:
+        - Artificer
         - Barbarian
         - Bard
+        - Blood Hunter
         - Cleric
         - Druid
         - Fighter
@@ -43,12 +83,41 @@ en:
         - Warlock
         - Wizard
       races:
+        - Aarakocra
+        - Aasimar
+        - Bugbear
+        - Centaur
+        - Changeling
         - Dragonborn
         - Dwarf
         - Elf
+        - Firbolg
+        - Genasi
+        - Gith
         - Gnome
+        - Goblin
+        - Goliath
+        - Grung
         - Half-Elf
-        - Halfling
         - Half-Orc
+        - Halfling
+        - Hobgoblin
         - Human
-        - Tielfing
+        - Kalashtar
+        - Kenku
+        - Kobold
+        - Lizardfolk
+        - Locathah
+        - Loxodon
+        - Minotaur
+        - Orc
+        - Shifter
+        - Simic Hybrid
+        - Tabaxi
+        - Tiefling
+        - Tortle
+        - Triton
+        - Vedalken
+        - Verdan
+        - Warforged
+        - Yuan-Ti

--- a/lib/locales/en/dnd.yml
+++ b/lib/locales/en/dnd.yml
@@ -1,29 +1,16 @@
 en:
   faker:
     dnd:
-      species:
-        - Dragonborn
-        - Dwarf
-        - Elf
-        - Gnome
-        - Half-Elf
-        - Halfling
-        - Half-Orc
-        - Human
-        - Tielfing
-      klasses:
-        - Barbarian
-        - Bard
-        - Cleric
-        - Druid
-        - Fighter
-        - Monk
-        - Paladin
-        - Ranger
-        - Rogue
-        - Sorcerer
-        - Warlock
-        - Wizard
+      alignments:
+        - Chaotic Evil
+        - Chaotic Good
+        - Chaotic Neutral
+        - Lawful Evil
+        - Lawful Good
+        - Lawful Neutral
+        - Neutral Evil
+        - Neutral Good
+        - True Neutral
       backgrounds:
         - Acolyte
         - Charlatan
@@ -42,13 +29,26 @@ en:
         - Soldier
         - Spy
         - Urchin
-      alignments:
-        - Lawful Good
-        - Neutral Good
-        - Chaotic Good
-        - Lafwul Neutral
-        - Neutral
-        - Chaotic Neutral
-        - Lawful Evil
-        - Neutral Evil
-        - Chaotic Evil
+      klasses:
+        - Barbarian
+        - Bard
+        - Cleric
+        - Druid
+        - Fighter
+        - Monk
+        - Paladin
+        - Ranger
+        - Rogue
+        - Sorcerer
+        - Warlock
+        - Wizard
+      races:
+        - Dragonborn
+        - Dwarf
+        - Elf
+        - Gnome
+        - Half-Elf
+        - Halfling
+        - Half-Orc
+        - Human
+        - Tielfing

--- a/test/faker/games/test_faker_dnd.rb
+++ b/test/faker/games/test_faker_dnd.rb
@@ -7,19 +7,19 @@ class TestFakerDnD < Test::Unit::TestCase
     @tester = Faker::Games::DnD
   end
 
-  def test_species
-    assert @tester.species.match(/\w+/)
-  end
-
-  def test_klass
-    assert @tester.klass.match(/\w+/)
+  def test_alignment
+    assert @tester.alignment.match(/\w+/)
   end
 
   def test_background
     assert @tester.background.match(/\w+/)
   end
 
-  def test_alignment
-    assert @tester.alignment.match(/\w+/)
+  def test_klass
+    assert @tester.klass.match(/\w+/)
+  end
+
+  def test_race
+    assert @tester.race.match(/\w+/)
   end
 end

--- a/test/faker/games/test_faker_dnd.rb
+++ b/test/faker/games/test_faker_dnd.rb
@@ -15,11 +15,31 @@ class TestFakerDnD < Test::Unit::TestCase
     assert @tester.background.match(/\w+/)
   end
 
+  def test_city
+    assert @tester.city.match(/\w+/)
+  end
+
   def test_klass
     assert @tester.klass.match(/\w+/)
   end
 
+  def test_language
+    assert @tester.language.match(/\w+/)
+  end
+
+  def test_melee_weapon
+    assert @tester.melee_weapon.match(/\w+/)
+  end
+
+  def test_monster
+    assert @tester.monster.match(/\w+/)
+  end
+
   def test_race
     assert @tester.race.match(/\w+/)
+  end
+
+  def test_ranged_weapon
+    assert @tester.ranged_weapon.match(/\w+/)
   end
 end


### PR DESCRIPTION
Added DND generators for cities, languages, monsters and weapons (melee and ranged).

Updated existing generators to include resources from 5th edition DND players handbook.

Deprecated `species` and readded as `races`, as referenced in the handbook.