### PR TITLE
Move Digest classes to OpenSSL

### DIFF
--- a/lib/faker/blockchain/bitcoin.rb
+++ b/lib/faker/blockchain/bitcoin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'digest'
+require 'openssl'
 require 'securerandom'
 
 module Faker
@@ -51,7 +51,7 @@ module Faker
         def address_for(network)
           version = PROTOCOL_VERSIONS.fetch(network)
           packed = version.chr + Faker::Config.random.bytes(20)
-          checksum = Digest::SHA2.digest(Digest::SHA2.digest(packed))[0..3]
+          checksum = OpenSSL::Digest::SHA256.digest(OpenSSL::Digest::SHA256.digest(packed))[0..3]
           Faker::Base58.encode(packed + checksum)
         end
       end

--- a/lib/faker/blockchain/tezos.rb
+++ b/lib/faker/blockchain/tezos.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'digest'
+require 'openssl'
 require 'securerandom'
 
 module Faker
@@ -126,7 +126,7 @@ module Faker
         def encode_tz(prefix, payload_size)
           prefix = PREFIXES.fetch(prefix)
           packed = prefix.map(&:chr).join('') + Faker::Config.random.bytes(payload_size)
-          checksum = Digest::SHA2.digest(Digest::SHA2.digest(packed))[0..3]
+          checksum = OpenSSL::Digest::SHA256.digest(OpenSSL::Digest::SHA256.digest(packed))[0..3]
           Faker::Base58.encode(packed + checksum)
         end
       end

--- a/lib/faker/default/crypto.rb
+++ b/lib/faker/default/crypto.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'digest'
+require 'openssl'
 
 module Faker
   class Crypto < Base
@@ -15,7 +15,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def md5
-        Digest::MD5.hexdigest(Lorem.characters)
+        OpenSSL::Digest::MD5.hexdigest(Lorem.characters)
       end
 
       ##
@@ -28,7 +28,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha1
-        Digest::SHA1.hexdigest(Lorem.characters)
+        OpenSSL::Digest::SHA1.hexdigest(Lorem.characters)
       end
 
       ##
@@ -41,7 +41,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha256
-        Digest::SHA256.hexdigest(Lorem.characters)
+        OpenSSL::Digest::SHA256.hexdigest(Lorem.characters)
       end
     end
   end


### PR DESCRIPTION
In older Ruby versions, Digest uses legacy OpenSSL APIs to implement the digest methods. These APIs break in some configurations such as FIPS mode enforcement. In the latest Ruby, this was removed (see https://github.com/ruby/ruby/pull/3149), but that means Digest uses the non OpenSSL implementations. In those same environments that want FIPS enforcement, that is not desired as all crypto operations should be using OpenSSL there.

Another consequence of that change is that the Digest implementations have a slower implementation as the OpenSSL version has hardware acceleration and optimized assembly where available.

In https://github.com/ruby/openssl/pull/377, it is discussed to replace the constants when OpenSSL is loaded. But what is a limiting factor here, is that OpenSSL doesn't have the equivalent of Digest::SHA2 (which really ends up computing a SHA256 digest).

So this removes the usage of Digest::SHA2 which is harder to wrap and also switches to use OpenSSL digest directly.