### PR TITLE
An attempt to load only necessary locales on the fly

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -8,10 +8,19 @@ require 'set' # Fixes a bug in i18n 0.6.11
 
 Dir.glob(File.join(mydir, 'helpers', '*.rb')).sort.each { |file| require file }
 
-I18n.load_path += Dir[File.join(mydir, 'locales', '**/*.yml')]
-I18n.reload! if I18n.backend.initialized?
-
 module Faker
+  @i18n_loaded = nil
+
+  class << self
+    def load_i18n
+      unless @i18n_loaded
+        I18n.load_path += ::Dir[::File.join(__dir__, 'locales', '**/*.yml')]
+        I18n.reload! if I18n.backend.initialized?
+        @i18n_loaded = true
+      end
+    end
+  end
+
   class Config
     @locale = nil
     @random = nil
@@ -21,6 +30,8 @@ module Faker
       attr_writer :random
 
       def locale
+        Faker.load_i18n
+
         # Because I18n.locale defaults to :en, if we don't have :en in our available_locales, errors will happen
         @locale || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
       end
@@ -150,6 +161,8 @@ module Faker
       # Call I18n.translate with our configured locale if no
       # locale is specified
       def translate(*args, **opts)
+        Faker.load_i18n
+
         opts[:locale] ||= Faker::Config.locale
         opts[:raise] = true
         I18n.translate(*args, **opts)
@@ -166,6 +179,8 @@ module Faker
 
       # Executes block with given locale set.
       def with_locale(tmp_locale = nil)
+        Faker.load_i18n
+
         current_locale = Faker::Config.own_locale
         Faker::Config.locale = tmp_locale
 

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -13,11 +13,19 @@ module Faker
 
   class << self
     def load_i18n
-      unless @i18n_loaded
+      return if @i18n_loaded
+
+      if I18n.available_locales&.any?
+        # We expect all locale .yml files to have the locale name in its filename
+        I18n.load_path += ::Dir[::File.join(__dir__, 'locales', "{#{I18n.available_locales.join(',')}}.yml")]
+        # Or to be located in a directory with the locale name
+        I18n.load_path += ::Dir[::File.join(__dir__, 'locales', "{#{I18n.available_locales.join(',')}}/*.yml")]
+      else
         I18n.load_path += ::Dir[::File.join(__dir__, 'locales', '**/*.yml')]
-        I18n.reload! if I18n.backend.initialized?
-        @i18n_loaded = true
       end
+
+      I18n.reload! if I18n.backend.initialized?
+      @i18n_loaded = true
     end
   end
 

--- a/test/test_locale.rb
+++ b/test/test_locale.rb
@@ -78,4 +78,19 @@ class TestLocale < Test::Unit::TestCase
   def test_available_locales
     assert I18n.locale_available?('en-GB')
   end
+
+  def test_load_i18n
+    Faker.instance_variable_set :@i18n_loaded, nil
+    available_locales_was = I18n.available_locales
+
+    I18n.available_locales = %i[en ja id]
+    Faker.load_i18n
+    I18n.eager_load!
+
+    assert Faker.instance_variable_get(:@i18n_loaded)
+    assert_equal %i[en id ja], I18n.backend.translations.keys.sort
+  ensure
+    I18n.available_locales = available_locales_was
+    Faker.instance_variable_set :@i18n_loaded, nil
+  end
 end


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------
This patch attempts not to always load all bundled locale files.

Motivation:
------
Faker bundles so many I18n resources for various locales in the gem package, but indeed our real-world applications do not usually use all these locales. In my case, number of locales that we use in our tests are usually one or two.
That means, most of locales that Faker loads are consuming our time and memory per each test run although we never use them.
It'd be nicer if Faker loads the YAML files only for "the locales that we would use" i.e. `available_locales`.

Strategy:
------
Before this patch, Faker was telling I18n to load all bundled locale files at the very top level.
Instead, this patch suggests to load the ones that correspond to `I18n.available_locales` (note that the implementation is based on the assumption that each YAML file has the name of the locale that it contains).

In consideration of the case where `I18n.available_locales` value is not yet configured when the ruby process loads this library but being configured somewhere in the application initialization process, this patch tries to postpone loading YAML files as late as possible.
As a side effect, starting up a ruby process that bundles Faker but does not use Faker would become faster and less memory-consuming.

Note:
------
This PR would conflict with my previous PR #2167 but of course I'm happy to rebase whichever one.
