### PR TITLE
Allow disabling the usage of open compounds in sentences

### DIFF
--- a/doc/books/lovecraft.md
+++ b/doc/books/lovecraft.md
@@ -12,10 +12,11 @@ Faker::Books::Lovecraft.location #=> "Kingsport"
 
 Faker::Books::Lovecraft.word #=> "furtive"
 
-# Keyword arguments: word_count, random_words_to_add
+# Keyword arguments: word_count, random_words_to_add, open_compounds_allowed
 Faker::Books::Lovecraft.sentence #=> "Furtive antiquarian squamous dank cat loathsome amorphous lurk."
 Faker::Books::Lovecraft.sentence(word_count: 3) #=> "Daemoniac antediluvian fainted squamous comprehension gambrel nameless singular."
 Faker::Books::Lovecraft.sentence(word_count: 3, random_words_to_add: 1) #=> "Amorphous indescribable tenebrous."
+Faker::Books::Lovecraft.sentence(word_count: 3, random_words_to_add: 0, open_compounds_allowed: true) #=> "Effulgence unmentionable gambrel." 
 
 # Keyword arguments: number, spaces_allowed
 Faker::Books::Lovecraft.words #=> ["manuscript", "abnormal", "singular"]

--- a/doc/default/hipster.md
+++ b/doc/default/hipster.md
@@ -11,12 +11,14 @@ Faker::Hipster.words(number: 4) #=> ["ugh", "cardigan", "poutine", "stumptown"]
 Faker::Hipster.words(number: 4, supplemental: true) #=> ["iste", "seitan", "normcore", "provident"]
 Faker::Hipster.words(number: 4, supplemental: true, spaces_allowed: true) #=> ["qui", "magni", "craft beer", "est"]
 
-# Keyword arguments: word_count, supplemental, random_words_to_add
+# Keyword arguments: word_count, supplemental, random_words_to_add, open_compounds_allowed
 Faker::Hipster.sentence #=> "Park iphone leggings put a bird on it."
 Faker::Hipster.sentence(word_count: 3) #=> "Pour-over swag godard."
 Faker::Hipster.sentence(word_count: 3, supplemental: true) #=> "Beard laboriosam sequi celiac."
 Faker::Hipster.sentence(word_count: 3, supplemental: false, random_words_to_add: 4) #=> "Bitters retro mustache aesthetic biodiesel 8-bit."
 Faker::Hipster.sentence(word_count: 3, supplemental: true, random_words_to_add: 4) #=> "Occaecati deleniti messenger bag meh crucifix autem."
+Faker::Hipster.sentence(word_count: 3, supplemental: true, random_words_to_add: 0, open_compounds_allowed: true) #=> "Kale chips nihil eos."
+Faker::Hipster.sentence(word_count: 3, supplemental: true, random_words_to_add: 0, open_compounds_allowed: false) #=> "Dreamcatcher umami fixie."
 
 # Keyword arguments: number, supplemental
 Faker::Hipster.sentences #=> ["Godard pitchfork vinegar chillwave everyday 90's whatever.", "Pour-over artisan distillery street waistcoat.", "Salvia yr leggings franzen blue bottle."]

--- a/lib/faker/books/lovecraft.rb
+++ b/lib/faker/books/lovecraft.rb
@@ -68,6 +68,7 @@ module Faker
         #
         # @param word_count [Integer] The number of words to have in the sentence
         # @param random_words_to_add [Integer]
+        # @param open_compounds_allowed [Boolean] If true, generated sentence can contain words having additional spaces
         #
         # @return [String]
         #
@@ -80,15 +81,18 @@ module Faker
         # @example
         #   Faker::Books::Lovecraft.sentence(word_count: 3, random_words_to_add: 1)
         #     #=> "Amorphous indescribable tenebrous."
+        # @example
+        #   Faker::Books::Lovecraft.sentence(word_count: 3, random_words_to_add: 0, open_compounds_allowed: true)
+        #     #=> "Effulgence unmentionable gambrel."
         #
         # @faker.version 1.9.3
-        def sentence(legacy_word_count = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, random_words_to_add: 6)
+        def sentence(legacy_word_count = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, random_words_to_add: 6, open_compounds_allowed: true)
           warn_for_deprecated_arguments do |keywords|
             keywords << :word_count if legacy_word_count != NOT_GIVEN
             keywords << :random_words_to_add if legacy_random_words_to_add != NOT_GIVEN
           end
 
-          words(number: word_count + rand(random_words_to_add.to_i).to_i, spaces_allowed: true).join(' ').capitalize + '.'
+          words(number: word_count + rand(random_words_to_add.to_i).to_i, spaces_allowed: open_compounds_allowed).join(' ').capitalize + '.'
         end
 
         ##

--- a/lib/faker/default/hipster.rb
+++ b/lib/faker/default/hipster.rb
@@ -59,7 +59,8 @@ module Faker
       #
       # @param word_count [Integer] Specifies the number of words in the sentence
       # @param supplemental [Boolean] Specifies if the words are supplemental
