### PR TITLE
Faker::Config can be a Module rather than a Class

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -29,7 +29,7 @@ module Faker
     end
   end
 
-  class Config
+  module Config
     @locale = nil
     @random = nil
 


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------
Here's a dead simple one line patch.
No one creates an instance of `Faker::Config`. No one inherits from this class.
So this "class" is indeed nothing but just a Module.