### PR TITLE
Fixes a bug when generating a password with min_length eq 1

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -115,11 +115,7 @@ module Faker
           keywords << :special_characters if legacy_special_characters != NOT_GIVEN
         end
 
-        min_alpha = if mix_case && min_length > 1
-                      2
-                    else
-                      0
-                    end
+        min_alpha = (mix_case && min_length > 1) ? 2 : 0
         temp = Lorem.characters(number: min_length, min_alpha: min_alpha)
         diff_length = max_length - min_length
 

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -115,7 +115,11 @@ module Faker
           keywords << :special_characters if legacy_special_characters != NOT_GIVEN
         end
 
-        min_alpha = mix_case ? 2 : 0
+        min_alpha = if mix_case && min_length > 1
+                      2
+                    else
+                      0
+                    end
         temp = Lorem.characters(number: min_length, min_alpha: min_alpha)
         diff_length = max_length - min_length
 

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -115,7 +115,7 @@ module Faker
           keywords << :special_characters if legacy_special_characters != NOT_GIVEN
         end
 
-        min_alpha = (mix_case && min_length > 1) ? 2 : 0
+        min_alpha = mix_case && min_length > 1 ? 2 : 0
         temp = Lorem.characters(number: min_length, min_alpha: min_alpha)
         diff_length = max_length - min_length
 

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -145,6 +145,20 @@ class TestFakerInternet < Test::Unit::TestCase
     assert downcase_count >= 1
   end
 
+  def test_password_with_min_length_eq_1
+    min_length = 1
+    password = @tester.password(min_length: min_length)
+    assert password.match(/\w+/)
+  end
+
+  def test_password_with_min_length_and_max_length
+    min_length = 2
+    max_length = 5
+    password = @tester.password(min_length: min_length, max_length: max_length)
+    assert password.match(/\w+/)
+    assert (min_length..max_length).include?(password.size), 'Password size is incorrect'
+  end
+
   def test_password_without_mixed_case
     assert @tester.password(min_length: 8, max_length: 12, mix_case: false).match(/[^A-Z]+/)
   end


### PR DESCRIPTION
Issue# 

https://github.com/faker-ruby/faker/issues/1770

Description:

As describe on #1770 running a command like this:
```
>> Faker::Internet.password min_length: 1, max_length: 3
ArgumentError (min_alpha + min_numeric must be <= number)
	from (irb):2
```
caused an error, the root cause is the parameter min_length, which raises an argument error when `mix_case` is set to true.

With this fix setting `min_length` to 1 won't cause this exception.