### PR TITLE
Add Bank.iban_country_code.

### DIFF
--- a/lib/faker/default/bank.rb
+++ b/lib/faker/default/bank.rb
@@ -31,12 +31,13 @@ module Faker
       ##
       # Produces a bank iban number.
       #
-      # @param country_code [String] Specifies what country prefix is used to generate the iban code.
+      # @param country_code [String, nil] Specifies what country prefix is used to generate the iban code. Providing `nil` will use a random country.
       # @return [String]
       #
       # @example
       #   Faker::Bank.iban #=> "GB76DZJM33188515981979"
       #   Faker::Bank.iban(country_code: "be") #=> "BE6375388567752043"
+      #   Faker::Bank.iban(country_code: nil) #=> "DE45186738071857270067"
       #
       # @faker.version 1.7.0
       def iban(legacy_country_code = NOT_GIVEN, country_code: 'GB')
@@ -46,6 +47,8 @@ module Faker
         warn_for_deprecated_arguments do |keywords|
           keywords << :country_code if legacy_country_code != NOT_GIVEN
         end
+
+        country_code ||= iban_country_code
 
         begin
           pattern = fetch("bank.iban_details.#{country_code.downcase}.bban_pattern")
@@ -58,6 +61,19 @@ module Faker
 
         # Add country code and checksum to the generated account to form valid IBAN
         country_code.upcase + iban_checksum(country_code, account) + account
+      end
+
+      ##
+      # Produces the ISO 3166 code of a country that uses the IBAN system.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Bank.iban_country_code #=> "CH"
+      #
+      # @faker.version next
+      def iban_country_code
+        sample(translate('faker.bank.iban_details').keys).to_s.upcase
       end
 
       ##

--- a/test/faker/default/test_faker_bank.rb
+++ b/test/faker/default/test_faker_bank.rb
@@ -46,7 +46,7 @@ class TestFakerBank < Test::Unit::TestCase
     assert @tester.swift_bic.match(/(\w+\.? ?){2,3}/)
   end
 
-  # This test makes sure there are no collissions in BIC number pool
+  # This test makes sure there are no collisions in BIC number pool
   # https://github.com/faker-ruby/faker/pull/2130#issuecomment-703213837
   # def test_swift_bic_collission
   #   10.times do
@@ -56,8 +56,16 @@ class TestFakerBank < Test::Unit::TestCase
   #   end
   # end
 
+  def test_iban_country_code
+    assert_match(/^[A-Z]{2}$/, @tester.iban_country_code)
+  end
+
   def test_iban_default
-    assert @tester.iban.match(/[A-Z]{4}\d{14}/)
+    assert_match(/^GB\d{2}[A-Z]{4}\d{14}$/, @tester.iban)
+  end
+
+  def test_iban_rand_country
+    assert_match(/^[A-Z]{2}\d{2}[A-Z\d]{10,30}$/, @tester.iban(country_code: nil))
   end
 
   # Andorra


### PR DESCRIPTION
Closes: https://github.com/faker-ruby/faker/issues/2244

Description:
------
As described in the ticket, there is currently no way to randomly get a valid IBAN across countries. 
The new method returns a random ISO 3166 code for a country that uses the IBAN system.
Updates `Bank.iban` to use a random country code when the `country_code` param is passed as `nil`.