### PR TITLE
Generate different values when generating a hash

### DIFF
--- a/lib/faker/default/types.rb
+++ b/lib/faker/default/types.rb
@@ -72,7 +72,7 @@ module Faker
       #   Faker::Types.rb_hash(number: 2) #=> {name: "bob", last: "marley"}
       #
       # @faker.version 1.8.6
-      def rb_hash(legacy_number = NOT_GIVEN, legacy_type = NOT_GIVEN, number: 1, type: random_type)
+      def rb_hash(legacy_number = NOT_GIVEN, legacy_type = NOT_GIVEN, number: 1, type: -> { random_type })
         warn_for_deprecated_arguments do |keywords|
           keywords << :number if legacy_number != NOT_GIVEN
           keywords << :type if legacy_type != NOT_GIVEN
@@ -80,7 +80,8 @@ module Faker
 
         {}.tap do |hsh|
           Lorem.words(number: number * 2).uniq.first(number).each do |s|
-            hsh.merge!(s.to_sym => type)
+            value = type.is_a?(Proc) ? type.call : type
+            hsh.merge!(s.to_sym => value)
           end
         end
       end
@@ -102,7 +103,7 @@ module Faker
           keywords << :number if legacy_number != NOT_GIVEN
         end
 
-        rb_hash(number: number, type: random_complex_type)
+        rb_hash(number: number, type: -> { random_complex_type })
       end
 
       ##

--- a/test/faker/default/test_faker_types.rb
+++ b/test/faker/default/test_faker_types.rb
@@ -41,6 +41,7 @@ class TestFakerTypes < Test::Unit::TestCase
 
   def test_hash_returns_the_correct_number_of_keys
     assert @tester.rb_hash(number: 3).keys.length == 3
+    assert @tester.rb_hash(number: 3).values.uniq.length > 1
     assert @tester.rb_hash(number: 0).keys.empty?
     assert @tester.rb_hash.keys.length == 1
   end
@@ -51,6 +52,7 @@ class TestFakerTypes < Test::Unit::TestCase
 
   def test_complex_hash_returns_the_correct_number_of_keys
     assert @tester.complex_rb_hash(number: 3).keys.length == 3
+    assert @tester.complex_rb_hash(number: 3).values.uniq.length > 1
     assert @tester.complex_rb_hash(number: 0).keys.empty?
     assert @tester.complex_rb_hash.keys.length == 1
   end


### PR DESCRIPTION
Issue#
------

https://github.com/faker-ruby/faker/issues/2269

Description:
------
Generate different hash values for the objects retruned by `Faker::Types.rb_hash` and `Faker:Types.complex_rb_hash`. A complete description of the issue can be found here: https://github.com/faker-ruby/faker/issues/2269