### PR TITLE
Fix typo in doc/games/heroes.md

### DIFF
--- a/doc/games/heroes.md
+++ b/doc/games/heroes.md
@@ -1,4 +1,4 @@
-# Faker::Games::House
+# Faker::Games::Heroes
 
 ```ruby
 Faker::Games::Heroes.name #=> "Christian"


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------
Fix a typo in doc/games/heroes.md
Was "Faker::Games::House" instead of "Faker::Games::Heroes"