### PR TITLE
Add Kazuya to Faker::Games::SuperSmashBros

### DIFF
--- a/lib/locales/en/super_smash_bros.yml
+++ b/lib/locales/en/super_smash_bros.yml
@@ -66,7 +66,7 @@ en:
           - Pit
           - Pokémon Trainer
           - R.O.B.
-          - Richter Belmont
+          - Richter
           - Ridley
           - Robin
           - Rosalina
@@ -76,7 +76,7 @@ en:
           - Sephiroth
           - Sheik
           - Shulk
-          - Simon Belmont
+          - Simon
           - Snake
           - Sonic
           - Squirtle

--- a/lib/locales/en/super_smash_bros.yml
+++ b/lib/locales/en/super_smash_bros.yml
@@ -35,6 +35,7 @@ en:
           - Ivysaur
           - Jigglypuff
           - Joker
+          - Kazuya
           - Ken
           - King Dedede
           - King K. Rool


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------

Adds the newly-announced fighter Kazuya to `Faker::Games::SuperSmashBros`. His stage doesn't yet have a confirmed name.

Also removes the surnames from Simon and Richter as they aren't referred to with them in-game.
