### PR TITLE
Add Faker::Music::Clash class

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
 
 ### Music
   - [Faker::Music](doc/music/music.md)
+  - [Faker::Music::Clash](doc/music/clash.md)
   - [Faker::Music::GratefulDead](doc/music/grateful_dead.md)
   - [Faker::Music::Opera](doc/music/opera.md)
   - [Faker::Music::PearlJam](doc/music/pearl_jam.md)

--- a/doc/music/clash.md
+++ b/doc/music/clash.md
@@ -1,0 +1,9 @@
+# Faker::Music::Clash
+
+```ruby
+Faker::Music::Clash.punk_rocker #=> "Joe Strummer"
+
+Faker::Music::Clash.album #=> "Sandinista!"
+
+Faker::Music::Clash.song #=> "Clampdown"
+```

--- a/lib/faker/music/clash.rb
+++ b/lib/faker/music/clash.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative 'music'
+
+module Faker
+  class Music
+    class Clash < Base
+      class << self
+        ##
+        # Produces the name of a member of The Clash.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Music::Clash.punk_rocker #=> "Joe Strummer"
+        #
+        # @faker.version next
+        def punk_rocker
+          fetch('clash.punk_rocker')
+        end
+
+        ##
+        # Produces the name of an album by The Clash.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Music::Clash.album #=> "Sandinista!"
+        #
+        # @faker.version next
+        def album
+          fetch('clash.album')
+        end
+
+        ##
+        # Produces the name of a song by The Clash.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Music::Clash.song #=> "Clampdown"
+        #
+        # @faker.version next
+        def song
+          fetch('clash.song')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/clash.yml
+++ b/lib/locales/en/clash.yml
@@ -1,0 +1,115 @@
+en:
+  faker:
+    clash:
+      punk_rocker:
+        - Joe Strummer
+        - Mick Jones
+        - Paul Simonon
+        - Topper Headon
+        - Terry Chimes
+        - Keith Levene
+      album:
+        - The Clash
+        - Give 'Em Enough Rope
+        - London Calling
+        - Sandinista!
+        - Combat Rock
+      song:
+        - Janie Jones
+        - Remote Control
+        - I'm So Bored with the USA
+        - White Riot
+        - Hate and War
+        - What's My Name
+        - Deny
+        - London's Burning
+        - Career Opportunities
+        - Cheat
+        - Protex Blue
+        - Police & Thieves
+        - 48 Hours
+        - Garageland
+        - Clash City Rockers
+        - Complete Control
+        - (White Man) In Hammersmith Palais
+        - I Fought the Law
+        - Jail Guitar Doors
+        - Gates of the West
+        - Pressure Drop
+        - Bankrobber
+        - Safe European Home
+        - English Civil War
+        - Tommy Gun
+        - Julie's Been Working for the Drug Squad
+        - Last Gang in Town
+        - Guns on the Roof
+        - Drug-Stabbing Time
+        - Stay Free
+        - Cheapskates
+        - All the Young Punks (New Boots and Contracts)
+        - London Calling
+        - Brand New Cadillac
+        - Jimmy Jazz
+        - Hateful
+        - Rudie Can't Fail
+        - Spanish Bombs
+        - The Right Profile
+        - Lost in the Supermarket
+        - Clampdown
+        - The Guns of Brixton
+        - Wrong 'Em Boyo'
+        - Death or Glory
+        - Koka Kola
+        - The Card Cheat
+        - Lover's Rock
+        - Four Horsemen
+        - I'm Not Down
+        - Revolution Rock
+        - Train in Vain
+        - The Magnificent Seven
+        - Hitsville UK
+        - Junco Partner
+        - Ivan Meets G.I. Joe
+        - The Leader
+        - Something About England
+        - Rebel Waltz
+        - Look Here
+        - The Crooked Beat
+        - Somebody Got Murdered
+        - One More Time
+        - One More Dub
+        - Lightning Strikes (Not Once but Twice)
+        - Up in Heaven (Not Only Here)
+        - Corner Soul
+        - Let's Go Crazy
+        - If Music Could Talk
+        - The Sound of Sinners
+        - Police on My Back
+        - Midnight Log
+        - The Equaliser
+        - The Call Up
+        - Washington Bullets
+        - Broadway
+        - Lose This Skin
+        - Charlie Don't Surf
+        - Mensforth Hill
+        - Junkie Slip
+        - Kingston Advice
+        - The Street Parade
+        - Version City
+        - Living in Fame
+        - Silicone on Sapphire
+        - Version Pardner
+        - Shepherds Delight
+        - Know Your Rights
+        - Car Jamming
+        - Should I Stay or Should I Go
+        - Rock the Casbah
+        - Red Angel Dragnet
+        - Straight to Hell
+        - Overpowered by Funk
+        - Atom Tan
+        - Sean Flynn
+        - Ghetto Defendant
+        - Inoculated City
+        - Death Is a Star

--- a/test/faker/music/test_faker_clash.rb
+++ b/test/faker/music/test_faker_clash.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerClash < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Music::Clash
+  end
+
+  def test_punk_rocker
+    assert @tester.punk_rocker.match(/\w+/)
+  end
+
+  def test_album
+    assert @tester.album.match(/\w+/)
+  end
+
+  def test_song
+    assert @tester.song.match(/\w+/)
+  end
+end


### PR DESCRIPTION
Adds The Clash to Faker::Music

Issue# 
------
`No-Story`

Description:
------
This PR increases the ability to stick it to the man through test data. 
```ruby
Faker::Music::Clash.punk_rocker #=> "Joe Strummer"

Faker::Music::Clash.album #=> "Sandinista!"

Faker::Music::Clash.song #=> "Clampdown"
```