### PR TITLE
Add generator for vulnerability identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
   - [Faker::University](doc/default/university.md)
   - [Faker::Vehicle](doc/default/vehicle.md)
   - [Faker::Verbs](doc/default/verbs.md)
+  - [Faker::VulnerabilityIdentifier](doc/default/vulnerability_identifier.md)
   - [Faker::WorldCup](doc/default/world_cup.md)
 
 ### Blockchain

--- a/doc/default/vulnerability_identifier.md
+++ b/doc/default/vulnerability_identifier.md
@@ -1,0 +1,7 @@
+# Faker::VulnerabilityIdentifier
+
+Available since version next.
+
+```ruby
+Faker::VulnerabilityIdentifier.cve #=> "CVE-2021-1337"
+```

--- a/lib/faker/default/vulnerability_identifier.rb
+++ b/lib/faker/default/vulnerability_identifier.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Faker
+  class VulnerabilityIdentifier < Base
+    class << self
+      ##
+      # Produces a Common Vulnerabilities and Exposures (CVE) identifier.
+      #
+      # @param year [Integer] The year-part of the CVE identifier (defaults to the current year)
+      # @return [String]
+      #
+      # @example
+      #   Faker::VulnerabilityIdentifier.cve #=> "CVE-2021-1337"
+      #   Faker::VulnerabilityIdentifier.cve(year: 1999) #=> "CVE-1999-0523"
+      #
+      # @faker.version next
+      def cve(year: ::Date.today.year)
+        index = rand_in_range(1, 99_999).to_s.rjust(4, '0')
+        "CVE-#{year}-#{index}"
+      end
+    end
+  end
+end

--- a/test/faker/default/test_faker_vulnerability_identifier.rb
+++ b/test/faker/default/test_faker_vulnerability_identifier.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerVulnerabilityIdentifier < Test::Unit::TestCase
+  def setup
+    @tester = Faker::VulnerabilityIdentifier
+  end
+
+  def test_cve_no_args
+    assert @tester.cve.match(/^CVE-\d{4}-\d{4,}$/)
+  end
+
+  def test_cve_with_year
+    assert @tester.cve(year: 2012).match(/^CVE-2012-\d{4,}$/)
+  end
+end


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------
This PR adds a generator for CVE identifiers, e.g. `CVE-2020-123456`.

Our use case: We have an application tracking dependencies and their known vulnerabilities. These vulnerabilities are tracked through their assigned identifier (most commonly CVE for us, but sometimes also GHSA or others). Being able to generate identifiers through faker means, that our test data will look more realistic.