### PR TITLE
Removed extra space getting added in words method

### DIFF
--- a/lib/faker/books/lovecraft.rb
+++ b/lib/faker/books/lovecraft.rb
@@ -88,7 +88,10 @@ module Faker
             keywords << :random_words_to_add if legacy_random_words_to_add != NOT_GIVEN
           end
 
-          words(number: word_count + rand(random_words_to_add.to_i).to_i, spaces_allowed: true).join(' ').capitalize + '.'
+          words(
+            number: word_count + rand(random_words_to_add.to_i).to_i,
+            spaces_allowed: true
+          ).map { |w| w.delete(' ') }.join(' ').capitalize + '.'
         end
 
         ##
@@ -177,11 +180,7 @@ module Faker
             keywords << :number if legacy_number != NOT_GIVEN
           end
 
-          [].tap do |sentences|
-            1.upto(resolve(number)) do
-              sentences << sentence(word_count: 3)
-            end
-          end
+          1.upto(resolve(number)).map { sentence(word_count: 3) }
         end
 
         ##

--- a/lib/faker/default/hipster.rb
+++ b/lib/faker/default/hipster.rb
@@ -79,7 +79,11 @@ module Faker
           keywords << :random_words_to_add if legacy_random_words_to_add != NOT_GIVEN
         end
 
-        words(number: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental, spaces_allowed: true).join(' ').capitalize + '.'
+        words(
+          number: word_count + rand(random_words_to_add.to_i).to_i,
+          supplemental: supplemental,
+          spaces_allowed: true
+        ).map { |w| w.delete(' ') }.join(' ').capitalize + '.'
       end
 
       ##
@@ -101,11 +105,7 @@ module Faker
           keywords << :supplemental if legacy_supplemental != NOT_GIVEN
         end
 
-        [].tap do |sentences|
-          1.upto(resolve(number)) do
-            sentences << sentence(word_count: 3, supplemental: supplemental)
-          end
-        end
+        1.upto(resolve(number)).map { sentence(word_count: 3, supplemental: supplemental) }
       end
 
       ##

--- a/lib/faker/default/lorem.rb
+++ b/lib/faker/default/lorem.rb
@@ -64,7 +64,10 @@ module Faker
           keywords << :random_words_to_add if legacy_random_words_to_add != NOT_GIVEN
         end
 
-        words(number: word_count + rand(random_words_to_add.to_i), supplemental: supplemental).join(locale_space).capitalize + locale_period
+        words(
+          number: word_count + rand(random_words_to_add.to_i),
+          supplemental: supplemental
+        ).map { |w| w.delete(locale_space) }.join(locale_space).capitalize + locale_period
       end
 
       def sentences(legacy_number = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, number: 3, supplemental: false)
@@ -73,7 +76,7 @@ module Faker
           keywords << :supplemental if legacy_supplemental != NOT_GIVEN
         end
 
-        1.upto(resolve(number)).collect { sentence(word_count: 3, supplemental: supplemental) }
+        1.upto(resolve(number)).map { sentence(word_count: 3, supplemental: supplemental) }
       end
 
       # rubocop:disable Metrics/ParameterLists


### PR DESCRIPTION
Issue #2102 

Description:
------
This is patch for the sentence methods in lib, as `words` sometime returns a word with space in between two characters causing sentence to return more that required number of words even if random word count param as 0 is passed.

Also refactored code and chose `map` over `collect` as Ruby best practice.

