### PR TITLE
Add finance/stock generators

### DIFF
--- a/doc/default/finance.md
+++ b/doc/default/finance.md
@@ -14,6 +14,6 @@ Faker::Finance.vat_number(country: 'ZA') #=> "ZA79494416181"
 
 # Random ticker
 Faker::Finance.ticker #=> "AMZN"
-## Supported: NASDAQ, NYSE, AMEX
+## Supported: NASDAQ, NYSE
 Faker::Finance.ticker('NASDAQ') #=> "GOOG"
 ```

--- a/doc/default/finance.md
+++ b/doc/default/finance.md
@@ -11,4 +11,9 @@ Faker::Finance.credit_card(:mastercard, :visa) #=> "4448-8934-1277-7195"
 Faker::Finance.vat_number #=> "BR38.395.329/2471-83"
 Faker::Finance.vat_number(country: 'DE') #=> "DE593306671"
 Faker::Finance.vat_number(country: 'ZA') #=> "ZA79494416181"
+
+# Random ticker
+Faker::Finance.ticker #=> "AMZN"
+## Supported: NASDAQ, NYSE, AMEX
+Faker::Finance.ticker('NASDAQ') #=> "GOOG"
 ```

--- a/lib/faker/default/finance.rb
+++ b/lib/faker/default/finance.rb
@@ -6,6 +6,9 @@ module Faker
                            diners_club jcb switch solo dankort
                            maestro forbrugsforeningen laser].freeze
 
+    MARKET_LIST = %i[nyse nasdaq].freeze
+    require 'csv'
+
     class << self
       ##
       # Produces a random credit card number.
@@ -62,6 +65,26 @@ module Faker
 
       def vat_number_keys
         translate('faker.finance.vat_number').keys
+      end
+
+      ##
+      # Returns a randomly-selected stock ticker from a specified market.
+      #
+      # @param markets [String] The name of the market to choose the ticker from (e.g. NYSE, NASDAQ)
+      # @return [String]
+      #
+      # @example
+      #   Faker::Finance.ticker #=> 'AMZN'
+      #   Faker::Finance.vat_number('NASDAQ') #=> 'GOOG'
+
+      # @faker.version next
+      def ticker(*markets)
+        # Updated CSVs can be downloaded here: https://www.nasdaq.com/screening/company-list.aspx
+        markets = MARKET_LIST if markets.empty?
+        market = sample(markets)
+        fetch("finance.ticker.#{market}")
+      rescue I18n::MissingTranslationData
+        raise ArgumentError, "Could not find market named #{market}"
       end
     end
   end

--- a/lib/faker/default/finance.rb
+++ b/lib/faker/default/finance.rb
@@ -7,7 +7,6 @@ module Faker
                            maestro forbrugsforeningen laser].freeze
 
     MARKET_LIST = %i[nyse nasdaq].freeze
-    require 'csv'
 
     class << self
       ##
@@ -76,10 +75,9 @@ module Faker
       # @example
       #   Faker::Finance.ticker #=> 'AMZN'
       #   Faker::Finance.vat_number('NASDAQ') #=> 'GOOG'
-
+      #
       # @faker.version next
       def ticker(*markets)
-        # Updated CSVs can be downloaded here: https://www.nasdaq.com/screening/company-list.aspx
         markets = MARKET_LIST if markets.empty?
         market = sample(markets)
         fetch("finance.ticker.#{market}")

--- a/lib/locales/en/finance.yml
+++ b/lib/locales/en/finance.yml
@@ -111,3 +111,56 @@ en:
         ZA:
         - "ZA##########"
         - "ZA###########"
+      ticker:
+        nasdaq:
+          - MSFT
+          - AAPL
+          - AMZN
+          - GOOG
+          - FB
+          - INTC
+          - CSCO
+          - CMCSA
+          - PEP
+          - ADBE
+          - NVDA
+          - NFLX
+          - PYPL
+          - COST
+          - AMGN
+          - AVGO
+          - TXN
+          - CHTR
+          - SBUX
+          - QCOM
+          - GILD
+          - MDLZ
+          - FISV
+          - BKNG
+          - INTU
+        nyse:
+          - XOM
+          - WFC
+          - JNJ
+          - GE
+          - NVX
+          - WMT
+          - JPM
+          - PG
+          - TM
+          - PFE
+          - CVX
+          - BABA
+          - VZ
+          - BUD
+          - ORCL
+          - DIS
+          - KO
+          - HSBC
+          - T
+          - BAC
+          - C
+          - MRK
+          - V
+          - BRK.B
+          - MA

--- a/test/faker/default/test_faker_finance.rb
+++ b/test/faker/default/test_faker_finance.rb
@@ -26,4 +26,19 @@ class TestFakerFinance < Test::Unit::TestCase
   def test_south_african_vat_number
     assert_match(/\AZA\d{10,11}\z/, Faker::Finance.vat_number(country: 'ZA'))
   end
+
+  def test_ticker
+    assert Faker::Finance.ticker.match(/\w+/)
+  end
+
+  def test_ticker_with_invalid_params
+    assert_raise ArgumentError do
+      Faker::Finance.ticker(Faker::Lorem.word)
+    end
+  end
+
+  def test_ticker_with_valid_params
+    ticker_return = Faker::Finance.ticker('nyse')
+    assert Faker::Base.fetch_all('finance.ticker.nyse').join(', ').include?(ticker_return)
+  end
 end


### PR DESCRIPTION
Resolution for issue #1511 and #1517 

Uses the code contributed in #1517 but removes all the unnecessary changes.

This PR adds a generator that generates stock ticker symbols (e.g. AAPL, GOOG). Pretty basic but lays a foundation that can include other stock/equity information such as last/bid/ask price, volume, etc...