### PR TITLE
update documentation to include Float type

### DIFF
--- a/doc/default/number.md
+++ b/doc/default/number.md
@@ -30,10 +30,12 @@ Faker::Number.hexadecimal(digits: 3) #=> "e74"
 # Boundary numbers are inclusive
 # Keyword arguments: from, to
 Faker::Number.between(from: 1, to: 10) #=> 7
+Faker::Number.between(from: 0.0, to: 1.0) #=> 0.7844640543957383
 
 # Min and Max boundaries of range are inclusive
 # Keyword arguments: range
 Faker::Number.within(range: 1..10) #=> 7
+Faker::Number.within(range: 0.0..1.0) #=> 0.7844640543957383
 
 Faker::Number.positive #=> 235.59238499107653
 

--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -143,7 +143,7 @@ module Faker
       # Produces a float given a mean and standard deviation.
       #
       # @param mean [Integer]
-      # @param standard_deviation [Integer, Float]
+      # @param standard_deviation [Numeric]
       # @return [Float]
       #
       # @example
@@ -165,9 +165,9 @@ module Faker
       ##
       # Produces a number between two provided values. Boundaries are inclusive.
       #
-      # @param from [Integer, Float] The lowest number to include.
-      # @param to [Integer, Float] The highest number to include.
-      # @return [Integer, Float]
+      # @param from [Numeric] The lowest number to include.
+      # @param to [Numeric] The highest number to include.
+      # @return [Numeric]
       #
       # @example
       #   Faker::Number.between(from: 1, to: 10) #=> 7
@@ -187,7 +187,7 @@ module Faker
       # Produces a number within two provided values. Boundaries are inclusive or exclusive depending on the range passed.
       #
       # @param range [Range] The range from which to generate a number.
-      # @return [Integer, Float]
+      # @return [Numeric]
       #
       # @example
       #   Faker::Number.within(range: 1..10) #=> 7

--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -165,12 +165,13 @@ module Faker
       ##
       # Produces a number between two provided values. Boundaries are inclusive.
       #
-      # @param from [Integer] The lowest number to include.
-      # @param to [Integer] The highest number to include.
-      # @return [Integer]
+      # @param from [Integer, Float] The lowest number to include.
+      # @param to [Integer, Float] The highest number to include.
+      # @return [Integer, Float]
       #
       # @example
       #   Faker::Number.between(from: 1, to: 10) #=> 7
+      #   Faker::Number.between(from: 0.0, to: 1.0) #=> 0.7844640543957383
       #
       # @faker.version 1.0.0
       def between(legacy_from = NOT_GIVEN, legacy_to = NOT_GIVEN, from: 1.00, to: 5000.00)
@@ -186,10 +187,11 @@ module Faker
       # Produces a number within two provided values. Boundaries are inclusive or exclusive depending on the range passed.
       #
       # @param range [Range] The range from which to generate a number.
-      # @return [Integer]
+      # @return [Integer, Float]
       #
       # @example
       #   Faker::Number.within(range: 1..10) #=> 7
+      #   Faker::Number.within(range: 0.0..1.0) #=> 0.7844640543957383
       #
       # @faker.version 1.0.0
       def within(legacy_range = NOT_GIVEN, range: 1.00..5000.00)


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------
Update documentation for `Number#between` and `Number#within` to be more accurate. Indeed, these methods accept `Integer` and `Float` and returns an `Integer` or a `Float`, depending on the params type.

I've added examples in the documentation so it will be more obvious for next people who read it that they can use these methods to generate floats.

Examples [in the yardoc documentation](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md#documenting-attributes) where `Numeric` is used as type (`@return [Numeric]`). It is not fully documented but as I understand, it covers these cases where a method accepts and/or returns Integer or Float.

I've changed the documentation for the `#normal` method (replacing `Integer, Float` by `Numeric` to keep consistency in the documentation).