### PR TITLE
Add Sephiroth and Northern Cave to Faker::Games::SuperSmashBros

### DIFF
--- a/lib/locales/en/super_smash_bros.yml
+++ b/lib/locales/en/super_smash_bros.yml
@@ -73,6 +73,7 @@ en:
           - Roy
           - Ryu
           - Samus
+          - Sephiroth
           - Sheik
           - Shulk
           - Simon Belmont
@@ -161,6 +162,7 @@ en:
           - New Donk City Hall
           - New Pork City
           - Norfair
+          - Northern Cave
           - Onett
           - Orbital Gate Assault
           - Pac-Land


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------

Adds the new fighter and stage introduced in Challenger Pack 8 for Super Smash Bros. Ultimate to its generator.
