### PR TITLE
feat: Add number with affixes

### DIFF
--- a/doc/default/number.md
+++ b/doc/default/number.md
@@ -40,6 +40,12 @@ Faker::Number.between(from: 0.0, to: 1.0) #=> 0.7844640543957383
 Faker::Number.within(range: 1..10) #=> 7
 Faker::Number.within(range: 0.0..1.0) #=> 0.7844640543957383
 
+# Produces a random number with affixes
+# Keyword arguments: prefix, suffix, digits
+Faker::Number.with_affixes(prefix: 'ABC', digits: 10) #=> "ABC9593623"
+Faker::Number.with_affixes(suffix: 'XYZ', digits: 10) #=> "5424372XYZ"
+Faker::Number.with_affixes(prefix: 'ABC', suffix: 'XYZ', digits: 10) #=> "ABC7432XYZ"
+
 Faker::Number.positive #=> 235.59238499107653
 
 Faker::Number.negative #=> -4480.042585669558

--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -261,6 +261,26 @@ module Faker
         less_than_zero(random_number)
       end
 
+      ##
+      # Produces a random number with affixes
+      #
+      # @param digits [Integer] Number of digits that the generated number should have.
+      # @param prefix [String] The leading text of the number.
+      # @param suffix [String] The ending text of the number.
+      # @return [String]
+      #
+      # @example
+      #   Faker::Number.with_affixes(prefix: 'ABC', digits: 10) #=> "ABC9593623"
+      #   Faker::Number.with_affixes(suffix: 'XYZ', digits: 10) #=> "5424372XYZ"
+      #   Faker::Number.with_affixes(prefix: 'ABC', suffix: 'XYZ', digits: 10) #=> "ABC7432XYZ"
+      #
+      # @faker.version next
+      def with_affixes(prefix: '', suffix: '', digits: 10)
+        number_length = digits - prefix.length - suffix.length
+
+        [prefix, number(digits: number_length), suffix].join[0...digits]
+      end
+
       private
 
       def generate(count)

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -134,4 +134,14 @@ class TestFakerNumber < Test::Unit::TestCase
     assert @tester.binary(digits: 8).match(/^[0-1]{8}$/)
     assert @tester.binary.match(/^[0-1]{4}$/)
   end
+
+  def test_with_affixes
+    assert @tester.with_affixes(prefix: 'ABC').match(/^ABC[0-9]{7}/)
+    assert @tester.with_affixes(suffix: 'XYZ').match(/^[0-9]{7}XYZ/)
+    assert @tester.with_affixes(prefix: 'ABC', digits: 20).match(/^ABC[0-9]{17}/)
+    assert @tester.with_affixes(suffix: 'ZXC', digits: 20).match(/^[0-9]{17}ZXC/)
+    assert @tester.with_affixes(prefix: 'ABC', suffix: 'ZXC').match(/^ABC[0-9]{4}ZXC/)
+    assert @tester.with_affixes(prefix: 'ABC', suffix: 'ZXC', digits: 20).match(/^ABC[0-9]{14}ZXC/)
+    assert_equal @tester.with_affixes(prefix: 'ABC', digits: 1), 'A'
+  end
 end


### PR DESCRIPTION
Description:
------
In our app, we use patterns with numbers for payouts, payments, and orders.

Simplified example:
```ruby
"PYT12345678"
```

We currently do it as follows:
```ruby
"PYT#{Faker::Number.number(digits: 8)}"
# or
Faker::Base.numerify('PYT########')
```

With this PR, we can now do:
```ruby
Faker::Number.with_affixes(prefix: 'PYT', digits: 11)
```