### PR TITLE
Add space force and coast guard to military

### DIFF
--- a/doc/default/military.md
+++ b/doc/default/military.md
@@ -9,5 +9,9 @@ Faker::Military.navy_rank #=> "Seaman"
 
 Faker::Military.air_force_rank #=> "Captain"
 
+Faker::Military.space_force_rank #=> "Senior Enlisted Advisor of the Space Force"
+
+Faker::Military.coast_guard_rank #=> "Master Chief Petty Officer of the Coast Guard"
+
 Faker::Military.dod_paygrade #=> "E-6"
 ```

--- a/lib/faker/default/military.rb
+++ b/lib/faker/default/military.rb
@@ -56,6 +56,32 @@ module Faker
       end
 
       ##
+      # Produces a rank in the U.S. Space Force.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Military.space_force_rank #=> "Senior Enlisted Advisor of the Space Force"
+      #
+      # @faker.version next
+      def space_force_rank
+        fetch('military.space_force_rank')
+      end
+
+      ##
+      # Produces a rank in the U.S. Coast Guard
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Military.caost_guard_rank #=> "Master Chief Petty Officer of the Coast Guard"
+      #
+      # @faker.version next
+      def coast_guard_rank
+        fetch('military.coast_guard_rank')
+      end
+
+      ##
       # Produces a U.S. Department of Defense Paygrade.
       #
       # @return [String]

--- a/lib/faker/default/military.rb
+++ b/lib/faker/default/military.rb
@@ -74,7 +74,7 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Military.caost_guard_rank #=> "Master Chief Petty Officer of the Coast Guard"
+      #   Faker::Military.coast_guard_rank #=> "Master Chief Petty Officer of the Coast Guard"
       #
       # @faker.version next
       def coast_guard_rank

--- a/lib/locales/en/military.yml
+++ b/lib/locales/en/military.yml
@@ -1,8 +1,182 @@
 en:
   faker:
     military:
-      army_rank: ["Private","Private First Class","Specialist","Corporal","Sergeant","Staff Sergeant","Sergeant First Class","Master Sergeant","First Sergeant","Sergeant Major","Command Sergeant Major","Sergeant Major of the Army","Second Lieutenant","First Lieutenant","Captain","Major","Lieutenant Colonel","Colonel","Brigadier General","Major General","Lieutenant General","General","General of the Army","General of the Armies"]
-      marines_rank: ["Private","Private First Class","Lance Corporal","Corporal","Sergeant","Staff Sergeant","Gunnery Sergeant","Master Sergeant","First Sergeant","Master Gunnery Sergeant","Sergeant Major","Sergeant Major of the Marine Corps","Second Lieutenant","First Lieutenant","Captain","Major","Lieutenant Colonel","Colonel","Brigadier General","Major General","Lieutenant General","General"]
-      navy_rank: ["Seaman Recruit","Fireman Recruit","Airman Recruit","Constructionman Recruit","Seaman Apprentice","Fireman Apprentice","Airman Apprentice","Constructionman Apprentice","Seaman","Fireman","Airman","Constructionman","Petty Officer Third Class","Petty Officer Second Class","Petty Officer First Class","Chief Petty Officer","Senior Petty Officer","Master Chief Petty Officer","Command Senior Chief Petty Officer","Command Master Chief Petty Officer","Fleet Master Chief Petty Officer","Master Chief Petty Officer of the Navy","Ensign","Lieutenant","Lieutenant Commander","Commander","Captain","Rear Admiral","Vice Admiral","Admiral","Fleet Admiral","Admiral of the Navy"]
-      air_force_rank: ["Airman Basic","Airman First Class","Senior Airman","Staff Sergeant","Technical Sergeant","Master Sergeant","Senior Master Sergeant","Chief Master Sergeant","Command Chief Master Sergeant","Chief Master Sergeant of the Air Force","Second Lieutenant","First Lieutenant","Captain","Major","Lieutenant Colonel","Colonel","Brigadier General","Major General","Lieutenant General","General","General of the Air Force"]
-      dod_paygrade: ["E-1","E-2","E-3","E-4","E-5","E-6","E-7","E-8","E-9","O-1","O-2","O-3","O-4","O-5","O-6","O-7","O-8","O-9","O-10","Special"]
+      army_rank:
+        - Private
+        - Private First Class
+        - Specialist
+        - Corporal
+        - Sergeant
+        - Staff Sergeant
+        - Sergeant First Class
+        - Master Sergeant
+        - First Sergeant
+        - Sergeant Major
+        - Command Sergeant Major
+        - Sergeant Major of the Army
+        - Second Lieutenant
+        - First Lieutenant
+        - Captain
+        - Major
+        - Lieutenant Colonel
+        - Colonel
+        - Brigadier General
+        - Major General
+        - Lieutenant General
+        - General
+        - General of the Army
+        - General of the Armies
+      marines_rank:
+        - Private
+        - Private First Class
+        - Lance Corporal
+        - Corporal
+        - Sergeant
+        - Staff Sergeant
+        - Gunnery Sergeant
+        - Master Sergeant
+        - First Sergeant
+        - Master Gunnery Sergeant
+        - Sergeant Major
+        - Sergeant Major of the Marine Corps
+        - Second Lieutenant
+        - First Lieutenant
+        - Captain
+        - Major
+        - Lieutenant Colonel
+        - Colonel
+        - Brigadier General
+        - Major General
+        - Lieutenant General
+        - General
+      navy_rank:
+        - Seaman Recruit
+        - Fireman Recruit
+        - Airman Recruit
+        - Constructionman Recruit
+        - Seaman Apprentice
+        - Fireman Apprentice
+        - Airman Apprentice
+        - Constructionman Apprentice
+        - Seaman
+        - Fireman
+        - Airman
+        - Constructionman
+        - Petty Officer Third Class
+        - Petty Officer Second Class
+        - Petty Officer First Class
+        - Chief Petty Officer
+        - Senior Chief Petty Officer
+        - Command Senior Chief Petty Officer
+        - Master Chief Petty Officer
+        - Command Master Chief Petty Officer
+        - Fleet Master Chief Petty Officer
+        - Force Master Chief Petty Officer
+        - Master Chief Petty Officer of the Navy
+        - Ensign
+        - Lieutenant
+        - Lieutenant Commander
+        - Commander
+        - Captain
+        - Rear Admiral
+        - Vice Admiral
+        - Admiral
+        - Fleet Admiral
+        - Admiral of the Navy
+      coast_guard_rank:
+        - Seaman Recruit
+        - Seaman Apprentice
+        - Seaman
+        - Petty Officer Third Class
+        - Petty Officer Second Class
+        - Petty Officer First Class
+        - Chief Petty Officer
+        - Senior Chief Petty Officer
+        - Master Chief Petty Officer
+        - Command Master Chief Petty Officer
+        - Area Command Master Chief Petty Officer
+        - Coast Guard Reserve Force Master Chief Petty Officer
+        - Master Chief Petty Officer of the Coast Guard
+        - Ensign
+        - Lieutenant
+        - Lieutenant Commander
+        - Commander
+        - Captain
+        - Rear Admiral
+        - Vice Admiral
+        - Admiral
+        - Fleet Admiral
+        - Admiral of the Navy
+      air_force_rank:
+        - Airman Basic
+        - Airman First Class
+        - Senior Airman
+        - Staff Sergeant
+        - Technical Sergeant
+        - Master Sergeant
+        - Senior Master Sergeant
+        - Chief Master Sergeant
+        - Command Chief Master Sergeant
+        - Chief Master Sergeant of the Air Force
+        - Second Lieutenant
+        - First Lieutenant
+        - Captain
+        - Major
+        - Lieutenant Colonel
+        - Colonel
+        - Brigadier General
+        - Major General
+        - Lieutenant General
+        - General
+        - General of the Air Force
+      space_force_rank:
+        - Airman Basic
+        - Airman First Class
+        - Senior Airman
+        - Staff Sergeant
+        - Technical Sergeant
+        - Master Sergeant
+        - Senior Master Sergeant
+        - Chief Master Sergeant
+        - Command Chief Master Sergeant
+        - Senior Enlisted Advisor of the Space Force
+        - Senior Enlisted Advisor to the Chairman
+        - Second Lieutenant
+        - First Lieutenant
+        - Captain
+        - Major
+        - Lieutenant Colonel
+        - Colonel
+        - Brigadier General
+        - Major General
+        - Lieutenant General
+        - General
+      dod_paygrade:
+        - E-1
+        - E-2
+        - E-3
+        - E-4
+        - E-5
+        - E-6
+        - E-7
+        - E-8
+        - E-9
+        - O-1
+        - O-1E
+        - O-2
+        - O-2E
+        - O-3
+        - O-3E
+        - O-4
+        - O-5
+        - O-6
+        - O-7
+        - O-8
+        - O-9
+        - O-10
+        - W-1
+        - W-2
+        - W-3
+        - W-4
+        - W-5
+        - Special

--- a/test/faker/default/test_faker_military.rb
+++ b/test/faker/default/test_faker_military.rb
@@ -23,6 +23,14 @@ class TestFakerMilitary < Test::Unit::TestCase
     assert @tester.air_force_rank.match(/\w/)
   end
 
+  def test_space_force_rank
+    assert @tester.space_force_rank.match(/\w/)
+  end
+
+  def test_coast_guard_rank
+    assert @tester.coast_guard_rank.match(/\w/)
+  end
+
   def test_dod_paygrade
     assert @tester.dod_paygrade.match(/\w/)
   end


### PR DESCRIPTION
Issue# 
------
`No-Story`

Description:
------
The military generator was lacking methods for both the "Coast Guard" and the newly minted "Space Force". I also added the missing paygrades for officers with years of enlisted service as well as warrant officers. Additionally, I fixed the deprecated style format for YAML arrays on the existing data.

All details verified against https://www.wikiwand.com/en/Uniformed_services_pay_grades_of_the_United_States
