### PR TITLE
Add Faker::Games::Dota.neutral_item

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
   - [Faker::Marketing](doc/default/marketing.md)
   - [Faker::Measurement](doc/default/measurement.md)
   - [Faker::Military](doc/default/military.md)
+  - [Faker::Mountain](doc/default/mountain.md)
   - [Faker::Name](doc/default/name.md)
   - [Faker::Nation](doc/default/nation.md)
   - [Faker::NatoPhoneticAlphabet](doc/default/nato_phonetic_alphabet.md)

--- a/doc/default/mountain.md
+++ b/doc/default/mountain.md
@@ -1,0 +1,6 @@
+# Faker::Mountain
+
+```ruby
+Faker::Mountain.name #=> "Mount Everest"
+Faker::Mountain.range #=> "Dhaulagiri Himalaya"
+```

--- a/doc/games/dota.md
+++ b/doc/games/dota.md
@@ -20,3 +20,10 @@ Faker::Games::Dota.player #=> "Dendi"
 Faker::Games::Dota.quote #=> "You have called death upon yourself."
 Faker::Games::Dota.quote(hero: 'alchemist') #=> "Better living through alchemy!"
 ```
+
+Available since version next
+
+```ruby
+# Random neutral item
+Faker::Games::Dota.neutral_item #=> "Royal Jelly"
+```


### PR DESCRIPTION
A set of newly released neutral items list for `Faker::Games::Dota` : https://dota2.gamepedia.com/Neutral_Items

Currently `Faker::Games::Dota` class do not support list of neutral items.