### PR TITLE
Handle +, unbound groups, and non-capturing groups in #regexify

### DIFF
--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -26,7 +26,8 @@ class TestFaker < Test::Unit::TestCase
   def test_regexify
     {
       'uk post code' => /^([A-PR-UWYZ0-9][A-HK-Y0-9][AEHMNPRTVXY0-9]?[ABEHMNPRVWXY0-9]? {1,2}[0-9][ABD-HJLN-UW-Z]{2}|GIR 0AA)$/,
-      'us phone' => /^(1-?)[2-8][0-1][0-9]-\d{3}-\d{4}$/
+      'us phone' => /^(1-?)[2-8][0-1][0-9]-\d{3}-\d{4}$/,
+      'us zipcode' => /(?:\d{5}-\d{4})|(?:\d{5})/
     }.each do |label, re|
       10.times do
         assert re.match(result = Faker::Base.regexify(re)), "#{result} is not a match for #{label}"


### PR DESCRIPTION
Issue
------

https://github.com/faker-ruby/faker/issues/1577


Description:
------
This extends the functionality of the `#regexify` method. I have been using this method as an extension of regexify on my personal projects for a bit now and it has been quite helpful, and I was combing through my open GH issues and wanted to at least try to propose a solution to this issue I created a bit ago. If it's not desired, not to worry!