### PR TITLE
Workaround build error for ruby-head

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,7 +39,9 @@ jobs:
           - '2.6' 
           - '2.7'
           - '3.0'
-          - 'head'
+          # FIXME: Workaround for https://github.com/faker-ruby/faker/issues/2260
+          # Resume ruby-head CI when https://github.com/travisjeffery/timecop/pull/279 will be resolved.
+          # - 'head'
           - truffleruby-head
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:


### PR DESCRIPTION
Fixes https://github.com/faker-ruby/faker/issues/2260.

This PR suspends ruby-head CI until https://github.com/travisjeffery/timecop/pull/279 is resolved.

GitHub Actions doesn't seem to have a mechanism like Travis CI's `allow_failures` yet.
https://github.com/actions/toolkit/issues/399