-      # @param random_words_to_add [Boolean] Specifies the number of random words to add
+      # @param random_words_to_add [Integer] Specifies the number of random words to add
+      # @param open_compounds_allowed [Boolean] Specifies if the generated sentence can contain words having additional spaces
       # @return [String]
       #
       # @example
@@ -68,10 +69,12 @@ module Faker
       #   Faker::Hipster.sentence(word_count: 3, supplemental: true) #=> "Beard laboriosam sequi celiac."
       #   Faker::Hipster.sentence(word_count: 3, supplemental: false, random_words_to_add: 4) #=> "Bitters retro mustache aesthetic biodiesel 8-bit."
       #   Faker::Hipster.sentence(word_count: 3, supplemental: true, random_words_to_add: 4) #=> "Occaecati deleniti messenger bag meh crucifix autem."
+      #   Faker::Hipster.sentence(word_count: 3, supplemental: true, random_words_to_add: 0, open_compounds_allowed: true) #=> "Kale chips nihil eos."
+      #   Faker::Hipster.sentence(word_count: 3, supplemental: true, random_words_to_add: 0, open_compounds_allowed: false) #=> "Dreamcatcher umami fixie."
       #
       # @faker.version 1.6.0
       # rubocop:disable Metrics/ParameterLists
-      def sentence(legacy_word_count = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, supplemental: false, random_words_to_add: 6)
+      def sentence(legacy_word_count = NOT_GIVEN, legacy_supplemental = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, supplemental: false, random_words_to_add: 6, open_compounds_allowed: true)
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|
           keywords << :word_count if legacy_word_count != NOT_GIVEN
@@ -79,7 +82,7 @@ module Faker
           keywords << :random_words_to_add if legacy_random_words_to_add != NOT_GIVEN
         end
 
-        words(number: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental, spaces_allowed: true).join(' ').capitalize + '.'
+        words(number: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental, spaces_allowed: open_compounds_allowed).join(' ').capitalize + '.'
       end
 
       ##

--- a/test/faker/books/test_lovecraft.rb
+++ b/test/faker/books/test_lovecraft.rb
@@ -66,6 +66,21 @@ class TestFakerBooksLovecraft < Test::Unit::TestCase
     assert(array.length == 250 || array.length == 500)
   end
 
+  def test_sentence_with_open_compounds_allowed
+    1000.times do
+      sentence = @tester.sentence(word_count: 5, random_words_to_add: 0, open_compounds_allowed: true)
+      assert(sentence.split.length >= 5)
+    end
+  end
+
+  # Sentence should not contain any open compounds
+  def test_sentence_without_open_compounds_allowed
+    1000.times do
+      sentence = @tester.sentence(word_count: 5, random_words_to_add: 0, open_compounds_allowed: false)
+      assert(sentence.split.length == 5)
+    end
+  end
+
   def test_paragraph_char_count
     paragraph = @tester.paragraph_by_chars
     assert(paragraph.length == 256)

--- a/test/faker/default/test_faker_hipster.rb
+++ b/test/faker/default/test_faker_hipster.rb
@@ -77,6 +77,21 @@ class TestFakerHipster < Test::Unit::TestCase
     assert(array.length == 250 || array.length == 500)
   end
 
+  def test_sentence_with_open_compounds_allowed
+    1000.times do
+      sentence = @tester.sentence(word_count: 5, random_words_to_add: 0, open_compounds_allowed: true)
+      assert(sentence.split.length >= 5)
+    end
+  end
+
+  # Sentence should not contain any open compounds
+  def test_sentence_without_open_compounds_allowed
+    1000.times do
+      sentence = @tester.sentence(word_count: 5, random_words_to_add: 0, open_compounds_allowed: false)
+      assert(sentence.split.length == 5)
+    end
+  end
+
   def test_paragraph_char_count
     paragraph = @tester.paragraph_by_chars(characters: 256)
     assert(paragraph.length == 256)


### PR DESCRIPTION
Connected with: Issue #2102 

Alternative solution fixing the same issue: #2108 

Description
------

- Added param `open_compounds_allowed` that allows to disable using open compounds ('words' containing additional spaces inside) in `Faker::Hipster.sentence` and `Faker::Books::Lovecraft.sentence`. By default the usage of open compounds would be allowed,
- Fixed wrong `random_words_to_add` param type in comment regarding `Faker::Hipster.sentence` method.

Additional info
------

- Currently there are no open compounds included in `faker.lovecraft.words` list but `Faker::Books::Lovecraft.words` have a possibility of handling them, so it can be used after word list is updated,
- There is a similar method in `Faker::Lorem` but both `Faker::Lorem.words` doesn't have a possibility to treat open compounds differently than normal words, and there is no open compounds on `faker.lorem.words` list. 