### PR TITLE
Add stock_market to Faker::Finance

### DIFF
--- a/doc/default/finance.md
+++ b/doc/default/finance.md
@@ -16,4 +16,7 @@ Faker::Finance.vat_number(country: 'ZA') #=> "ZA79494416181"
 Faker::Finance.ticker #=> "AMZN"
 ## Supported: NASDAQ, NYSE
 Faker::Finance.ticker('NASDAQ') #=> "GOOG"
+
+# Random stock market
+Faker::Finance.stock_market #=> "NASDAQ"
 ```

--- a/lib/faker/default/finance.rb
+++ b/lib/faker/default/finance.rb
@@ -84,6 +84,19 @@ module Faker
       rescue I18n::MissingTranslationData
         raise ArgumentError, "Could not find market named #{market}"
       end
+
+      ##
+      # Returns a randomly-selected stock market.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Finance.stock_market #=> 'NASDAQ'
+      #
+      # @faker.version next
+      def stock_market
+        fetch('finance.stock_market')
+      end
     end
   end
 end

--- a/lib/locales/en/finance.yml
+++ b/lib/locales/en/finance.yml
@@ -164,3 +164,24 @@ en:
           - V
           - BRK.B
           - MA
+      stock_market:
+        - NYSE
+        - NASDAQ
+        - SSE
+        - HKEX
+        - JPX
+        - SZSE
+        - LSE
+        - TSX
+        - NSE-INDIA
+        - FSX
+        - TADAWUL
+        - OMXC-COPENHAGEN
+        - KRX
+        - BSE-BOMBAY
+        - SIX
+        - EURONEXT-PARIS
+        - TWSE
+        - ASX
+        - JSE
+        - BOVESPA

--- a/test/faker/default/test_faker_finance.rb
+++ b/test/faker/default/test_faker_finance.rb
@@ -41,4 +41,8 @@ class TestFakerFinance < Test::Unit::TestCase
     ticker_return = Faker::Finance.ticker('nyse')
     assert Faker::Base.fetch_all('finance.ticker.nyse').join(', ').include?(ticker_return)
   end
+
+  def test_stock_market
+    assert Faker::Finance.stock_market.match(/\w+/)
+  end
 end


### PR DESCRIPTION
Issue#
------
https://github.com/faker-ruby/faker/issues/1511

Description:
------
As it was suggested in https://github.com/faker-ruby/faker/issues/1511,
this PR adds stock_market method to Faker::Finance, which return a randomly selected stock market name.  