### PR TITLE
Add Faker::Games::Dota.building

### DIFF
--- a/lib/faker/games/dota.rb
+++ b/lib/faker/games/dota.rb
@@ -5,6 +5,19 @@ module Faker
     class Dota < Base
       class << self
         ##
+        # Produces the name of a building from Dota.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Games::Dota.building #=> "Tower"
+        #
+        # @faker.version 1.9.0
+        def building
+          fetch('games.dota.building')
+        end
+
+        ##
         # Produces the name of a hero from Dota.
         #
         # @return [String]

--- a/lib/locales/en/dota.yml
+++ b/lib/locales/en/dota.yml
@@ -2,6 +2,13 @@ en:
   faker:
     games:
       dota:
+        building:
+          - Tower
+          - Barrack
+          - Ancient
+          - Fountain
+          - Effigy
+          - Outpost
         hero:
           - Abaddon
           - Alchemist

--- a/test/faker/games/test_faker_dota.rb
+++ b/test/faker/games/test_faker_dota.rb
@@ -13,6 +13,10 @@ class TestFakerDota < Test::Unit::TestCase
                  underlord undying wraith_king]
   end
 
+  def test_building
+    assert @tester.building.match(/\w+/)
+  end
+
   def test_hero
     assert @tester.hero.match(/\w+/)
   end


### PR DESCRIPTION
`No-Story`

Description:
------
Since Dota 2 game objective is about defending our own team buildings and destroying the enemy's buildings. It would be nice if we can generate the name of the buildings that exist in Dota 2 (ref: [dota2 wiki](https://dota2.fandom.com/wiki/Buildings)). Here I add:
```ruby
Faker::Games::Dota.building # => "Tower"
Faker::Games::Dota.building # => "Ancient"
Faker::Games::Dota.building # => "Outpost"
```
