### PR TITLE
fix broken link for placeholdit 

### DIFF
--- a/doc/default/omniauth.md
+++ b/doc/default/omniauth.md
@@ -215,7 +215,7 @@ Faker::Omniauth.github #=>
     :nickname => "jackson-keeling",
     :email => "jackson.keeling@example.com",
     :name => "Jackson Keeling",
-    :image => "https://placehold.it/300x300.png",
+    :image => "https://via.placeholder.com/300x300.png",
     :urls => {
       :GitHub => "https://github.com/jackson-keeling"
     }
@@ -228,7 +228,7 @@ Faker::Omniauth.github #=>
     :raw_info => {
       :login => "jackson-keeling",
       :id => "95144751",
-      :avatar_url => "https://placehold.it/300x300.png",
+      :avatar_url => "https://via.placeholder.com/300x300.png",
       :gravatar_id => "",
       :url => "https://api.github.com/users/jackson-keeling",
       :html_url => "https://github.com/jackson-keeling",

--- a/doc/default/placeholdit.md
+++ b/doc/default/placeholdit.md
@@ -2,13 +2,13 @@
 
 ```ruby
 # Keyword arguments: size, format, background_color, text_color, text
-Faker::Placeholdit.image #=> "https://placehold.it/300x300.png"
-Faker::Placeholdit.image(size: '50x50') #=> "https://placehold.it/50x50.png"
-Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://placehold.it/50x50.jpg"
-Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://placehold.it/50x50.gif/ffffff"
-Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://placehold.it/50x50.jpeg/39eba7"
-Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://placehold.it/50x50.jpeg/ffffff/000"
-Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://placehold.it/50x50.jpg/ffffff/000?text=Some Custom Text"
+Faker::Placeholdit.image #=> "https://via.placeholder.com/300x300.png"
+Faker::Placeholdit.image(size: '50x50') #=> "https://via.placeholder.com/50x50.png"
+Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://via.placeholder.com/50x50.jpg"
+Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://via.placeholder.com/50x50.gif/ffffff"
+Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://via.placeholder.com/50x50.jpeg/39eba7"
+Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://via.placeholder.com/50x50.jpeg/ffffff/000"
+Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://via.placeholder.com/50x50.jpg/ffffff/000?text=Some Custom Text"
 ```
 
 ## Tips

--- a/lib/faker/default/placeholdit.rb
+++ b/lib/faker/default/placeholdit.rb
@@ -8,7 +8,7 @@ module Faker
       # rubocop:disable Metrics/ParameterLists
 
       ##
-      # Produces a random placeholder image from https://placehold.it.
+      # Produces a random placeholder image from https://via.placeholder.com.
       #
       # @param size [String] Specifies the image's size, dimensions separated by 'x'.
       # @param format [String] Specifies the image's extension.
@@ -19,13 +19,13 @@ module Faker
       #
       # @example
       #     # Keyword arguments: size, format, background_color, text_color, text
-      #   Faker::Placeholdit.image #=> "https://placehold.it/300x300.png"
-      #   Faker::Placeholdit.image(size: '50x50') #=> "https://placehold.it/50x50.png"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://placehold.it/50x50.jpg"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://placehold.it/50x50.gif/ffffff"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://placehold.it/50x50.jpeg/39eba7"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://placehold.it/50x50.jpeg/ffffff/000"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://placehold.it/50x50.jpg/ffffff/000?text=Some Custom Text"
+      #   Faker::Placeholdit.image #=> "https://via.placeholder.com/300x300.png"
+      #   Faker::Placeholdit.image(size: '50x50') #=> "https://via.placeholder.com/50x50.png"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://via.placeholder.com/50x50.jpg"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://via.placeholder.com/50x50.gif/ffffff"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://via.placeholder.com/50x50.jpeg/39eba7"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://via.placeholder.com/50x50.jpeg/ffffff/000"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://via.placeholder.com/50x50.jpg/ffffff/000?text=Some Custom Text"
       #
       # @faker.version 1.6.0
       def image(legacy_size = NOT_GIVEN, legacy_format = NOT_GIVEN, legacy_background_color = NOT_GIVEN, legacy_text_color = NOT_GIVEN, legacy_text = NOT_GIVEN, size: '300x300', format: 'png', background_color: nil, text_color: nil, text: nil)
@@ -45,7 +45,7 @@ module Faker
         raise ArgumentError, "background_color must be a hex value without '#'" unless background_color.nil? || background_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
         raise ArgumentError, "text_color must be a hex value without '#'" unless text_color.nil? || text_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
 
-        image_url = "https://placehold.it/#{size}.#{format}"
+        image_url = "https://via.placeholder.com/#{size}.#{format}"
         image_url += "/#{background_color}" if background_color
         image_url += "/#{text_color}" if text_color
         image_url += "?text=#{text}" if text

--- a/test/faker/default/test_placeholdit.rb
+++ b/test/faker/default/test_placeholdit.rb
@@ -8,11 +8,11 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_placeholdit
-    assert !@tester.image.match(%r{https://placehold\.it/(.+)(png?)})[1].nil?
+    assert !@tester.image.match(%r{https://via\.placeholder\.com/(.+)(png?)})[1].nil?
   end
 
   def test_avatar_with_custom_size
-    assert @tester.image(size: '3x3').match(%r{https://placehold\.it/+(\d+x\d+)})[1] == '3x3'
+    assert @tester.image(size: '3x3').match(%r{https://via\.placeholder\.com/+(\d+x\d+)})[1] == '3x3'
   end
 
   def test_avatar_with_incorrect_size
@@ -22,7 +22,7 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_with_supported_format
-    assert @tester.image(size: '300x300', format: 'jpg').match(%r{https://placehold\.it/(.+)(jpg?)})
+    assert @tester.image(size: '300x300', format: 'jpg').match(%r{https://via\.placeholder\.com/(.+)(jpg?)})
   end
 
   def test_avatar_with_incorrect_format
@@ -32,15 +32,15 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_background_with_correct_six_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff').match(%r{https://placehold\.it/(.+)(jpg?)/ffffff})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff').match(%r{https://via\.placeholder\.com/(.+)(jpg?)/ffffff})
   end
 
   def test_avatar_background_with_correct_three_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff').match(%r{https://placehold\.it/(.+)(jpg?)/fff})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff').match(%r{https://via\.placeholder\.com/(.+)(jpg?)/fff})
   end
 
   def test_avatar_background_with_random_color
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: :random).match(%r{https://placehold\.it/(.+)(jpg?)/[a-f0-9]{6}})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: :random).match(%r{https://via\.placeholder\.com/(.+)(jpg?)/[a-f0-9]{6}})
   end
 
   def test_avatar_background_with_wrong_six_char_hex
@@ -62,15 +62,15 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_font_color_with_correct_six_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '000000').match(%r{https://placehold\.it/(.+)(jpg?)/ffffff/000000})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '000000').match(%r{https://via\.placeholder\.com/(.+)(jpg?)/ffffff/000000})
   end
 
   def test_avatar_font_color_with_correct_three_char_hex
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(%r{https://placehold\.it/(.+)(jpg?)/fff})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(%r{https://via\.placeholder\.com/(.+)(jpg?)/fff})
   end
 
   def test_avatar_font_color_with_random_color
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: :random).match(%r{https://placehold\.it/(.+)(jpg?)/fff/[a-f0-9]{6}})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: :random).match(%r{https://via\.placeholder\.com/(.+)(jpg?)/fff/[a-f0-9]{6}})
   end
 
   def test_avatar_font_color_with_wrong_six_char_hex
@@ -92,10 +92,10 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_text_not_present
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(%r{https://placehold\.it/[^\\?]+$})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(%r{https://via\.placeholder\.com/[^\\?]+$})
   end
 
   def test_text_present
-    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000', text: 'hello').match(%r{https://placehold\.it/(.+)\?text=hello})
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000', text: 'hello').match(%r{https://via\.placeholder\.com/(.+)\?text=hello})
   end
 end


### PR DESCRIPTION
Issue#
------

https://github.com/faker-ruby/faker/issues/2328

Description:
------
- Placeholdit image url is no longer available in https. It seems that placeholder.it changed their domain. For example, https://placehold.it/300x300.png redirects to http://placehold.it/300x300.png automatically. 

> Just specify the image size after our URL (https://via.placeholder.com/) and you’ll get a placeholder image. 

C/O https://placeholder.com/ 

## Before
```
> Faker::Placeholdit.image
https://placehold.it/300x300.png
> Faker::Placeholdit.image(size: '50x50')
https://placehold.it/50x50.png
```
## After 
```
> Faker::Placeholdit.image
https://via.placeholder.com/300x300.png
> Faker::Placeholdit.image(size: '50x50')
https://via.placeholder.com/50x50.png
```

