### PR TITLE
Fix ci for es-AR

### DIFF
--- a/test/test_es_ar_locale.rb
+++ b/test/test_es_ar_locale.rb
@@ -11,7 +11,7 @@ class TestEsArLocale < Test::Unit::TestCase
     @one_or_more_words_pattern = /(?u:(?:\w+\ )*\w+)/
     @many_words_pattern = /(?u:(?:\w+\ )+\w+)/
 
-    @name_with_nickname_pattern = /(?u:(?:\'*\w+\'*\ )+(?:\'*\w+\'*))/
+    @name_with_nickname_pattern = /(?u:(?:'*\w+'*\ )+(?:'*\w+'*))/
 
     @compass_letter_pattern = /^[NEOS]{1,2}(?:p?[NEOS]{1,2})?$/
     @compass_number_pattern = /^\d+(?:.\d\d?)?$/

--- a/test/test_es_ar_locale.rb
+++ b/test/test_es_ar_locale.rb
@@ -6,14 +6,14 @@ class TestEsArLocale < Test::Unit::TestCase
   def setup
     Faker::Config.locale = 'es-AR'
 
-    @no_words_pattern = /\w{0}$/u
-    @one_word_pattern = /\w+/u
-    @one_or_more_words_pattern = /(?:\w+\ )*\w+/u
-    @many_words_pattern = /(?:\w+\ )+\w+/u
+    @no_words_pattern = /(?u:\w{0})$/
+    @one_word_pattern = /(?u:\w+)/
+    @one_or_more_words_pattern = /(?u:(?:\w+\ )*\w+)/
+    @many_words_pattern = /(?u:(?:\w+\ )+\w+)/
 
-    @name_with_nickname_pattern = /(?:\'*\w+\'*\ )+(?:\'*\w+\'*)/u
+    @name_with_nickname_pattern = /(?u:(?:\'*\w+\'*\ )+(?:\'*\w+\'*))/
 
-    @compass_letter_pattern = /^[NEOS]{1,2}(?:p?[NEOS]{1,2})?$/u
+    @compass_letter_pattern = /^[NEOS]{1,2}(?:p?[NEOS]{1,2})?$/
     @compass_number_pattern = /^\d+(?:.\d\d?)?$/
   end
 


### PR DESCRIPTION
`No-Story`

Description:
------

I fixed failing ci.

example:
```
===============================================================================
Failure: test_es_ar_football_coach(TestEsArLocale): <nil> is not true.
/home/runner/work/faker/faker/test/test_es_ar_locale.rb:147:in `test_es_ar_football_coach'
     144:   end
     145: 
     146:   def test_es_ar_football_coach
  => 147:     assert Faker::Sports::Football.coach.match(@name_with_nickname_pattern)
     148:   end
     149: 
     150:   def test_es_ar_football_competition
===============================================================================
```

`/pat/u` sets encoding of regexp literal to UTF-8. it is not set character set option.
ref. https://github.com/k-takata/Onigmo/blob/dd8a18af5c2f2871104b1bdbf3bbb597ec9e4665/doc/RE#L254-L257