### PR TITLE
Fix yard doc warnings

### DIFF
--- a/lib/faker/default/barcode.rb
+++ b/lib/faker/default/barcode.rb
@@ -4,7 +4,7 @@ module Faker
   class Barcode < Base
     class << self
       ## Returns a EAN 8 or 13 digit format barcode number with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.ean      => "85657526"
@@ -17,7 +17,7 @@ module Faker
       end
 
       ## Returns a EAN 8 or 13 digit format barcode number with composite string attached with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.ean_with_composite_sumbology      => "41007624|JHOC6649"
@@ -30,7 +30,7 @@ module Faker
       end
 
       ## Returns a UPC_A format barcode number with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.upc_a      => "766807541831"
@@ -41,7 +41,7 @@ module Faker
       end
 
       ## Returns a UPC_E format barcode number with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.upc_e      => "03746820"
@@ -52,7 +52,7 @@ module Faker
       end
 
       ## Returns a UPC_A format barcode number with composite string attached with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.upc_a_with_composite_symbology      => "790670155765|JOVG6208"
@@ -63,7 +63,7 @@ module Faker
       end
 
       ## Returns a UPC_E format barcode number with composite string attached with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.upc_e_with_composite_symbology      => "05149247|BKZX9722"
@@ -74,7 +74,7 @@ module Faker
       end
 
       ## Returns a ISBN format barcode number with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.isbn      => "9798363807732"
@@ -85,7 +85,7 @@ module Faker
       end
 
       ## Returns a ISMN format barcode number with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.ismn      => "9790527672897"
@@ -96,7 +96,7 @@ module Faker
       end
 
       ## Returns a ISSN format barcode number with check digit
-      #  @returns [String]
+      #  @return [String]
       #
       #  @example
       #     Faker::Barcode.issn      => "9775541703338"
@@ -116,7 +116,7 @@ module Faker
 
       ## Returns the sum of even and odd numbers from value passed
       #
-      # @returns [Array]
+      # @return [Array]
       #
       # @example
       #   Faker::Barcode.send(:sum_even_odd, 12345)   => [9, 5]
@@ -139,7 +139,7 @@ module Faker
 
       ## Generates the check digits from sum passed
       #
-      # @returns [Integer]
+      # @return [Integer]
       #
       # @example
       #   Faker::Barcode.send(:generate_check_digit, 12, 4)   => 0

--- a/lib/faker/default/markdown.rb
+++ b/lib/faker/default/markdown.rb
@@ -117,9 +117,11 @@ module Faker
       end
 
       ##
-      # Produces a random method from the methods above or the methods listed in the arguments.
+      # Produces a random method from the methods above, excluding the methods listed in the arguments.
       #
-      # @param methods [Symbol] Specify which methods to use.
+      # @overload random(methods)
+      #   @param methods [Symbol] Specify which methods to exclude.
+      #
       # @return [String, Array<String>]
       #
       # @example

--- a/lib/faker/tv_shows/big_bang_theory.rb
+++ b/lib/faker/tv_shows/big_bang_theory.rb
@@ -25,7 +25,7 @@ module Faker
         # @return [String]
         #
         # @example
-        # Faker::TvShows::BigBangTheory.quote #=> "I'm not crazy. My mother had me tested."
+        #  Faker::TvShows::BigBangTheory.quote #=> "I'm not crazy. My mother had me tested."
         #
         # @faker.version 2.13.0
         def quote

--- a/lib/faker/tv_shows/suits.rb
+++ b/lib/faker/tv_shows/suits.rb
@@ -25,7 +25,7 @@ module Faker
         # @return [String]
         #
         # @example
-        # Faker::TvShows::Suits.quote #=> "Don't play the odds, play the man."
+        #  Faker::TvShows::Suits.quote #=> "Don't play the odds, play the man."
         #
         # @faker.version 2.13.0
         def quote


### PR DESCRIPTION
`No-Story`

Description:

Fix yard doc warnings and misleading description.
------
While working on [PR-2230](https://github.com/faker-ruby/faker/pull/2230) I noticed the following yard doc warnings. This pull request resolves those warnings.

```
[warn]: Invalid tag format for @example in file `lib/faker/tv_shows/suits.rb` near line 31
[warn]: Unknown tag @returns in file `lib/faker/default/barcode.rb` near line 126
[warn]: Unknown tag @returns in file `lib/faker/default/barcode.rb` near line 149
[warn]: @param tag has unknown parameter name: methods
    in file `lib/faker/default/markdown.rb' near line 131
[warn]: Invalid tag format for @example in file `lib/faker/tv_shows/big_bang_theory.rb` near line 31
```

The `Invalid tag format for @example` warnings just needed correct indentation.
The `Unknown tag @returns` warning just needed the plural `@returns` to change to the singular `@return`.

The `@param tag has unknown parameter name: methods` was due to the use of `*args` and not `method`. I updated the docs to use the [recommended yard tag](https://rubydoc.info/gems/yard/file/docs/Tags.md#overload) of `@overload` for `*args` . The `@overload` tag is also used in [Faker::DrivingLicence.uk_driving_licence](https://github.com/faker-ruby/faker/blob/e706f34eaaa8b906bddcf6fd50f5f7e462757ae8/lib/faker/default/driving_licence.rb#L57)

While updating the doc I noticed the original described the method as _"Produces a random method from the methods above or the methods listed in the arguments."_ however the method actually excludes any methods listed in the arguments. I checked the [tests for the method](https://github.com/faker-ruby/faker/blob/e706f34eaaa8b906bddcf6fd50f5f7e462757ae8/test/faker/default/test_faker_markdown.rb#L74) and it does ensure that any method names passed as args are excluded from the returned values. 

I updated the docs to read "_Produces a random method from the methods above, excluding the methods listed in the arguments_"

