### PR TITLE
Fix `Faker::Json#add_depth_to_json` sometimes adding additional width

### DIFF
--- a/lib/faker/default/json.rb
+++ b/lib/faker/default/json.rb
@@ -117,8 +117,8 @@ module Faker
           end
         else
           add_hash(key_array, hash, width, options)
-          key_array.pop
         end
+        key_array.pop
       end
 
       def add_hash(key_array, hash, width, options)


### PR DESCRIPTION
We need to pop the `key_array` value after to the JSON structure in all
cases or we sometimes add additional width to the structure depending on
the whims of randomness.

`No-Story`

Description:
------
Using `Faker::Json` was sometimes failing for us when checking the width of the JSON being created and the failures were intermittent and random. Moving the `key_array.pop` in this section of code produces consistent results.
