### PR TITLE
Deprecate `celebrity` methods in favor of `actor`

### DIFF
--- a/doc/tv_shows/buffy.md
+++ b/doc/tv_shows/buffy.md
@@ -5,7 +5,7 @@ Faker::TvShows::Buffy.character #=> "Buffy Summers"
 
 Faker::TvShows::Buffy.quote #=> "If the apocalypse comes, beep me."
 
-Faker::TvShows::Buffy.celebrity #=> "John Ritter"
+Faker::TvShows::Buffy.actor #=> "John Ritter"
 
 Faker::TvShows::Buffy.big_bad #=> "Glory"
 

--- a/doc/tv_shows/the_fresh_prince_of_bel_air.md
+++ b/doc/tv_shows/the_fresh_prince_of_bel_air.md
@@ -3,7 +3,7 @@
 ```ruby
 Faker::TvShows::TheFreshPrinceOfBelAir.character #=> "Will Smith"
 
-Faker::TvShows::TheFreshPrinceOfBelAir.celebrity #=> "Quincy Jones"
+Faker::TvShows::TheFreshPrinceOfBelAir.actor #=> "Quincy Jones"
 
 Faker::TvShows::TheFreshPrinceOfBelAir.quote #=> "Girl, you look so good, I would marry your brother just to get in your family."
 ```

--- a/lib/faker/tv_shows/buffy.rb
+++ b/lib/faker/tv_shows/buffy.rb
@@ -40,7 +40,7 @@ module Faker
         # @example
         #   Faker::TvShows::Buffy.actor #=> "John Ritter"
         #
-        # @faker.version 2.14.1
+        # @faker.version next
         def actor
           fetch('buffy.actors')
         end

--- a/lib/faker/tv_shows/buffy.rb
+++ b/lib/faker/tv_shows/buffy.rb
@@ -33,17 +33,30 @@ module Faker
         end
 
         ##
-        # Produces a celebrity from Buffy the Vampire Slayer.
+        # Produces a actor from Buffy the Vampire Slayer.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::Buffy.actor #=> "John Ritter"
+        #
+        # @faker.version 2.14.1
+        def actor
+          fetch('buffy.actors')
+        end
+
+        ##
+        # Produces a actor from Buffy the Vampire Slayer.
         #
         # @return [String]
         #
         # @example
         #   Faker::TvShows::Buffy.celebrity #=> "John Ritter"
         #
+        # @deprecated Use the `actor` method instead.
+        #
         # @faker.version 1.9.2
-        def celebrity
-          fetch('buffy.celebrities')
-        end
+        alias celebrity actor
 
         ##
         # Produces a big bad from Buffy the Vampire Slayer.

--- a/lib/faker/tv_shows/the_fresh_prince_of_bel_air.rb
+++ b/lib/faker/tv_shows/the_fresh_prince_of_bel_air.rb
@@ -27,7 +27,7 @@ module Faker
         # @example
         #   Faker::TvShows::TheFreshPrinceOfBelAir.actor #=> "Quincy Jones"
         #
-        # @faker.version 2.14.1
+        # @faker.version next
         def actor
           fetch('the_fresh_prince_of_bel_air.actors')
         end

--- a/lib/faker/tv_shows/the_fresh_prince_of_bel_air.rb
+++ b/lib/faker/tv_shows/the_fresh_prince_of_bel_air.rb
@@ -20,17 +20,30 @@ module Faker
         end
 
         ##
-        # Produces a celebrity from The Fresh Prince of Bel-Air.
+        # Produces a actor from The Fresh Prince of Bel-Air.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::TvShows::TheFreshPrinceOfBelAir.actor #=> "Quincy Jones"
+        #
+        # @faker.version 2.14.1
+        def actor
+          fetch('the_fresh_prince_of_bel_air.actors')
+        end
+
+        ##
+        # Produces a actor from The Fresh Prince of Bel-Air.
         #
         # @return [String]
         #
         # @example
         #   Faker::TvShows::TheFreshPrinceOfBelAir.celebrity #=> "Quincy Jones"
         #
+        # @deprecated Use the `actor` method instead.
+        #
         # @faker.version 1.8.3
-        def celebrity
-          fetch('the_fresh_prince_of_bel_air.celebrities')
-        end
+        alias celebrity actor
 
         ##
         # Produces a quote from The Fresh Prince of Bel-Air.

