### PR TITLE
Added more science examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v2.18.1](https://github.com/faker-ruby/faker/tree/v2.18.1) (2021-08-17)
+
+## Feature Request
+ - [PR #2369](https://github.com/faker-ruby/faker/pull/2369) Added more Science examples - science branches, modifiers and tools [@itay-grudev](https://github.com/itay-grudev)
+
 ## [v2.18.0](https://github.com/faker-ruby/faker/tree/v2.18.0) (2021-05-15)
 
 ## Bug/Fixes

--- a/doc/default/science.md
+++ b/doc/default/science.md
@@ -1,6 +1,16 @@
 # Faker::Science
 
 ```ruby
+##
+# Produces a name of a science
+# You can optionally filter by specifying one or more of the following:
+# `:empirical, :formal, :natural, :social, :basic, :applied`
+# @see https://en.wikipedia.org/wiki/Science#Branches_of_science
+# @see Faker::Educator.subject
+Faker::Science.science #=> "Space science"
+Faker::Science.science(:natural, :applied) #=> "Engineering"
+Faker::Science.science(:formal, :applied) #=> "Computer Science"
+
 Faker::Science.element #=> "Carbon"
 
 Faker::Science.element_symbol #=> "Pb"
@@ -10,4 +20,17 @@ Faker::Science.element_state #=> "Liquid"
 Faker::Science.element_subcategory #=> "Reactive nonmetal"
 
 Faker::Science.scientist #=> "Isaac Newton"
+
+Faker::Science.scientist #=> "Isaac Newton"
+
+Faker::Science.modifier #=> "Quantum"
+
+##
+# Produces the name of a scientific tool.
+# Optionally it can generate tools with a science word modifier that sound more fancy.
+#
+# @param simple [Boolean] Whether to generate fancy non-realistic tool names, using the Q-word for example.
+# @return [String]
+Faker::Science.tool #=> "Superconductive Microcentrifuge"
+Faker::Science.tool(simple: true) #=> "Microcentrifuge"
 ```

--- a/lib/faker/default/science.rb
+++ b/lib/faker/default/science.rb
@@ -27,7 +27,7 @@ module Faker
       #   Faker::Science.science(:natural, :applied) #=> "Engineering"
       #   Faker::Science.science(:formal, :applied) #=> "Computer Science"
       #
-      # @faker.version 2.18.1
+      # @faker.version next
       def science(*branches)
         selected = BRANCHES.values.flatten.uniq
         branches.each do |branch|
@@ -118,7 +118,7 @@ module Faker
       #   Faker::Science.modifier #=> "Quantum"
       #   Faker::Science.modifier #=> "Superconductive"
       #
-      # @faker.version 2.18.1
+      # @faker.version next
       def modifier
         fetch('science.modifier')
       end
@@ -136,7 +136,7 @@ module Faker
       #   Faker::Science.tool #=> "Quantum Spectrophotometer"
       #   Faker::Science.tool(simple: true) #=> "Microcentrifuge"
       #
-      # @faker.version 2.18.1
+      # @faker.version next
       def tool(simple: false)
         tool = fetch('science.tool')
         return tool if simple

--- a/lib/faker/default/science.rb
+++ b/lib/faker/default/science.rb
@@ -125,9 +125,9 @@ module Faker
 
       ##
       # Produces the name of a scientific tool.
-      # Optionally it can generate tools with a science word modifier that sound more fancy.
+      # By default it uses a science word modifier to generate more diverse data, which can be disabled.
       #
-      # @param simple [Boolean] Whether to generate fancy non-realistic tool names, using the Q-word for example.
+      # @param simple [Boolean] Whether to generate simple realistic tool names, (no Q-word).
       # @return [String]
       #
       # @example

--- a/lib/faker/default/science.rb
+++ b/lib/faker/default/science.rb
@@ -3,6 +3,47 @@
 module Faker
   class Science < Base
     class << self
+      BRANCHES = {
+        empirical: %i[empirical_natural_basic empirical_natural_applied empirical_social_basic empirical_social_applied],
+        formal: %i[formal_basic formal_applied],
+        natural: %i[empirical_natural_basic empirical_natural_applied],
+        social: %i[empirical_social_basic empirical_social_applied],
+        basic: %i[empirical_natural_basic empirical_social_basic formal_basic],
+        applied: %i[empirical_natural_applied empirical_social_applied formal_applied]
+      }.freeze
+
+      ##
+      # Produces a name of a science
+      # You can optionally filter by specifying one or more of the following:
+      # `:empirical, :formal, :natural, :social, :basic, :applied`
+      # @see https://en.wikipedia.org/wiki/Science#Branches_of_science
+      # @see Faker::Educator.subject
+      #
+      # @param branches [Array<Symbol>]
+      # @return [String]
+      #
+      # @example
+      #   Faker::Science.science #=> "Space science"
+      #   Faker::Science.science(:natural, :applied) #=> "Engineering"
+      #   Faker::Science.science(:formal, :applied) #=> "Computer Science"
+      #
+      # @faker.version 2.18.1
+      def science(*branches)
+        selected = BRANCHES.values.flatten.uniq
+        branches.each do |branch|
+          selected &= BRANCHES[branch] if BRANCHES.key? branch
+        end
+
+        raise ArgumentError, 'Filters do not match any sciences' if selected.empty?
+
+        sciences = []
+        selected.each do |branch|
+          sciences += translate("faker.science.branch.#{branch}")
+        end
+
+        sample(sciences)
+      end
+
       ##
       # Produces the name of a element.
       #
@@ -66,6 +107,47 @@ module Faker
       # @faker.version 1.8.5
       def scientist
         fetch('science.scientist')
+      end
+
+      ##
+      # Produces a scientifically sounding word
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Science.modifier #=> "Quantum"
+      #   Faker::Science.modifier #=> "Superconductive"
+      #
+      # @faker.version 2.18.1
+      def modifier
+        fetch('science.modifier')
+      end
+
+      ##
+      # Produces the name of a scientific tool.
+      # Optionally it can generate tools with a science word modifier that sound more fancy.
+      #
+      # @param simple [Boolean] Whether to generate fancy non-realistic tool names, using the Q-word for example.
+      # @return [String]
+      #
+      # @example
+      #   Faker::Science.tool #=> "Superconductive Microcentrifuge"
+      #   Faker::Science.tool #=> "Portable Cryostat"
+      #   Faker::Science.tool #=> "Quantum Spectrophotometer"
+      #   Faker::Science.tool(simple: true) #=> "Microcentrifuge"
+      #
+      # @faker.version 2.18.1
+      def tool(simple: false)
+        tool = fetch('science.tool')
+        return tool if simple
+
+        # Makes sure the modifier are different
+        loop do
+          modifier = self.modifier
+          break unless tool.start_with?(modifier)
+        end
+
+        "#{modifier} #{tool}"
       end
     end
   end

--- a/lib/faker/version.rb
+++ b/lib/faker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Faker #:nodoc:
-  VERSION = '2.18.0'
+  VERSION = '2.18.1'
 end

--- a/lib/faker/version.rb
+++ b/lib/faker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Faker #:nodoc:
-  VERSION = '2.18.1'
+  VERSION = '2.18.0'
 end

--- a/lib/locales/en/science.yml
+++ b/lib/locales/en/science.yml
@@ -1,6 +1,38 @@
 en:
   faker:
     science:
+      branch:
+        empirical_natural_basic:
+          - Physics
+          - Chemistry
+          - Biology
+          - Earth Science
+          - Space Science
+        empirical_natural_applied:
+          - Engineering
+          - Agricultural Science
+          - Medicine
+          - Materials Science
+        empirical_social_basic:
+          - Antropology
+          - Economics
+          - Political Science
+          - Human Geography
+          - Psychology
+          - Sociology
+        empirical_social_applied:
+          - Business Administration
+          - Public Policy
+          - Marketing
+          - Law
+          - Pedagogy
+          - International Development
+        formal_basic:
+          - Logic
+          - Mathematics
+          - Statistics
+        formal_applied:
+          - Computer Science
       element: 
       - Actinium
       - Aluminum
@@ -255,6 +287,49 @@ en:
       - Reactive nonmetal
       - Transition metal
       - Unknown chemical properties
+      modifier:
+        - Quantum
+        - Laser
+        - Radio
+        - Vacuum
+        - Gas
+        - Solid
+        - Liquid
+        - Fluid
+        - Microfluidic
+        - Mass
+        - Gamma
+        - X-ray
+        - Electon
+        - Proton
+        - Subatomic
+        - UV
+        - Visual
+        - Infrared
+        - Supercooled
+        - Superconductive
+        - Mobile
+        - Portable
+        - Stationary
+        - Inverted
+        - Continuous
+        - Luminescence
+        - Vibration
+        - Scanning
+        - Linear
+        - Circular
+        - Monofocal
+        - Confocal
+        - Trifocal
+        - Thermal
+        - Small
+        - Large
+        - Polar
+        - Conductive
+        - Semiconductive
+        - Non-conductive
+        - Particle
+        - Microparticle
       scientist: 
       - Albert Einstein
       - Albrecht von Haller
@@ -356,3 +431,53 @@ en:
       - William Bayliss
       - William Harvey
       - William Herschel
+      tool:
+        - Microscope
+        - Stereomicroscope
+        - Laser
+        - Interferometer
+        - Spectrophotometer
+        - Spectrometer
+        - Mass Spectrometer
+        - NMR Spectrometer
+        - Homogeniser
+        - PCR
+        - NMR
+        - SDR
+        - Electrophoresis
+        - Simulator
+        - Centrifuge
+        - Microcentrifuge
+        - Transducer
+        - Calorimeter
+        - Glucometers
+        - Bioreactor
+        - Telescope
+        - Autoclave
+        - Microwave
+        - Computer
+        - Analyzer
+        - Imager
+        - Fumehood
+        - Cleanroom
+        - Mastersizer
+        - Accelerator
+        - Microphone
+        - Fluorimeter
+        - 3D Scanner
+        - Data Logger
+        - Freezer
+        - Furnace
+        - Synthesiser
+        - Reflector
+        - Cryostat
+        - Diffractometer
+        - Manifold
+        - Pump
+        - Incubator
+        - Regulator
+        - Sonicator
+        - Chromatographer
+        - Viscometer
+        - Generator
+        - Reactor

--- a/lib/locales/en/science.yml
+++ b/lib/locales/en/science.yml
@@ -456,6 +456,7 @@ en:
         - Autoclave
         - Microwave
         - Computer
+        - Supercomputer
         - Analyzer
         - Imager
         - Fumehood

--- a/test/faker/default/test_faker_science.rb
+++ b/test/faker/default/test_faker_science.rb
@@ -7,6 +7,26 @@ class TestFakerScience < Test::Unit::TestCase
     @tester = Faker::Science
   end
 
+  def test_science
+    assert @tester.science.match(/\w+/)
+    assert @tester.science(:empirical).match(/\w+/)
+    assert @tester.science(:formal).match(/\w+/)
+    assert @tester.science(:natural).match(/\w+/)
+    assert @tester.science(:social).match(/\w+/)
+    assert @tester.science(:basic).match(/\w+/)
+    assert @tester.science(:applied).match(/\w+/)
+    assert @tester.science(:empirical, :natural).match(/\w+/)
+    assert @tester.science(:empirical, :social).match(/\w+/)
+    assert @tester.science(:empirical, :natural, :basic).match(/\w+/)
+    assert @tester.science(:empirical, :natural, :applied).match(/\w+/)
+    assert @tester.science(:empirical, :social, :basic).match(/\w+/)
+    assert @tester.science(:empirical, :social, :applied).match(/\w+/)
+    assert @tester.science(:empirical, :basic).match(/\w+/)
+    assert @tester.science(:empirical, :applied).match(/\w+/)
+    assert @tester.science(:formal, :basic).match(/\w+/)
+    assert @tester.science(:formal, :applied).match(/\w+/)
+  end
+
   def test_element
     assert @tester.element.match(/\w+/)
   end
@@ -25,5 +45,13 @@ class TestFakerScience < Test::Unit::TestCase
 
   def test_scientist
     assert @tester.scientist.match(/\w+/)
+  end
+
+  def test_modifier
+    assert @tester.modifier.match(/\w+/)
+  end
+
+  def test_tool
+    assert @tester.tool.match(/\w+/)
   end
 end


### PR DESCRIPTION
Description:
------

Adds a list of generic science names that can be filtered like:

```ruby
Faker::Science.science #=> "Space science"
Faker::Science.science(:natural, :applied) #=> "Engineering"
Faker::Science.science(:formal, :applied) #=> "Computer Science"
```

Adds a list of science modifiers words that can used like:
```ruby
Faker::Science.modifier #=> "Quantum"
Faker::Science.modifier #=> "Superconductive"
```

Adds a list of science tools that can include modifiers to generate more diverse data, although not guaranteed to be real:
```ruby
Faker::Science.tool #=> "Superconductive Microcentrifuge"
Faker::Science.tool #=> "Portable Cryostat"
Faker::Science.tool #=> "Quantum Spectrophotometer"
Faker::Science.tool(simple: true) #=> "Microcentrifuge"
```