### PR TITLE
Add digits flag to Faker::Internet.password

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -139,6 +139,7 @@ module Faker
       # @param max_length [Integer] The maximum length of the password
       # @param mix_case [Boolean] Toggles if uppercased letters are allowed. If true, at least one will be added.
       # @param special_characters [Boolean] Toggles if special characters are allowed. If true, at least one will be added.
+      # @param digits [Boolean] Toggles if digits are allowed. If true, at least one will be added.
       #
       # @return [String]
       #
@@ -147,6 +148,8 @@ module Faker
       # @example
       #   Faker::Internet.password(min_length: 8) #=> "YfGjIk0hGzDqS0"
       # @example
+      #   Faker::Internet.password(min_length: 8, digits: false) #=> "PUkPIkxhazDqSZ"
+      # @example
       #   Faker::Internet.password(min_length: 10, max_length: 20) #=> "EoC9ShWd1hWq4vBgFw"
       # @example
       #   Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true) #=> "3k5qS15aNmG"
@@ -154,7 +157,7 @@ module Faker
       #   Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true, special_characters: true) #=> "*%NkOnJsH4"
       #
       # @faker.version 2.1.3
-      def password(legacy_min_length = NOT_GIVEN, legacy_max_length = NOT_GIVEN, legacy_mix_case = NOT_GIVEN, legacy_special_characters = NOT_GIVEN, min_length: 8, max_length: 16, mix_case: true, special_characters: false)
+      def password(legacy_min_length = NOT_GIVEN, legacy_max_length = NOT_GIVEN, legacy_mix_case = NOT_GIVEN, legacy_special_characters = NOT_GIVEN, min_length: 8, max_length: 16, mix_case: true, special_characters: false, digits: true)
         warn_for_deprecated_arguments do |keywords|
           keywords << :min_length if legacy_min_length != NOT_GIVEN
           keywords << :max_length if legacy_max_length != NOT_GIVEN
@@ -162,8 +165,11 @@ module Faker
           keywords << :special_characters if legacy_special_characters != NOT_GIVEN
         end
 
+        raise ArgumentError, 'min_length must be greater than 2 when mix_case and digits are true' if min_length <= 2 && mix_case && digits
+
         min_alpha = mix_case && min_length > 1 ? 2 : 0
-        temp = Lorem.characters(number: min_length, min_alpha: min_alpha)
+        min_numeric = digits ? 1 : 0
+        temp = Lorem.characters(number: min_length, min_alpha: min_alpha, min_numeric: min_numeric)
         diff_length = max_length - min_length
 
         if diff_length.positive?

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -147,14 +147,14 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_password_with_min_length_eq_1
     min_length = 1
-    password = @tester.password(min_length: min_length)
+    password = @tester.password(min_length: min_length, digits: false)
     assert password.match(/\w+/)
   end
 
   def test_password_with_min_length_and_max_length
     min_length = 2
     max_length = 5
-    password = @tester.password(min_length: min_length, max_length: max_length)
+    password = @tester.password(min_length: min_length, max_length: max_length, digits: false)
     assert password.match(/\w+/)
     assert (min_length..max_length).include?(password.size), 'Password size is incorrect'
   end
@@ -169,6 +169,15 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_password_without_special_chars
     assert @tester.password(min_length: 8, max_length: 12, mix_case: true).match(/[^!@#$%\^&*]+/)
+  end
+
+  def test_password_without_digit
+    assert @tester.password(min_length: 8, max_length: 12, digits: false).match(/[^0-9]+/)
+  end
+
+  def test_password_with_digit_mix_case_and_min_length_eq_2
+    exception = assert_raises(ArgumentError) { @tester.password(min_length: 2, mix_case: true) }
+    assert_equal('min_length must be greater than 2 when mix_case and digits are true', exception.message)
   end
 
   def test_domain_name_without_subdomain


### PR DESCRIPTION
Description:
------
In some cases Faker::Internet.password does not return any digits. I added a flag to force at least one digit in the returned value. To keep the current behavior, I set the default value to true. 
