### PR TITLE
Get rid of broken I18n locales configuration for the tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,12 +16,6 @@ require 'yaml'
 YAML::ENGINE.yamler = 'psych' if defined? YAML::ENGINE
 require File.expand_path(File.dirname(__FILE__) + '/../lib/faker')
 
-# configure I18n
-locales_path = File.expand_path(File.dirname(__FILE__) + '../lib/locales')
-I18n.available_locales = Dir[locales_path + '/*'].map do |file|
-  file.split('.').first
-end
-
 # deterministically_verify executes the test provided in the block successive
 #   times with the same deterministic_random seed.
 # @param subject_proc [Proc] a proc object that returns the subject under test


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------
 This patch simply removes four lines of code from test_helper.rb that is currently not working as expected.

Probably since its very first introduction at 9d47686626134f773d3b61e10cad8d282c23e114,
the code `File.expand_path(File.dirname(__FILE__) + '../lib/locales')` seems not to be working
because `File.dirname(__FILE__)` normally does not end_with a slash (unless we're on UNIX root directory...!)
and so `File.dirname(__FILE__) + '../lib/locales')` compiles to a broken string that doesn't point to a directory,
then consequently it fails to load any locale file.

And since it doesn't do anything, we could just safely remove this block of code.
The tests shall still pass without this.