### PR TITLE
Add how to train your dragon

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
   - [Faker::Movies::HarryPotter](doc/movies/harry_potter.md)
   - [Faker::Movies::HitchhikersGuideToTheGalaxy](doc/movies/hitchhikers_guide_to_the_galaxy.md)
   - [Faker::Movies::Hobbit](doc/movies/hobbit.md)
+  - [Faker::Movies::HowToTrainYourDragon](doc/movies/how_to_train_your_dragon.md)
   - [Faker::Movies::Lebowski](doc/movies/lebowski.md)
   - [Faker::Movies::LordOfTheRings](doc/movies/lord_of_the_rings.md)
   - [Faker::Movies::PrincessBride](doc/movies/princess_bride.md)

--- a/doc/movies/how_to_train_your_dragon.md
+++ b/doc/movies/how_to_train_your_dragon.md
@@ -1,0 +1,7 @@
+# Faker::Movies::HowToTrainYourDragon
+
+```ruby
+Faker::Movies::HowToTrainYourDragon.character #=> "Hiccup"
+Faker::Movies::HowToTrainYourDragon.location #=> "Berk"
+Faker::Movies::HowToTrainYourDragon.dragon #=> "Toothless"
+```

--- a/lib/faker/movies/how_to_train_your_dragon.rb
+++ b/lib/faker/movies/how_to_train_your_dragon.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Faker
+  class Movies
+    class HowToTrainYourDragon < Base
+      class << self
+        ##
+        # Produces a character from How To Train Your Dragon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Movies::HowToTrainYourDragon.character #=> "Hiccup"
+        #
+        # @faker.version next
+        def character
+          fetch('how_to_train_your_dragon.characters')
+        end
+
+        ##
+        # Produces a location from How To Train Your Dragon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Movies::HowToTrainYourDragon.location #=> "Berk"
+        #
+        # @faker.version next
+        def location
+          fetch('how_to_train_your_dragon.locations')
+        end
+
+        ##
+        # Produces a dragon from How To Train Your Dragon.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Movies::HowToTrainYourDragon.dragons #=> "Toothless"
+        #
+        # @faker.version next
+        def dragon
+          fetch('how_to_train_your_dragon.dragons')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/how_to_train_your_dragon.yml
+++ b/lib/locales/en/how_to_train_your_dragon.yml
@@ -1,0 +1,173 @@
+en:
+  faker:
+    how_to_train_your_dragon:
+      characters:
+        - Agnar
+        - Agnut Thorston
+        - Alvin the Treacherous
+        - Arick Denson
+        - Arngrim Dammen
+        - Astrid Hofferson
+        - Axel Finke
+        - Axel Skeptisson
+        - Drago Bludvist
+        - Bucket
+        - Buffnut
+        - Cleftjaw
+        - Dagur the Deranged
+        - Derrick
+        - Eret, Son of Eret
+        - Fenris Thorston
+        - Fishlegs Ingerman
+        - Flora May
+        - Froglegs
+        - Gobber the Belch
+        - Gothi
+        - Gruffnut Thorston
+        - Gustav Larson
+        - Hagan Frostbeard
+        - Heather
+        - Hiccup
+        - Hildegard
+        - Ingar Ingerman
+        - Iron Mason
+        - Jens Henderson
+        - Jorgen Redboot
+        - Krogan
+        - Maeve
+        - Mala
+        - Mildew
+        - Nuffink Haddock
+        - Oswald the Agreeable
+        - Padraig
+        - Piglegs
+        - Ruffnut
+        - Ryker Grimborn
+        - Savage
+      dragons:
+        - Axewing
+        - Barf and Belch
+        - Beachcomber
+        - Bewilderbeast
+        - Blazewing
+        - Bonesnarl
+        - Bonnefire
+        - Borealis
+        - Butt and Head
+        - Cagecruncher
+        - Carnastial
+        - Cheesemonger
+        - Chompers
+        - Cloudjumper
+        - Darkvarg
+        - Earsplitter
+        - Fishmeat
+        - Ghostglow
+        - Gressjester
+        - Hookfire
+        - Icebane
+        - Incognito
+        - Irontooth
+        - Krustler
+        - Meatlug
+        - Nightwatch
+        - Obskewer
+        - Reignstorm
+        - Rhineblow
+        - Scardian
+        - Sentinel
+        - Skullcrusher
+        - Smidvarg
+        - Snifflestone
+        - Snogglewing
+        - Stormfly
+        - Thornado
+        - Thorntail
+        - Thunderfish
+        - Toothless
+        - Tripfire
+        - Valdwail
+        - Wavewight
+        - Windshear
+        - Winterwick
+        - Wonderclap
+        - Zeppla
+      locations:
+        - Algae Island
+        - Armorwing Island
+        - Askeblad Island
+        - Barbaric Archipelago
+        - Belching Bog
+        - Berk
+        - Berserker Island
+        - Boarhead Island
+        - Breakneck Bog
+        - Caves of Jotunn
+        - Changewing Island
+        - Clover Coast
+        - Dark Deep
+        - Dark Harbor
+        - Dragon Island
+        - Eastern Strait
+        - Eel Island
+        - Eternitree
+        - Everfrost Forest
+        - Fireworm Island
+        - Gronckle Island
+        - Hazard Island
+        - Hidden World
+        - Hobblegrunt Island
+        - Horrendous Point
+        - Hunter Island
+        - Huttsgalor
+        - Icestorm Island
+        - Island of Friga
+        - Itchy Armpit
+        - Jotun Hot Springs
+        - Knucklebone Knoll
+        - Maze Caves
+        - Melody Island
+        - Misty Backwoods
+        - Mount Ymir
+        - New Berk
+        - Northern Swamp
+        - Outcast Island
+        - Pointy Point
+        - Puffin Point
+        - Quaking Cavern
+        - Radiant Meadows
+        - Ragnarok Rock
+        - Raven Point
+        - Rookery
+        - Rough Sands
+        - Scriven Rock
+        - Scuttleclaw Island
+        - Sea of Despair
+        - Ship Graveyard
+        - Shivering Shores
+        - Shredstone Walls
+        - Snoggletog Island
+        - Sparkfire Mountain
+        - Speed Stinger Island
+        - Straits of Baldur
+        - Sullen Sea
+        - Sundering Wastes
+        - Sunken City
+        - Sunstone Island
+        - Thornbane Valley
+        - Thunderhead Bay
+        - Timberjack Hollow
+        - Titan Island
+        - Training Arena
+        - Trembling Faults
+        - Uglythug Lands
+        - Valhalla
+        - Valka's Mountain
+        - Vanaheim
+        - Viking Cliff
+        - Vinland
+        - Wild Woodland
+        - Windswept Ruin
+        - Woolly Canyon
+        - Wreck Reef
+        - Zippleback Island

--- a/lib/locales/en/how_to_train_your_dragon.yml
+++ b/lib/locales/en/how_to_train_your_dragon.yml
@@ -171,3 +171,4 @@ en:
         - Woolly Canyon
         - Wreck Reef
         - Zippleback Island
+        

--- a/test/faker/movies/test_faker_how_to_train_your_dragon.rb
+++ b/test/faker/movies/test_faker_how_to_train_your_dragon.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerHowToTrainYourDragon < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Movies::HowToTrainYourDragon
+  end
+
+  def test_character
+    assert @tester.character.match(/\w+/)
+  end
+
+  def test_location
+    assert @tester.location.match(/\w+/)
+  end
+
+  def test_dragon
+    assert @tester.dragon.match(/\w+/)
+  end
+end


### PR DESCRIPTION
Issue#:
`No-Story`

Description:
Adds How To Train Your Dragon's data.
```ruby
Faker::Movies::HowToTrainYourDragon.character #=> "Hiccup"
Faker::Movies::HowToTrainYourDragon.location #=> "Berk"
Faker::Movies::HowToTrainYourDragon.dragon #=> "Toothless"
```

This is useful in generating dragons and viking characters/locations from the fiction movie based children's book by British author Cressida Cowell.
