### PR TITLE
fix #2271 "Deterministic random doesn't work with unique values"

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -17,7 +17,7 @@ module Faker
     @random = nil
 
     class << self
-      attr_writer :locale, :random
+      attr_writer :locale
 
       def locale
         # Because I18n.locale defaults to :en, if we don't have :en in our available_locales, errors will happen
@@ -30,6 +30,11 @@ module Faker
 
       def random
         @random || Random.new
+      end
+
+      def random=(random)
+        Faker::UniqueGenerator.clear
+        @random = random
       end
     end
   end

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -75,6 +75,14 @@ class TestFaker < Test::Unit::TestCase
     assert v == Faker::Base.rand_in_range(0, 1000)
   end
 
+  def test_deterministic_unique
+    Faker::Config.random = Random.new(42)
+    v = Faker::Name.unique.name
+    
+    Faker::Config.random = Random.new(42)
+    assert v == Faker::Name.unique.name
+  end
+
   def test_parse
     data = {
       faker: {


### PR DESCRIPTION
Issue#
------
https://github.com/faker-ruby/faker/issues/2271

Description:
------
Fixed issue that generating unique value after seeding causes non-deterministic. 
If user re-specify the Faker::Config.random, @previous_results should also be reset at the same time. 

### Before 
```
irb(main):001:0> Faker::Config.random = Random.new(42)
=> #<Random:0x00007fad449498e8>
irb(main):002:0> Faker::Name.unique.name
=> "Brittany Klocko"
irb(main):003:0> Faker::Config.random = Random.new(42)
=> #<Random:0x00007fad48895600>
irb(main):004:0> Faker::Name.unique.name
=> "Newton Hand" ❌
```

### After 
```
irb(main):001:0> Faker::Config.random = Random.new(42)
=> #<Random:0x00007fad449498e8>
irb(main):002:0> Faker::Name.unique.name
=> "Brittany Klocko"
irb(main):003:0> Faker::Config.random = Random.new(42)
=> #<Random:0x00007fad48895600>
irb(main):004:0> Faker::Name.unique.name
=> "Brittany Klocko"✅
```