--- a/lib/locales/en/buffy.yml
+++ b/lib/locales/en/buffy.yml
@@ -64,7 +64,7 @@ en:
         "We don't know much about them except for they're very ugly, and they're very mobile for blind people.",
         "And I wonder what possible catastrophe came crashing down from heaven and brought this dashing stranger to tears?"
       ]
-      celebrities: [
+      actors: [
         'Sarah Michelle Geller',
         'Alyson Hannigan',
         'David Boreanaz',

--- a/lib/locales/en/fresh_prince_of_bel_air.yml
+++ b/lib/locales/en/fresh_prince_of_bel_air.yml
@@ -2,7 +2,7 @@ en:
   faker:
     the_fresh_prince_of_bel_air:
       characters: ['Will Smith', 'Philip Banks', 'Carlton Banks', 'Ashley Banks', 'Hilary Banks', 'Vivian Banks', 'Nicky Banks', 'Geoffrey Butler', 'Jazz', 'Vy Smith', 'Hattie Banks', 'Lisa Wilkes', 'Jackie Ames', 'Henry Furth', 'Trevor', 'Tyriq', 'Ice Tray', 'Dee Dee', 'Kellogg Lieberbaum', 'Coach Smiley', 'Judge Carl Robertson']
-      celebrities: ['Quincy Jones', 'Jay Leno', 'Ronald Reagan', 'Dick Clark', 'Evander Holyfield', 'Isaiah Thomas', 'Heavy D', 'Don Cornelius', 'Kadeem Hardison', 'Hugh M. Hefner', 'Kareem Abdul-Jabbar', 'Bo Jackson', 'Ken Griffey Jr.', 'Al B. Sure!', 'John Ridley', 'Doctor Dré', 'Regis Philbin', 'William Shatner', 'B. B. King', 'Kim Fields', 'Arthel Neville', 'Oprah Winfrey', 'Donal J. Trump', 'Leeza Gibbons', 'Susan Powter', 'Tempestt Bledsoe', 'Kathie Lee Gifford', 'Garcelle Beauvais', 'Bree Walker']
+      actors: ['Quincy Jones', 'Jay Leno', 'Ronald Reagan', 'Dick Clark', 'Evander Holyfield', 'Isaiah Thomas', 'Heavy D', 'Don Cornelius', 'Kadeem Hardison', 'Hugh M. Hefner', 'Kareem Abdul-Jabbar', 'Bo Jackson', 'Ken Griffey Jr.', 'Al B. Sure!', 'John Ridley', 'Doctor Dré', 'Regis Philbin', 'William Shatner', 'B. B. King', 'Kim Fields', 'Arthel Neville', 'Oprah Winfrey', 'Donal J. Trump', 'Leeza Gibbons', 'Susan Powter', 'Tempestt Bledsoe', 'Kathie Lee Gifford', 'Garcelle Beauvais', 'Bree Walker']
       quotes: [
         "Girl, you look so good, I would marry your brother just to get in your family.",
         "In west Philadelphia born and raised, on the playground was where I spent most of my days.",

--- a/test/faker/tv_shows/test_buffy.rb
+++ b/test/faker/tv_shows/test_buffy.rb
@@ -15,6 +15,11 @@ class TestFakerTvShowsBuffy < Test::Unit::TestCase
     assert @tester.quote.match(/\w+/)
   end
 
+  def test_actor
+    assert @tester.actor.match(/\w+/)
+  end
+
+  # deprecated
   def test_celebrity
     assert @tester.celebrity.match(/\w+/)
   end

--- a/test/faker/tv_shows/test_the_fresh_prince_of_bel_air.rb
+++ b/test/faker/tv_shows/test_the_fresh_prince_of_bel_air.rb
@@ -11,6 +11,11 @@ class TestFakerTvShowsTheFreshPrinceOfBelAir < Test::Unit::TestCase
     assert @tester.character.match(/\w+/)
   end
 
+  def test_actor
+    assert @tester.actor.match(/\w+/)
+  end
+
+  # deprecated
   def test_celebrity
     assert @tester.celebrity.match(/\w+/)
   end


### PR DESCRIPTION
Deprecated the 'Buffy.celebrity' and 'TheFreshPrinceOfBelAir.celebrity' methods with corresponding 'actor' methods.

Issue# 
------
This PR fixes the following issue #1760 


Description:
------------
This PR fixes the issue reported.