### PR TITLE
[Internet::Password] Improve mix_case and special_characters support

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -162,6 +162,8 @@ module Faker
           keywords << :special_characters if legacy_special_characters != NOT_GIVEN
         end
 
+        raise ArgumentError, 'Password of length 1 can not have both mixed case and special characters' if min_length <= 1 && mix_case && special_characters
+
         min_alpha = mix_case && min_length > 1 ? 2 : 0
         temp = Lorem.characters(number: min_length, min_alpha: min_alpha)
         diff_length = max_length - min_length
@@ -187,6 +189,8 @@ module Faker
             temp[i] = chars[rand(chars.length)]
           end
         end
+
+        temp[rand(temp.size - 1)] = Lorem.characters(number: 1, min_alpha: 1).upcase if mix_case && special_characters && !temp.match(/[A-z]+/)
 
         temp
       end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -171,6 +171,36 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.password(min_length: 8, max_length: 12, mix_case: true).match(/[^!@#$%\^&*]+/)
   end
 
+  def test_password_with_special_chars_and_mixed_case
+    32.times do
+      password = @tester.password(min_length: 4, max_length: 6, mix_case: true, special_characters: true)
+      assert password.match(/[!@#$%\^&*]+/)
+      assert password.match(/[A-z]+/)
+    end
+  end
+
+  def test_password_with_special_chars_and_mixed_case_on_2chars_password
+    16.times do
+      password = @tester.password(min_length: 2, max_length: 6, mix_case: true, special_characters: true)
+      assert password.match(/[!@#$%\^&*]+/)
+      assert password.match(/[A-z]+/)
+    end
+  end
+
+  def test_password_with_incompatible_min_length_and_requirements
+    assert_raise ArgumentError do
+      @tester.password(min_length: 1, mix_case: true, special_characters: true)
+    end
+  end
+
+  def test_password_with_compatible_min_length_and_requirements
+    assert_nothing_raised do
+      [false, true].each do |value|
+        @tester.password(min_length: 1, mix_case: value, special_characters: !value)
+      end
+    end
+  end
+
   def test_domain_name_without_subdomain
     assert @tester.domain_name.match(/[\w-]+\.\w+/)
   end


### PR DESCRIPTION
Ensure password gets at least 1 letter when `mix_case` and `special_characters` are both required and doing so even on really small length.

Issue
------

When activating both `mix_case` and `special_characters` flags, it was possible to result in a password without any letter.

Example : 
```
irb(main):044:0> Faker::Internet.password(min_length: 4, max_length: 6, mix_case: true, special_characters: true)
=> "&&%$9"
irb(main):045:0> Faker::Internet.password(min_length: 48, max_length: 48, mix_case: true, special_characters: true)
=> "^##&!@&%$%**@!\#@#\#@#^!@@&$!!^*!$*&^%!&!#%&*!#%&!"
```

This is due to the special characters blocs replacing between 1 and `min_length` characters, which might be bigger than the number of letters in the string (which is a minimum of 2 when `mix_case` is enabled). With bad luck, all letters could end up being all replaced.

This issue can raise errors when testing the uniqueness of passwords with case sensitivity.

