### PR TITLE
Fix spanish organisation number

### DIFF
--- a/lib/faker/default/company.rb
+++ b/lib/faker/default/company.rb
@@ -553,7 +553,7 @@ module Faker
       end
 
       def spanish_cif_control_digit(organization_type, code)
-        letters = %w[J A B C D E F G H]
+        letters = %w[J A B C D E F G H I]
 
         control = code.split('').each_with_index.inject(0) do |sum, (value, index)|
           if (index + 1).even?


### PR DESCRIPTION
Issue#2345
------

Example:

https://github.com/faker-ruby/faker/issues/2345


Description:
------
*Add validation for CIF Spanish number organization in company module, and fix the generator, a character was missing*
