### PR TITLE
Add full_address to Ukrainian locale

### DIFF
--- a/lib/locales/uk.yml
+++ b/lib/locales/uk.yml
@@ -25,6 +25,8 @@ uk:
         - "#{masculine_street_prefix} #{masculine_street_title}"
       street_address:
         - "#{street_name}, #{building_number}"
+      full_address:
+        - "#{street_address}, #{city}, #{state}, #{postcode}"
       default_country: [Україна]
 
     internet:


### PR DESCRIPTION
Address format according to DSTU 4163 standard

Fixes Faker::Address.full_address crash with uk-UA locale