### PR TITLE
Fix syntax highlighting and missing version in Seinfeld docs

### DIFF
--- a/doc/tv_shows/seinfeld.md
+++ b/doc/tv_shows/seinfeld.md
@@ -1,9 +1,11 @@
 # Faker::TvShows::Seinfeld
 
+Available since version 1.8.3.
+
 ```ruby
-Faker::TvShows::Seinfeld.character #=> George Costanza
+Faker::TvShows::Seinfeld.character  #=> George Costanza
 
-Faker::TvShows::Seinfeld.quote #=> I'm not a lesbian. I hate men, but I'm not a lesbian
+Faker::TvShows::Seinfeld.quote      #=> I'm not a lesbian. I hate men, but I'm not a lesbian
 
-Faker::TvShows::Seinfeld.business #=> Kruger Industrial Smoothing
+Faker::TvShows::Seinfeld.business   #=> Kruger Industrial Smoothing
 ```


### PR DESCRIPTION
I think this will fix the lack of ruby colouring here https://github.com/faker-ruby/faker/blob/master/doc/tv_shows/seinfeld.md