### PR TITLE
Use Random.new instead of Random::DEFAULT

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -29,7 +29,7 @@ module Faker
       end
 
       def random
-        @random || Random::DEFAULT
+        @random || Random.new
       end
     end
   end


### PR DESCRIPTION
Issue# 
------

Fixes #2225.

Description:
------
Random::DEFAULT is deprecated in Ruby 3.0. This replaces it with `Random.new`, which should be equivalent and backwards compatible with 2.5 and above.
