### PR TITLE
Add Faker::JapaneseMedia::KamenRider

### DIFF
--- a/doc/japanese_media/kamen_rider.md
+++ b/doc/japanese_media/kamen_rider.md
@@ -1,0 +1,25 @@
+# Faker::JapaneseMedia::KamenRider
+
+```ruby
+Faker::JapaneseMedia::KamenRider.kamen_rider #=> "Kamen Rider Revice"
+Faker::JapaneseMedia::KamenRider.user #=> "Ikki Igarashi"
+Faker::JapaneseMedia::KamenRider.series #=> "Kamen Rider Revice"
+```
+
+## Passing Eras
+
+If you want Kamen Rider material from a specific era, you can either pass an
+argument:
+
+```ruby
+Faker::JapaneseMedia::KamenRider.series(:reiwa)
+=> "Kamen Rider Saber"
+```
+
+...or configure which eras you'd like to use on the class:
+
+```ruby
+Faker::JapaneseMedia::KamenRider.eras = [:heisei, :reiwa]
+Faker::JapaneseMedia::KamenRider.series
+=> "Kamen Rider Kiva"
+```

--- a/lib/faker/japanese_media/kamen_rider.rb
+++ b/lib/faker/japanese_media/kamen_rider.rb
@@ -19,9 +19,9 @@ module Faker
         # @example
         #   Faker::JapaneseMedia::KamenRider.kamen_rider #=> "Kamen Rider Revice"
         #
-        # @faker.version 1.8.0
+        # @faker.version next
         def kamen_rider(*eras)
-          series_from_eras(*eras)[:riders].sample[:kamen_rider]
+          from_eras(*eras, field: :kamen_riders)
         end
 
         ##
@@ -34,7 +34,7 @@ module Faker
         #
         # @faker.version next
         def user(*eras)
-          series_from_eras(*eras)[:riders].sample[:user]
+          from_eras(*eras, field: :users)
         end
 
         ##
@@ -47,7 +47,7 @@ module Faker
         #
         # @faker.version next
         def series(*eras)
-          series_from_eras(*eras)[:name]
+          from_eras(*eras, field: :series)
         end
 
         private
@@ -56,13 +56,13 @@ module Faker
           @eras ||= ERAS
         end
 
-        def series_from_eras(*input_eras)
+        def from_eras(*input_eras, field:)
           selected_eras = (ERAS & input_eras).yield_self do |selected|
             selected.empty? ? eras : selected
           end
-          selected_eras.map do |era|
-            fetch_all("kamen_rider.#{era}")
-          end.flatten.sample
+          selected_eras.sample.yield_self do |era|
+            fetch("kamen_rider.#{era}.#{field}")
+          end
         end
       end
     end

--- a/lib/faker/japanese_media/kamen_rider.rb
+++ b/lib/faker/japanese_media/kamen_rider.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Faker
+  class JapaneseMedia
+    class KamenRider < Base
+      class << self
+        ERAS = %i[showa heisei reiwa].freeze
+
+        def eras=(*new_eras)
+          @eras = ERAS & new_eras
+        end
+
+        ##
+        # Produces the name of a Kamen Rider from a series in the given era.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::KamenRider.kamen_rider #=> "Kamen Rider Revice"
+        #
+        # @faker.version 1.8.0
+        def kamen_rider(*eras)
+          series_from_eras(*eras)[:riders].sample[:kamen_rider]
+        end
+
+        ##
+        # Produces the name of a main user of Kamen Rider.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::KamenRider.user #=> "Ikki Igarashi"
+        #
+        # @faker.version next
+        def user(*eras)
+          series_from_eras(*eras)[:riders].sample[:user]
+        end
+
+        ##
+        # Produces the name of a Kamen Rider series.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::KamenRider.series #=> "Kamen Rider Revice"
+        #
+        # @faker.version next
+        def series(*eras)
+          series_from_eras(*eras)[:name]
+        end
+
+        private
+
+        def eras
+          @eras ||= ERAS
+        end
+
+        def series_from_eras(*input_eras)
+          selected_eras = (eras & input_eras).yield_self do |selected|
+            selected.empty? ? eras : selected
+          end
+          selected_eras.map do |era|
+            fetch_all("kamen_rider.#{era}")
+          end.flatten.sample
+        end
+      end
+    end
+  end
+end

--- a/lib/faker/japanese_media/kamen_rider.rb
+++ b/lib/faker/japanese_media/kamen_rider.rb
@@ -6,8 +6,9 @@ module Faker
       class << self
         ERAS = %i[showa heisei reiwa].freeze
 
-        def eras=(*new_eras)
-          @eras = ERAS & new_eras
+        def eras=(new_eras)
+          selected_eras = ERAS & new_eras
+          @eras = selected_eras.empty? ? ERAS : selected_eras
         end
 
         ##

--- a/lib/faker/japanese_media/kamen_rider.rb
+++ b/lib/faker/japanese_media/kamen_rider.rb
@@ -57,7 +57,7 @@ module Faker
         end
 
         def series_from_eras(*input_eras)
-          selected_eras = (eras & input_eras).yield_self do |selected|
+          selected_eras = (ERAS & input_eras).yield_self do |selected|
             selected.empty? ? eras : selected
           end
           selected_eras.map do |era|

--- a/lib/locales/en/kamen_rider.yml
+++ b/lib/locales/en/kamen_rider.yml
@@ -2,537 +2,242 @@ en:
   faker:
     kamen_rider:
       showa:
-        - name: Kamen Rider
-          riders:
-            - kamen_rider: Kamen Rider 1
-              user: Takeshi Hongo
-            - kamen_rider: Kamen Rider 2
-              user: Hayato Ichimonji
-        - name: Kamen Rider V3
-          riders:
-            - kamen_rider: Kamen Rider V3
-              user: Shiro Kazami
-            - kamen_rider: Riderman
-              user: Joji Yuki
-        - name: Kamen Rider X
-          riders:
-            - kamen_rider: Kamen Rider X
-              user: Keisuke Jin
-        - name: Kamen Rider Amazon
-          riders:
-            - kamen_rider: Kamen Rider Amazon
-              user: Daisuke Yamamoto
-        - name: Kamen Rider Stronger
-          riders:
-            - kamen_rider: Kamen Rider Stronger
-              user: Shigeru Jo
-        - name: Kamen Rider (Skyrider)
-          riders:
-            - kamen_rider: Skyrider
-              user: Hiroshi Tsukuba
-        - name: Kamen Rider Super-1
-          riders:
-            - kamen_rider: Kamen Rider Super-1
-              user: Kazuya Oki
-        - name: Kamen Rider ZX
-          riders:
-            - kamen_rider: Kamen Rider ZX
-              user: Ryo Murasame
-        - name: Kamen Rider Black
-          riders:
-            - kamen_rider: Kamen Rider Black
-              user: Kohtaro Minami
-        - name: Kamen Rider Black RX
-          riders:
-            - kamen_rider: Kamen Rider Black RX
-              user: Kohtaro Minami
-        - name: "Shin Kamen Rider: Prologue"
-          riders:
-            - kamen_rider: Kamen Rider Shin
-              user: Shin Kazamatsuri
-        - name: Kamen Rider ZO
-          riders:
-            - kamen_rider: Kamen Rider ZO
-              user: Masaru Aso
-        - name: Kamen Rider J
-          riders:
-            - kamen_rider: Kamen Rider J
-              user: Kouji Segawa
+        series: ["Kamen Rider", "Kamen Rider V3", "Kamen Rider X", "Kamen Rider Amazon", "Kamen Rider Stronger", "Kamen Rider (Skyrider)", "Kamen Rider Super-1", "Kamen Rider Black", "Kamen Rider ZX", "Kamen Rider Black RX", "Shin Kamen Rider: Prologue", "Kamen Rider ZO", "Kamen Rider J"]
+        kamen_riders: ["Kamen Rider 1", "Kamen Rider 2", "Kamen Rider V3", "Riderman", "Kamen Rider X", "Kamen Rider Amazon", "Kamen Rider Stronger", "Skyrider", "Kamen Rider Super-1", "Kamen Rider ZX", "Kamen Rider Black", "Kamen Rider Black RX", "Kamen Rider Shin", "Kamen Rider ZO", "Kamen Rider J"]
+        users:
+          - Takeshi Hongo
+          - Hayato Ichimonji
+          - Shiro Kazami
+          - Joji Yuki
+          - Keisuke Jin
+          - Daisuke Yamamoto
+          - Shigeru Jo
+          - Hiroshi Tsukuba
+          - Kazuya Oki
+          - Ryo Murasame
+          - Kohtaro Minami
+          - Kohtaro Minami
+          - Shin Kazamatsuri
+          - Masaru Aso
+          - Kouji Segawa
       heisei:
-        - name: Kamen Rider Kuuga
-          riders:
-            - kamen_rider: Kamen Rider Kuuga
-              user: Yusuke Godai
-        - name: Kamen Rider Agito
-          riders:
-            - kamen_rider: Kamen Rider Agito
-              user: Shoichi Tsugami
-            - kamen_rider: Kamen Rider G3
-              user: Makoto Hikawa
-            - kamen_rider: Kamen Rider Gills
-              user: Ryo Ashihara
-            - kamen_rider: Kamen Rider G4
-              user: Shiro Mizuki
-            - kamen_rider: Another Agito
-              user: Kaoru Kino
-        - name: Kamen Rider Ryuki
-          riders:
-            - kamen_rider: Kamen Rider Ryuki
-              user: Shinji Kido
-            - kamen_rider: Kamen Rider Knight
-              user: Ren Akiyama
-            - kamen_rider: Kamen Rider Scissors
-              user: Masashi Sudo
-            - kamen_rider: Kamen Rider Zolda
-              user: Shuichi Kitaoka
-            - kamen_rider: Kamen Rider Raia
-              user: Miyuki Tezuka
-            - kamen_rider: Kamen Rider Gai
-              user: Jun Shibaura
-            - kamen_rider: Kamen Rider Ouja
-              user: Takeshi Asakura
-            - kamen_rider: Kamen Rider Odin
-              user: Kamen Rider Odin
-            - kamen_rider: Kamen Rider Femme
-              user: Miho Kirishima
-            - kamen_rider: Kamen Rider Ryuga
-              user: Dark Shinji
-            - kamen_rider: Kamen Rider Tiger
-              user: Satoru Tojo
-            - kamen_rider: Kamen Rider Verde
-              user: Itsuro Takamizawa
-            - kamen_rider: Kamen Rider Imperer
-              user: Mitsuru Sano
-        - name: Kamen Rider 555
-          riders:
-            - kamen_rider: Kamen Rider Faiz
-              user: Takumi Inui
-            - kamen_rider: Kamen Rider Kaixa
-              user: Masato Kusaka
-            - kamen_rider: Kamen Rider Delta
-              user: Syuji Mihara
-            - kamen_rider: Kamen Rider Psyga
-              user: Leo
-            - kamen_rider: Kamen Rider Orga
-              user: Yuji Kiba
-        - name: Kamen Rider Blade
-          riders:
-            - kamen_rider: Kamen Rider Blade
-              user: Kazuma Kenzaki
-            - kamen_rider: Kamen Rider Garren
-              user: Sakuya Tachibana
-            - kamen_rider: Kamen Rider Chalice
-              user: Hajime Aikawa
-            - kamen_rider: Kamen Rider Leangle
-              user: Mutsuki Kamijo
-            - kamen_rider: Kamen Rider Glaive
-              user: Junichi Shimura
-            - kamen_rider: Kamen Rider Lance
-              user: Shin Magaki
-            - kamen_rider: Kamen Rider Larc
-              user: Natsumi Miwa
-        - name: Kamen Rider Hibiki
-          riders:
-            - kamen_rider: Kamen Rider Hibiki
-              user: Hitoshi Hidaka
-            - kamen_rider: Kamen Rider Ibuki
-              user: Iori Izumi
-            - kamen_rider: Kamen Rider Danki
-              user: Daisuke Danda
-            - kamen_rider: Kamen Rider Sabaki
-              user: Sakae Saeki
-            - kamen_rider: Kamen Rider Todoroki
-              user: Tomizo Todayama
-            - kamen_rider: Kamen Rider Zanki
-              user: Zaomaru Zaitsuhara
-            - kamen_rider: Kamen Rider Eiki
-              user: Eiki
-            - kamen_rider: Kamen Rider Kabuki
-              user: Kabuki
-            - kamen_rider: Kamen Rider Touki
-              user: Touki
-            - kamen_rider: Kamen Rider Kirameki
-              user: Kirameki
-            - kamen_rider: Kamen Rider Nishiki
-              user: Nishiki
-            - kamen_rider: Kamen Rider Habataki
-              user: Habataki
-            - kamen_rider: Kamen Rider Shouki
-              user: Shouki
-            - kamen_rider: Kamen Rider Gouki
-              user: Gouki
-            - kamen_rider: Kamen Rider Toki
-              user: Toki
-            - kamen_rider: Kamen Rider Banki
-              user: Banki
-            - kamen_rider: Kamen Rider Shuki
-              user: Shiori Shinagawa
-        - name: Kamen Rider Kabuto
-          riders:
-            - kamen_rider: Kamen Rider Kabuto
-              user: Soji Tendo
-            - kamen_rider: Kamen Rider TheBee
-              user: Shun Kageyama
-            - kamen_rider: Kamen Rider Drake
-              user: Daisuke Kazama
-            - kamen_rider: Kamen Rider Sasword
-              user: Tsurugi Kamishiro
-            - kamen_rider: Kamen Rider Gatack
-              user: Arata Kagami
-            - kamen_rider: Kamen Rider Hercus
-              user: Hidenari Oda
-            - kamen_rider: Kamen Rider Ketaros
-              user: Tetsuki Yamato
-            - kamen_rider: Kamen Rider Caucasus
-              user: Issei Kurosaki
-            - kamen_rider: Kamen Rider KickHopper
-              user: So Yaguruma
-            - kamen_rider: Kamen Rider PunchHopper
-              user: Shun Kageyama
-            - kamen_rider: Kamen Rider Dark Kabuto
-              user: Soji Kusakabe
-        - name: Kamen Rider Den-O
-          riders:
-            - kamen_rider: Kamen Rider Den-O
-              user: Ryotaro Nogami
-            - kamen_rider: Kamen Rider Zeronos
-              user: Yuto Sakurai
-            - kamen_rider: Kamen Rider Gaoh
-              user: Gaoh
-            - kamen_rider: Kamen Rider Nega Den-O
-              user: Negataros
-            - kamen_rider: Kamen Rider Yuuki
-              user: Shiro
-            - kamen_rider: Kamen Rider New Den-O
-              user: Kotaro Nogami
-            - kamen_rider: Kamen Rider G Den-O
-              user: Reiji Kurosaki
-        - name: Kamen Rider Kiva
-          riders:
-            - kamen_rider: Kamen Rider Kiva
-              user: Wataru Kurenai
-            - kamen_rider: Kamen Rider Ixa
-              user: Keisuke Nago
-            - kamen_rider: Kamen Rider Rey
-              user: Takato Shiramine
-            - kamen_rider: Kamen Rider Arc
-              user: Takashi Sugimura
-            - kamen_rider: Kamen Rider Saga
-              user: Taiga Nobori
-            - kamen_rider: Kamen Rider Dark Kiva
-              user: King
-        - name: Kamen Rider Decade
-          riders:
-            - kamen_rider: Kamen Rider Decade
-              user: Tsukasa Kadoya
-            - kamen_rider: Kamen Rider Abyss
-              user: Kamata
-            - kamen_rider: Kamen Rider Diend
-              user: Daiki Kaito
-            - kamen_rider: Kamen Rider Amaki
-              user: Akira
-            - kamen_rider: Kamen Rider Kiva-la
-              user: Natsumi Hikari
-        - name: Kamen Rider W
-          riders:
-            - kamen_rider: Kamen Rider Double
-              user: Shotaro Hidari & Philip
-            - kamen_rider: Kamen Rider Skull
-              user: Sokichi Narumi
-            - kamen_rider: Kamen Rider Accel
-              user: Ryu Terui
-            - kamen_rider: Kamen Rider Eternal
-              user: Katsumi Daido
-            - kamen_rider: Kamen Rider Joker
-              user: Shotaro Hidari
-        - name: Kamen Rider OOO
-          riders:
-            - kamen_rider: Kamen Rider OOO
-              user: Eiji Hino
-            - kamen_rider: Kamen Rider Birth
-              user: Shintaro Goto
-            - kamen_rider: Kamen Rider Core
-              user: Kamen Rider Core
-            - kamen_rider: Kamen Rider Birth·Proto Type
-              user: Akira Date
-            - kamen_rider: Kamen Rider Poseidon
-              user: Poseidon
-            - kamen_rider: Kamen Rider Aqua
-              user: Michal Minato
-        - name: Kamen Rider Fourze
-          riders:
-            - kamen_rider: Kamen Rider Fourze
-              user: Gentaro Kisaragi
-            - kamen_rider: Kamen Rider Nadeshiko
-              user: Nadeshiko Misaki
-            - kamen_rider: Kamen Rider Meteor
-              user: Ryusei Sakuta
-        - name: Kamen Rider Wizard
-          riders:
-            - kamen_rider: Kamen Rider Wizard
-              user: Haruto Soma
-            - kamen_rider: Kamen Rider Wiseman
-              user: Sou Fueki
-            - kamen_rider: Kamen Rider Beast
-              user: Kosuke Nitoh
-            - kamen_rider: Kamen Rider Mage
-              user: Mayu Inamori
-            - kamen_rider: Kamen Rider Sorcerer
-              user: Ogma
-        - name: Kamen Rider Gaim
-          riders:
-            - kamen_rider: Kamen Rider Gaim
-              user: Kouta Kazuraba
-            - kamen_rider: Kamen Rider Zangetsu
-              user: Takatora Kureshima
-            - kamen_rider: Kamen Rider Baron
-              user: Kaito Kumon
-            - kamen_rider: Kamen Rider Ryugen
-              user: Mitsuzane Kureshima
-            - kamen_rider: Kamen Rider Gridon
-              user: Hideyasu Jonouchi
-            - kamen_rider: Kamen Rider Kurokage
-              user: Ryoji Hase
-            - kamen_rider: Kamen Rider Bravo
-              user: Oren Pierre Alfonzo
-            - kamen_rider: Kamen Rider Bujin Gaim
-              user: Bujin Gaim
-            - kamen_rider: Kamen Rider Duke
-              user: Ryoma Sengoku
-            - kamen_rider: Kamen Rider Marika
-              user: Yoko Minato
-            - kamen_rider: Kamen Rider Sigurd
-              user: Lock Dealer Sid
-            - kamen_rider: Kamen Rider Knuckle
-              user: Zack
-            - kamen_rider: Kamen Rider Fifteen
-              user: Ren Aoi
-            - kamen_rider: Kamen Rider Mars
-              user: Kohgane
-            - kamen_rider: Kamen Rider Kamuro
-              user: Lapis
-            - kamen_rider: Kamen Rider Jam
-              user: Kohgane
-            - kamen_rider: Kamen Rider Idunn
-              user: Touka Akatsuki
-            - kamen_rider: Kamen Rider Tyrant
-              user: Alfred
-            - kamen_rider: Kamen Rider Saver
-              user: Kugai Kudo
-            - kamen_rider: Kamen Rider Black Baron
-              user: Shura
-            - kamen_rider: Kamen Rider Sylphi
-              user: Masako Suzuka
-        - name: Kamen Rider Drive
-          riders:
-            - kamen_rider: Kamen Rider Protodrive
-              user: Chase
-            - kamen_rider: Kamen Rider Drive
-              user: Shinnosuke Tomari
-            - kamen_rider: Kamen Rider Lupin
-              user: Zoruku Tojo
-            - kamen_rider: Kamen Rider Mach
-              user: Gou Shijima
-            - kamen_rider: Kamen Rider 3
-              user: Kyoichiro Kuroi
-            - kamen_rider: Kamen Rider 4
-              user: Kamen Rider 4
-            - kamen_rider: Kamen Rider Chaser
-              user: Chase
-            - kamen_rider: Kamen Rider Dark Drive
-              user: Paradox Roidmude
-            - kamen_rider: Kamen Rider Jun
-              user: Jun Honganji
-            - kamen_rider: Kamen Rider Chaser Mach
-              user: Go Shijima
-            - kamen_rider: Kamen Rider Mach Chaser
-              user: Go Shijima
-            - kamen_rider: Kamen Rider Heart
-              user: Heart
-            - kamen_rider: Kamen Rider Brain
-              user: Brain
-        - name: Kamen Rider Ghost
-          riders:
-            - kamen_rider: Kamen Rider Ghost
-              user: Takeru Tenkuji
-            - kamen_rider: Kamen Rider Specter
-              user: Makoto Fukami
-            - kamen_rider: Kamen Rider Necrom
-              user: Alain
-            - kamen_rider: Kamen Rider Dark Necrom Pink
-              user: Alia
-            - kamen_rider: Kamen Rider Dark Ghost
-              user: Argos
-            - kamen_rider: Kamen Rider Dark Necrom Red
-              user: Jered
-            - kamen_rider: Kamen Rider Dark Necrom Blue
-              user: Jebil
-            - kamen_rider: Kamen Rider Dark Necrom Yellow
-              user: Jey
-            - kamen_rider: Kamen Rider Zero Specter
-              user: Daigo Fukami
-            - kamen_rider: Kamen Rider Extremer
-              user: Argos
-            - kamen_rider: Kamen Rider Kanon Specter
-              user: Kanon Fukami
-        - name: Kamen Rider Amazons
-          riders:
-            - kamen_rider: Kamen Rider Amazon Omega
-              user: Haruka Mizusawa
-            - kamen_rider: Kamen Rider Amazon Alpha
-              user: Jin Takayama
-            - kamen_rider: Kamen Rider Amazon Sigma
-              user: Jun Maehara
-            - kamen_rider: Kamen Rider Amazon Neo
-              user: Chihiro
-            - kamen_rider: Kamen Rider Amazon Neo Alpha
-              user: Einosuke Mido
-        - name: Kamen Rider Ex-Aid
-          riders:
-            - kamen_rider: Kamen Rider Ex-Aid
-              user: Emu Hojo
-            - kamen_rider: Kamen Rider Genm
-              user: Kuroto Dan
-            - kamen_rider: Kamen Rider Brave
-              user: Hiiro Kagami
-            - kamen_rider: Kamen Rider Snipe
-              user: Taiga Hanaya
-            - kamen_rider: Kamen Rider Lazer
-              user: Kiriya Kujo
-            - kamen_rider: Kamen Rider Para-DX
-              user: Parado
-            - kamen_rider: Kamen Rider True Brave
-              user: Another Hiiro
-            - kamen_rider: Aka-Rider
-              user: Emu Hojo
-            - kamen_rider: Ao-Rider
-              user: Yakumo KatouIcon-crosswiki.png
-            - kamen_rider: Mido-Rider
-              user: Shuichi Kitaoka
-            - kamen_rider: Ki-Rider
-              user: Masato JinIcon-crosswiki.png
-            - kamen_rider: Momo-Rider
-              user: Momotaros
-            - kamen_rider: Kamen Rider Poppy
-              user: Poppy Pipopapo
-            - kamen_rider: Kamen Rider Cronus
-              user: Masamune Dan
-            - kamen_rider: Kamen Rider Fuma
-              user: Kagenari Nagumo
-            - kamen_rider: Kamen Rider Another Para-DX
-              user: Black Parado
-        - name: Kamen Rider Build
-          riders:
-            - kamen_rider: Kamen Rider Build
-              user: Sento Kiryu
-            - kamen_rider: Kamen Rider Cross-Z
-              user: Ryuga Banjo
-            - kamen_rider: Kamen Rider Grease
-              user: Kazumi Sawatari
-            - kamen_rider: Kamen Rider Rogue
-              user: Gentoku Himuro
-            - kamen_rider: Kamen Rider Evol
-              user: Evolto
-            - kamen_rider: Kamen Rider MadRogue
-              user: Nariaki Utsumi
-            - kamen_rider: Kamen Rider Blood
-              user: Kengo Ino
-            - kamen_rider: Kamen Rider Killbus
-              user: Killbus
-            - kamen_rider: Kamen Rider Metal Build
-              user: Keiji Uraga
-        - name: Kamen Rider Zi-O
-          riders:
-            - kamen_rider: Kamen Rider Zi-O
-              user: Sougo Tokiwa
-            - kamen_rider: Kamen Rider Geiz
-              user: Geiz Myokoin
-            - kamen_rider: Kamen Rider Woz
-              user: Black Woz
-            - kamen_rider: Kamen Rider Shinobi
-              user: Rentaro Kagura
-            - kamen_rider: Kamen Rider Quiz
-              user: Mondo Douan
-            - kamen_rider: Kamen Rider Kikai
-              user: Rento Makina
-            - kamen_rider: Kamen Rider Hattari
-              user: Isamichi Konjo
-            - kamen_rider: Kamen Rider Ginga
-              user: Kamen Rider Ginga
-            - kamen_rider: Kamen Rider Barlckxs
-              user: SOUGO Tokiwa
-            - kamen_rider: Kamen Rider Zonjis
-              user: Kagen
-            - kamen_rider: Kamen Rider Zamonas
-              user: Jogen
-            - kamen_rider: Kamen Rider Tsukuyomi
-              user: Tsukuyomi
+        series: ["Kamen Rider Kuuga", "Kamen Rider Agito", "Kamen Rider Ryuki", "Kamen Rider 555", "Kamen Rider Blade", "Kamen Rider Hibiki", "Kamen Rider Kabuto", "Kamen Rider Den-O", "Kamen Rider Kiva", "Kamen Rider Decade", "Kamen Rider W", "Kamen Rider OOO", "Kamen Rider Fourze", "Kamen Rider Wizard", "Kamen Rider Gaim", "Kamen Rider Drive", "Kamen Rider Ghost", "Kamen Rider Amazons", "Kamen Rider Ex-Aid", "Kamen Rider Build", "Kamen Rider Zi-O"]
+        kamen_riders: ["Kamen Rider Kuuga", "Kamen Rider Agito", "Kamen Rider G3", "Kamen Rider Gills", "Kamen Rider G4", "Another Agito", "Kamen Rider Ryuki", "Kamen Rider Knight", "Kamen Rider Scissors", "Kamen Rider Zolda", "Kamen Rider Raia", "Kamen Rider Gai", "Kamen Rider Ouja", "Kamen Rider Odin", "Kamen Rider Femme", "Kamen Rider Ryuga", "Kamen Rider Tiger", "Kamen Rider Verde", "Kamen Rider Imperer", "Kamen Rider Faiz", "Kamen Rider Kaixa", "Kamen Rider Delta", "Kamen Rider Psyga", "Kamen Rider Orga", "Kamen Rider Blade", "Kamen Rider Garren", "Kamen Rider Chalice", "Kamen Rider Leangle", "Kamen Rider Glaive", "Kamen Rider Lance", "Kamen Rider Larc", "Kamen Rider Hibiki", "Kamen Rider Ibuki", "Kamen Rider Danki", "Kamen Rider Sabaki", "Kamen Rider Todoroki", "Kamen Rider Zanki", "Kamen Rider Eiki", "Kamen Rider Kabuki", "Kamen Rider Touki", "Kamen Rider Kirameki", "Kamen Rider Nishiki", "Kamen Rider Habataki", "Kamen Rider Shouki", "Kamen Rider Gouki", "Kamen Rider Toki", "Kamen Rider Banki", "Kamen Rider Shuki", "Kamen Rider Kabuto", "Kamen Rider TheBee", "Kamen Rider Drake", "Kamen Rider Sasword", "Kamen Rider Gatack", "Kamen Rider Hercus", "Kamen Rider Ketaros", "Kamen Rider Caucasus", "Kamen Rider KickHopper", "Kamen Rider PunchHopper", "Kamen Rider Dark Kabuto", "Kamen Rider Den-O", "Kamen Rider Zeronos", "Kamen Rider Gaoh", "Kamen Rider Nega Den-O", "Kamen Rider Yuuki", "Kamen Rider New Den-O", "Kamen Rider G Den-O", "Kamen Rider Kiva", "Kamen Rider Ixa", "Kamen Rider Rey", "Kamen Rider Arc", "Kamen Rider Saga", "Kamen Rider Dark Kiva", "Kamen Rider Decade", "Kamen Rider Abyss", "Kamen Rider Diend", "Kamen Rider Amaki", "Kamen Rider Kiva-la", "Kamen Rider Double", "Kamen Rider Skull", "Kamen Rider Accel", "Kamen Rider Eternal", "Kamen Rider Joker", "Kamen Rider OOO", "Kamen Rider Birth", "Kamen Rider Core", "Kamen Rider Birth·Proto Type", "Kamen Rider Poseidon", "Kamen Rider Aqua", "Kamen Rider Fourze", "Kamen Rider Nadeshiko", "Kamen Rider Meteor", "Kamen Rider Wizard", "Kamen Rider Wiseman", "Kamen Rider Beast", "Kamen Rider Mage", "Kamen Rider Sorcerer", "Kamen Rider Gaim", "Kamen Rider Zangetsu", "Kamen Rider Baron", "Kamen Rider Ryugen", "Kamen Rider Gridon", "Kamen Rider Kurokage", "Kamen Rider Bravo", "Kamen Rider Bujin Gaim", "Kamen Rider Duke", "Kamen Rider Marika", "Kamen Rider Sigurd", "Kamen Rider Knuckle", "Kamen Rider Fifteen", "Kamen Rider Mars", "Kamen Rider Kamuro", "Kamen Rider Jam", "Kamen Rider Idunn", "Kamen Rider Tyrant", "Kamen Rider Saver", "Kamen Rider Black Baron", "Kamen Rider Sylphi", "Kamen Rider Protodrive", "Kamen Rider Drive", "Kamen Rider Lupin", "Kamen Rider Mach", "Kamen Rider 3", "Kamen Rider 4", "Kamen Rider Chaser", "Kamen Rider Dark Drive", "Kamen Rider Jun", "Kamen Rider Chaser Mach", "Kamen Rider Mach Chaser", "Kamen Rider Heart", "Kamen Rider Brain", "Kamen Rider Ghost", "Kamen Rider Specter", "Kamen Rider Necrom", "Kamen Rider Dark Necrom Pink", "Kamen Rider Dark Ghost", "Kamen Rider Dark Necrom Red", "Kamen Rider Dark Necrom Blue", "Kamen Rider Dark Necrom Yellow", "Kamen Rider Zero Specter", "Kamen Rider Extremer", "Kamen Rider Kanon Specter", "Kamen Rider Amazon Omega", "Kamen Rider Amazon Alpha", "Kamen Rider Amazon Sigma", "Kamen Rider Amazon Neo", "Kamen Rider Amazon Neo Alpha", "Kamen Rider Ex-Aid", "Kamen Rider Genm", "Kamen Rider Brave", "Kamen Rider Snipe", "Kamen Rider Lazer", "Kamen Rider Para-DX", "Kamen Rider True Brave", "Aka-Rider", "Ao-Rider", "Mido-Rider", "Ki-Rider", "Momo-Rider", "Kamen Rider Poppy", "Kamen Rider Cronus", "Kamen Rider Fuma", "Kamen Rider Another Para-DX", "Kamen Rider Build", "Kamen Rider Cross-Z", "Kamen Rider Grease", "Kamen Rider Rogue", "Kamen Rider Evol", "Kamen Rider MadRogue", "Kamen Rider Blood", "Kamen Rider Killbus", "Kamen Rider Metal Build", "Kamen Rider Zi-O", "Kamen Rider Geiz", "Kamen Rider Woz", "Kamen Rider Shinobi", "Kamen Rider Quiz", "Kamen Rider Kikai", "Kamen Rider Hattari", "Kamen Rider Ginga", "Kamen Rider Barlckxs", "Kamen Rider Zonjis", "Kamen Rider Zamonas", "Kamen Rider Tsukuyomi"]
+        users:
+          - Yusuke Godai
+          - Shoichi Tsugami
+          - Makoto Hikawa
+          - Ryo Ashihara
+          - Shiro Mizuki
+          - Kaoru Kino
+          - Shinji Kido
+          - Ren Akiyama
+          - Masashi Sudo
+          - Shuichi Kitaoka
+          - Miyuki Tezuka
+          - Jun Shibaura
+          - Takeshi Asakura
+          - Kamen Rider Odin
+          - Miho Kirishima
+          - Dark Shinji
+          - Satoru Tojo
+          - Itsuro Takamizawa
+          - Mitsuru Sano
+          - Takumi Inui
+          - Masato Kusaka
+          - Syuji Mihara
+          - Leo
+          - Yuji Kiba
+          - Kazuma Kenzaki
+          - Sakuya Tachibana
+          - Hajime Aikawa
+          - Mutsuki Kamijo
+          - Junichi Shimura
+          - Shin Magaki
+          - Natsumi Miwa
+          - Hitoshi Hidaka
+          - Iori Izumi
+          - Daisuke Danda
+          - Sakae Saeki
+          - Tomizo Todayama
+          - Zaomaru Zaitsuhara
+          - Eiki
+          - Kabuki
+          - Touki
+          - Kirameki
+          - Nishiki
+          - Habataki
+          - Shouki
+          - Gouki
+          - Toki
+          - Banki
+          - Shiori Shinagawa
+          - Soji Tendo
+          - Shun Kageyama
+          - Daisuke Kazama
+          - Tsurugi Kamishiro
+          - Arata Kagami
+          - Hidenari Oda
+          - Tetsuki Yamato
+          - Issei Kurosaki
+          - So Yaguruma
+          - Shun Kageyama
+          - Soji Kusakabe
+          - Ryotaro Nogami
+          - Yuto Sakurai
+          - Gaoh
+          - Negataros
+          - Shiro
+          - Kotaro Nogami
+          - Reiji Kurosaki
+          - Wataru Kurenai
+          - Keisuke Nago
+          - Takato Shiramine
+          - Takashi Sugimura
+          - Taiga Nobori
+          - King
+          - Tsukasa Kadoya
+          - Kamata
+          - Daiki Kaito
+          - Akira
+          - Natsumi Hikari
+          - Shotaro Hidari & Philip
+          - Sokichi Narumi
+          - Ryu Terui
+          - Katsumi Daido
+          - Shotaro Hidari
+          - Eiji Hino
+          - Shintaro Goto
+          - Kamen Rider Core
+          - Akira Date
+          - Poseidon
+          - Michal Minato
+          - Gentaro Kisaragi
+          - Nadeshiko Misaki
+          - Ryusei Sakuta
+          - Haruto Soma
+          - Sou Fueki
+          - Kosuke Nitoh
+          - Mayu Inamori
+          - Ogma
+          - Kouta Kazuraba
+          - Takatora Kureshima
+          - Kaito Kumon
+          - Mitsuzane Kureshima
+          - Hideyasu Jonouchi
+          - Ryoji Hase
+          - Oren Pierre Alfonzo
+          - Bujin Gaim
+          - Ryoma Sengoku
+          - Yoko Minato
+          - Lock Dealer Sid
+          - Zack
+          - Ren Aoi
+          - Kohgane
+          - Lapis
+          - Kohgane
+          - Touka Akatsuki
+          - Alfred
+          - Kugai Kudo
+          - Shura
+          - Masako Suzuka
+          - Chase
+          - Shinnosuke Tomari
+          - Zoruku Tojo
+          - Gou Shijima
+          - Kyoichiro Kuroi
+          - Kamen Rider 4
+          - Chase
+          - Paradox Roidmude
+          - Jun Honganji
+          - Go Shijima
+          - Go Shijima
+          - Heart
+          - Brain
+          - Takeru Tenkuji
+          - Makoto Fukami
+          - Alain
+          - Alia
+          - Argos
+          - Jered
+          - Jebil
+          - Jey
+          - Daigo Fukami
+          - Argos
+          - Kanon Fukami
+          - Haruka Mizusawa
+          - Jin Takayama
+          - Jun Maehara
+          - Chihiro
+          - Einosuke Mido
+          - Emu Hojo
+          - Kuroto Dan
+          - Hiiro Kagami
+          - Taiga Hanaya
+          - Kiriya Kujo
+          - Parado
+          - Another Hiiro
+          - Emu Hojo
+          - Yakumo KatouIcon-crosswiki.png
+          - Shuichi Kitaoka
+          - Masato JinIcon-crosswiki.png
+          - Momotaros
+          - Poppy Pipopapo
+          - Masamune Dan
+          - Kagenari Nagumo
+          - Black Parado
+          - Sento Kiryu
+          - Ryuga Banjo
+          - Kazumi Sawatari
+          - Gentoku Himuro
+          - Evolto
+          - Nariaki Utsumi
+          - Kengo Ino
+          - Killbus
+          - Keiji Uraga
+          - Sougo Tokiwa
+          - Geiz Myokoin
+          - Black Woz
+          - Rentaro Kagura
+          - Mondo Douan
+          - Rento Makina
+          - Isamichi Konjo
+          - Kamen Rider Ginga
+          - SOUGO Tokiwa
+          - Kagen
+          - Jogen
+          - Tsukuyomi
       reiwa:
-        - name: Kamen Rider Zero-One
-          riders:
-            - kamen_rider: Kamen Rider Zero-One
-              user: Aruto Hiden
-            - kamen_rider: Kamen Rider Vulcan
-              user: Isamu Fuwa
-            - kamen_rider: Kamen Rider Valkyrie
-              user: Yua Yaiba
-            - kamen_rider: Kamen Rider Horobi
-              user: Horobi
-            - kamen_rider: Kamen Rider Jin
-              user: Jin
-            - kamen_rider: Kamen Rider Ikazuchi
-              user: Ikazuchi
-            - kamen_rider: Kamen Rider ZeroZero-One
-              user: Aruto Hiden
-            - kamen_rider: Kamen Rider Ichi-Gata
-              user: Soreo Hiden
-            - kamen_rider: Kamen Rider Thouser
-              user: Gai Amatsu
-            - kamen_rider: Kamen Rider Ark-Zero
-              user: Ark
-            - kamen_rider: Kamen Rider Naki
-              user: Naki
-            - kamen_rider: Kamen Rider Eden
-              user: Rihito Isshiki
-            - kamen_rider: Kamen Rider Abaddon
-              user: Behru
-            - kamen_rider: Kamen Rider Lucifer
-              user: Behru
-            - kamen_rider: Kamen Rider Zaia
-              user: Lyon Arkland
-            - kamen_rider: Kamen Rider MetsubouJinrai
-              user: MetsubouJinrai
-        - name: Kamen Rider Saber
-          riders:
-            - kamen_rider: Kamen Rider Saber
-              user: Touma Kamiyama
-            - kamen_rider: Kamen Rider Calibur
-              user: Daichi Kamijo
-            - kamen_rider: Kamen Rider Blades
-              user: Rintaro Shindo
-            - kamen_rider: Kamen Rider Buster
-              user: Ryo Ogami
-            - kamen_rider: Kamen Rider Espada
-              user: Kento Fukamiya
-            - kamen_rider: Kamen Rider Kenzan
-              user: Ren Akamichi
-            - kamen_rider: Kamen Rider Slash
-              user: Tetsuo Daishinji
-            - kamen_rider: Kamen Rider Falchion
-              user: Bahato
-            - kamen_rider: Kamen Rider Saikou
-              user: Yuri
-            - kamen_rider: Kamen Rider Sabela
-              user: Reika Shindai
-            - kamen_rider: Kamen Rider Durendal
-              user: Ryoga Shindai
-            - kamen_rider: Kamen Rider Solomon
-              user: Isaac
-            - kamen_rider: Kamen Rider Storious
-              user: Storious
-        - name: Kamen Rider Revice
-          riders:
-            - kamen_rider: Kamen Rider Revi
-              user: Ikki Igarashi
-            - kamen_rider: Kamen Rider Vice
-              user: Vice
+        series: ["Kamen Rider Zero-One", "Kamen Rider Saber", "Kamen Rider Revice"]
+        kamen_riders: ["Kamen Rider Zero-One",  "Kamen Rider Vulcan",  "Kamen Rider Valkyrie",  "Kamen Rider Horobi",  "Kamen Rider Jin",  "Kamen Rider Ikazuchi",  "Kamen Rider ZeroZero-One",  "Kamen Rider Ichi-Gata",  "Kamen Rider Thouser",  "Kamen Rider Ark-Zero",  "Kamen Rider Naki",  "Kamen Rider Eden",  "Kamen Rider Abaddon",  "Kamen Rider Lucifer",  "Kamen Rider Zaia",  "Kamen Rider MetsubouJinrai",  "Kamen Rider Saber",  "Kamen Rider Calibur",  "Kamen Rider Blades",  "Kamen Rider Buster",  "Kamen Rider Espada",  "Kamen Rider Kenzan",  "Kamen Rider Slash",  "Kamen Rider Falchion",  "Kamen Rider Saikou",  "Kamen Rider Sabela",  "Kamen Rider Durendal",  "Kamen Rider Solomon",  "Kamen Rider Storious",  "Kamen Rider Revi",  "Kamen Rider Vice"]
+        users:
+          - Aruto Hiden
+          - Isamu Fuwa
+          - Yua Yaiba
+          - Horobi
+          - Jin
+          - Ikazuchi
+          - Aruto Hiden
+          - Soreo Hiden
+          - Gai Amatsu
+          - Ark
+          - Naki
+          - Rihito Isshiki
+          - Behru
+          - Lyon Arkland
+          - MetsubouJinrai
+          - Touma Kamiyama
+          - Daichi Kamijo
+          - Rintaro Shindo
+          - Ryo Ogami
+          - Kento Fukamiya
+          - Ren Akamichi
+          - Tetsuo Daishinji
+          - Bahato
+          - Yuri
+          - Reika Shindai
+          - Ryoga Shindai
+          - Isaac
+          - Storious
+          - Ikki Igarashi
+          - Vice

--- a/lib/locales/en/kamen_rider.yml
+++ b/lib/locales/en/kamen_rider.yml
@@ -194,9 +194,9 @@ en:
         - name: Kamen Rider Den-O
           riders:
             - kamen_rider: Kamen Rider Den-O
-              user: Ryotaro Nogami/Momotaros
+              user: Ryotaro Nogami
             - kamen_rider: Kamen Rider Zeronos
-              user: Yuto Sakurai/Deneb
+              user: Yuto Sakurai
             - kamen_rider: Kamen Rider Gaoh
               user: Gaoh
             - kamen_rider: Kamen Rider Nega Den-O
@@ -206,7 +206,7 @@ en:
             - kamen_rider: Kamen Rider New Den-O
               user: Kotaro Nogami
             - kamen_rider: Kamen Rider G Den-O
-              user: Reiji Kurosaki/Eve
+              user: Reiji Kurosaki
         - name: Kamen Rider Kiva
           riders:
             - kamen_rider: Kamen Rider Kiva
@@ -312,7 +312,7 @@ en:
             - kamen_rider: Kamen Rider Kamuro
               user: Lapis
             - kamen_rider: Kamen Rider Jam
-              user: Unnamed girl/Kohgane
+              user: Kohgane
             - kamen_rider: Kamen Rider Idunn
               user: Touka Akatsuki
             - kamen_rider: Kamen Rider Tyrant

--- a/lib/locales/en/kamen_rider.yml
+++ b/lib/locales/en/kamen_rider.yml
@@ -1,0 +1,538 @@
+en:
+  faker:
+    kamen_rider:
+      showa:
+        - name: Kamen Rider
+          riders:
+            - kamen_rider: Kamen Rider 1
+              user: Takeshi Hongo
+            - kamen_rider: Kamen Rider 2
+              user: Hayato Ichimonji
+        - name: Kamen Rider V3
+          riders:
+            - kamen_rider: Kamen Rider V3
+              user: Shiro Kazami
+            - kamen_rider: Riderman
+              user: Joji Yuki
+        - name: Kamen Rider X
+          riders:
+            - kamen_rider: Kamen Rider X
+              user: Keisuke Jin
+        - name: Kamen Rider Amazon
+          riders:
+            - kamen_rider: Kamen Rider Amazon
+              user: Daisuke Yamamoto
+        - name: Kamen Rider Stronger
+          riders:
+            - kamen_rider: Kamen Rider Stronger
+              user: Shigeru Jo
+        - name: Kamen Rider (Skyrider)
+          riders:
+            - kamen_rider: Skyrider
+              user: Hiroshi Tsukuba
+        - name: Kamen Rider Super-1
+          riders:
+            - kamen_rider: Kamen Rider Super-1
+              user: Kazuya Oki
+        - name: Kamen Rider ZX
+          riders:
+            - kamen_rider: Kamen Rider ZX
+              user: Ryo Murasame
+        - name: Kamen Rider Black
+          riders:
+            - kamen_rider: Kamen Rider Black
+              user: Kohtaro Minami
+        - name: Kamen Rider Black RX
+          riders:
+            - kamen_rider: Kamen Rider Black RX
+              user: Kohtaro Minami
+        - name: "Shin Kamen Rider: Prologue"
+          riders:
+            - kamen_rider: Kamen Rider Shin
+              user: Shin Kazamatsuri
+        - name: Kamen Rider ZO
+          riders:
+            - kamen_rider: Kamen Rider ZO
+              user: Masaru Aso
+        - name: Kamen Rider J
+          riders:
+            - kamen_rider: Kamen Rider J
+              user: Kouji Segawa
+      heisei:
+        - name: Kamen Rider Kuuga
+          riders:
+            - kamen_rider: Kamen Rider Kuuga
+              user: Yusuke Godai
+        - name: Kamen Rider Agito
+          riders:
+            - kamen_rider: Kamen Rider Agito
+              user: Shoichi Tsugami
+            - kamen_rider: Kamen Rider G3
+              user: Makoto Hikawa
+            - kamen_rider: Kamen Rider Gills
+              user: Ryo Ashihara
+            - kamen_rider: Kamen Rider G4
+              user: Shiro Mizuki
+            - kamen_rider: Another Agito
+              user: Kaoru Kino
+        - name: Kamen Rider Ryuki
+          riders:
+            - kamen_rider: Kamen Rider Ryuki
+              user: Shinji Kido
+            - kamen_rider: Kamen Rider Knight
+              user: Ren Akiyama
+            - kamen_rider: Kamen Rider Scissors
+              user: Masashi Sudo
+            - kamen_rider: Kamen Rider Zolda
+              user: Shuichi Kitaoka
+            - kamen_rider: Kamen Rider Raia
+              user: Miyuki Tezuka
+            - kamen_rider: Kamen Rider Gai
+              user: Jun Shibaura
+            - kamen_rider: Kamen Rider Ouja
+              user: Takeshi Asakura
+            - kamen_rider: Kamen Rider Odin
+              user: Kamen Rider Odin
+            - kamen_rider: Kamen Rider Femme
+              user: Miho Kirishima
+            - kamen_rider: Kamen Rider Ryuga
+              user: Dark Shinji
+            - kamen_rider: Kamen Rider Tiger
+              user: Satoru Tojo
+            - kamen_rider: Kamen Rider Verde
+              user: Itsuro Takamizawa
+            - kamen_rider: Kamen Rider Imperer
+              user: Mitsuru Sano
+        - name: Kamen Rider 555
+          riders:
+            - kamen_rider: Kamen Rider Faiz
+              user: Takumi Inui
+            - kamen_rider: Kamen Rider Kaixa
+              user: Masato Kusaka
+            - kamen_rider: Kamen Rider Delta
+              user: Syuji Mihara
+            - kamen_rider: Kamen Rider Psyga
+              user: Leo
+            - kamen_rider: Kamen Rider Orga
+              user: Yuji Kiba
+        - name: Kamen Rider Blade
+          riders:
+            - kamen_rider: Kamen Rider Blade
+              user: Kazuma Kenzaki
+            - kamen_rider: Kamen Rider Garren
+              user: Sakuya Tachibana
+            - kamen_rider: Kamen Rider Chalice
+              user: Hajime Aikawa
+            - kamen_rider: Kamen Rider Leangle
+              user: Mutsuki Kamijo
+            - kamen_rider: Kamen Rider Glaive
+              user: Junichi Shimura
+            - kamen_rider: Kamen Rider Lance
+              user: Shin Magaki
+            - kamen_rider: Kamen Rider Larc
+              user: Natsumi Miwa
+        - name: Kamen Rider Hibiki
+          riders:
+            - kamen_rider: Kamen Rider Hibiki
+              user: Hitoshi Hidaka
+            - kamen_rider: Kamen Rider Ibuki
+              user: Iori Izumi
+            - kamen_rider: Kamen Rider Danki
+              user: Daisuke Danda
+            - kamen_rider: Kamen Rider Sabaki
+              user: Sakae Saeki
+            - kamen_rider: Kamen Rider Todoroki
+              user: Tomizo Todayama
+            - kamen_rider: Kamen Rider Zanki
+              user: Zaomaru Zaitsuhara
+            - kamen_rider: Kamen Rider Eiki
+              user: Eiki
+            - kamen_rider: Kamen Rider Kabuki
+              user: Kabuki
+            - kamen_rider: Kamen Rider Touki
+              user: Touki
+            - kamen_rider: Kamen Rider Kirameki
+              user: Kirameki
+            - kamen_rider: Kamen Rider Nishiki
+              user: Nishiki
+            - kamen_rider: Kamen Rider Habataki
+              user: Habataki
+            - kamen_rider: Kamen Rider Shouki
+              user: Shouki
+            - kamen_rider: Kamen Rider Gouki
+              user: Gouki
+            - kamen_rider: Kamen Rider Toki
+              user: Toki
+            - kamen_rider: Kamen Rider Banki
+              user: Banki
+            - kamen_rider: Kamen Rider Shuki
+              user: Shiori Shinagawa
+        - name: Kamen Rider Kabuto
+          riders:
+            - kamen_rider: Kamen Rider Kabuto
+              user: Soji Tendo
+            - kamen_rider: Kamen Rider TheBee
+              user: Shun Kageyama
+            - kamen_rider: Kamen Rider Drake
+              user: Daisuke Kazama
+            - kamen_rider: Kamen Rider Sasword
+              user: Tsurugi Kamishiro
+            - kamen_rider: Kamen Rider Gatack
+              user: Arata Kagami
+            - kamen_rider: Kamen Rider Hercus
+              user: Hidenari Oda
+            - kamen_rider: Kamen Rider Ketaros
+              user: Tetsuki Yamato
+            - kamen_rider: Kamen Rider Caucasus
+              user: Issei Kurosaki
+            - kamen_rider: Kamen Rider KickHopper
+              user: So Yaguruma
+            - kamen_rider: Kamen Rider PunchHopper
+              user: Shun Kageyama
+            - kamen_rider: Kamen Rider Dark Kabuto
+              user: Soji Kusakabe
+        - name: Kamen Rider Den-O
+          riders:
+            - kamen_rider: Kamen Rider Den-O
+              user: Ryotaro Nogami/Momotaros
+            - kamen_rider: Kamen Rider Zeronos
+              user: Yuto Sakurai/Deneb
+            - kamen_rider: Kamen Rider Gaoh
+              user: Gaoh
+            - kamen_rider: Kamen Rider Nega Den-O
+              user: Negataros
+            - kamen_rider: Kamen Rider Yuuki
+              user: Shiro
+            - kamen_rider: Kamen Rider New Den-O
+              user: Kotaro Nogami
+            - kamen_rider: Kamen Rider G Den-O
+              user: Reiji Kurosaki/Eve
+        - name: Kamen Rider Kiva
+          riders:
+            - kamen_rider: Kamen Rider Kiva
+              user: Wataru Kurenai
+            - kamen_rider: Kamen Rider Ixa
+              user: Keisuke Nago
+            - kamen_rider: Kamen Rider Rey
+              user: Takato Shiramine
+            - kamen_rider: Kamen Rider Arc
+              user: Takashi Sugimura
+            - kamen_rider: Kamen Rider Saga
+              user: Taiga Nobori
+            - kamen_rider: Kamen Rider Dark Kiva
+              user: King
+        - name: Kamen Rider Decade
+          riders:
+            - kamen_rider: Kamen Rider Decade
+              user: Tsukasa Kadoya
+            - kamen_rider: Kamen Rider Abyss
+              user: Kamata
+            - kamen_rider: Kamen Rider Diend
+              user: Daiki Kaito
+            - kamen_rider: Kamen Rider Amaki
+              user: Akira
+            - kamen_rider: Kamen Rider Kiva-la
+              user: Natsumi Hikari
+        - name: Kamen Rider W
+          riders:
+            - kamen_rider: Kamen Rider Double
+              user: Shotaro Hidari & Philip
+            - kamen_rider: Kamen Rider Skull
+              user: Sokichi Narumi
+            - kamen_rider: Kamen Rider Accel
+              user: Ryu Terui
+            - kamen_rider: Kamen Rider Eternal
+              user: Katsumi Daido
+            - kamen_rider: Kamen Rider Joker
+              user: Shotaro Hidari
+        - name: Kamen Rider OOO
+          riders:
+            - kamen_rider: Kamen Rider OOO
+              user: Eiji Hino
+            - kamen_rider: Kamen Rider Birth
+              user: Shintaro Goto
+            - kamen_rider: Kamen Rider Core
+              user: Kamen Rider Core
+            - kamen_rider: Kamen Rider Birth·Proto Type
+              user: Akira Date
+            - kamen_rider: Kamen Rider Poseidon
+              user: Poseidon
+            - kamen_rider: Kamen Rider Aqua
+              user: Michal Minato
+        - name: Kamen Rider Fourze
+          riders:
+            - kamen_rider: Kamen Rider Fourze
+              user: Gentaro Kisaragi
+            - kamen_rider: Kamen Rider Nadeshiko
+              user: Nadeshiko Misaki
+            - kamen_rider: Kamen Rider Meteor
+              user: Ryusei Sakuta
+        - name: Kamen Rider Wizard
+          riders:
+            - kamen_rider: Kamen Rider Wizard
+              user: Haruto Soma
+            - kamen_rider: Kamen Rider Wiseman
+              user: Sou Fueki
+            - kamen_rider: Kamen Rider Beast
+              user: Kosuke Nitoh
+            - kamen_rider: Kamen Rider Mage
+              user: Mayu Inamori
+            - kamen_rider: Kamen Rider Sorcerer
+              user: Ogma
+        - name: Kamen Rider Gaim
+          riders:
+            - kamen_rider: Kamen Rider Gaim
+              user: Kouta Kazuraba
+            - kamen_rider: Kamen Rider Zangetsu
+              user: Takatora Kureshima
+            - kamen_rider: Kamen Rider Baron
+              user: Kaito Kumon
+            - kamen_rider: Kamen Rider Ryugen
+              user: Mitsuzane Kureshima
+            - kamen_rider: Kamen Rider Gridon
+              user: Hideyasu Jonouchi
+            - kamen_rider: Kamen Rider Kurokage
+              user: Ryoji Hase
+            - kamen_rider: Kamen Rider Bravo
+              user: Oren Pierre Alfonzo
+            - kamen_rider: Kamen Rider Bujin Gaim
+              user: Bujin Gaim
+            - kamen_rider: Kamen Rider Duke
+              user: Ryoma Sengoku
+            - kamen_rider: Kamen Rider Marika
+              user: Yoko Minato
+            - kamen_rider: Kamen Rider Sigurd
+              user: Lock Dealer Sid
+            - kamen_rider: Kamen Rider Knuckle
+              user: Zack
+            - kamen_rider: Kamen Rider Fifteen
+              user: Ren Aoi
+            - kamen_rider: Kamen Rider Mars
+              user: Kohgane
+            - kamen_rider: Kamen Rider Kamuro
+              user: Lapis
+            - kamen_rider: Kamen Rider Jam
+              user: Unnamed girl/Kohgane
+            - kamen_rider: Kamen Rider Idunn
+              user: Touka Akatsuki
+            - kamen_rider: Kamen Rider Tyrant
+              user: Alfred
+            - kamen_rider: Kamen Rider Saver
+              user: Kugai Kudo
+            - kamen_rider: Kamen Rider Black Baron
+              user: Shura
+            - kamen_rider: Kamen Rider Sylphi
+              user: Masako Suzuka
+        - name: Kamen Rider Drive
+          riders:
+            - kamen_rider: Kamen Rider Protodrive
+              user: Chase
+            - kamen_rider: Kamen Rider Drive
+              user: Shinnosuke Tomari
+            - kamen_rider: Kamen Rider Lupin
+              user: Zoruku Tojo
+            - kamen_rider: Kamen Rider Mach
+              user: Gou Shijima
+            - kamen_rider: Kamen Rider 3
+              user: Kyoichiro Kuroi
+            - kamen_rider: Kamen Rider 4
+              user: Kamen Rider 4
+            - kamen_rider: Kamen Rider Chaser
+              user: Chase
+            - kamen_rider: Kamen Rider Dark Drive
+              user: Paradox Roidmude
+            - kamen_rider: Kamen Rider Jun
+              user: Jun Honganji
+            - kamen_rider: Kamen Rider Chaser Mach
+              user: Go Shijima
+            - kamen_rider: Kamen Rider Mach Chaser
+              user: Go Shijima
+            - kamen_rider: Kamen Rider Heart
+              user: Heart
+            - kamen_rider: Kamen Rider Brain
+              user: Brain
+        - name: Kamen Rider Ghost
+          riders:
+            - kamen_rider: Kamen Rider Ghost
+              user: Takeru Tenkuji
+            - kamen_rider: Kamen Rider Specter
+              user: Makoto Fukami
+            - kamen_rider: Kamen Rider Necrom
+              user: Alain
+            - kamen_rider: Kamen Rider Dark Necrom Pink
+              user: Alia
+            - kamen_rider: Kamen Rider Dark Ghost
+              user: Argos
+            - kamen_rider: Kamen Rider Dark Necrom Red
+              user: Jered
+            - kamen_rider: Kamen Rider Dark Necrom Blue
+              user: Jebil
+            - kamen_rider: Kamen Rider Dark Necrom Yellow
+              user: Jey
+            - kamen_rider: Kamen Rider Zero Specter
+              user: Daigo Fukami
+            - kamen_rider: Kamen Rider Extremer
+              user: Argos
+            - kamen_rider: Kamen Rider Kanon Specter
+              user: Kanon Fukami
+        - name: Kamen Rider Amazons
+          riders:
+            - kamen_rider: Kamen Rider Amazon Omega
+              user: Haruka Mizusawa
+            - kamen_rider: Kamen Rider Amazon Alpha
+              user: Jin Takayama
+            - kamen_rider: Kamen Rider Amazon Sigma
+              user: Jun Maehara
+            - kamen_rider: Kamen Rider Amazon Neo
+              user: Chihiro
+            - kamen_rider: Kamen Rider Amazon Neo Alpha
+              user: Einosuke Mido
+        - name: Kamen Rider Ex-Aid
+          riders:
+            - kamen_rider: Kamen Rider Ex-Aid
+              user: Emu Hojo
+            - kamen_rider: Kamen Rider Genm
+              user: Kuroto Dan
+            - kamen_rider: Kamen Rider Brave
+              user: Hiiro Kagami
+            - kamen_rider: Kamen Rider Snipe
+              user: Taiga Hanaya
+            - kamen_rider: Kamen Rider Lazer
+              user: Kiriya Kujo
+            - kamen_rider: Kamen Rider Para-DX
+              user: Parado
+            - kamen_rider: Kamen Rider True Brave
+              user: Another Hiiro
+            - kamen_rider: Aka-Rider
+              user: Emu Hojo
+            - kamen_rider: Ao-Rider
+              user: Yakumo KatouIcon-crosswiki.png
+            - kamen_rider: Mido-Rider
+              user: Shuichi Kitaoka
+            - kamen_rider: Ki-Rider
+              user: Masato JinIcon-crosswiki.png
+            - kamen_rider: Momo-Rider
+              user: Momotaros
+            - kamen_rider: Kamen Rider Poppy
+              user: Poppy Pipopapo
+            - kamen_rider: Kamen Rider Cronus
+              user: Masamune Dan
+            - kamen_rider: Kamen Rider Fuma
+              user: Kagenari Nagumo
+            - kamen_rider: Kamen Rider Another Para-DX
+              user: Black Parado
+        - name: Kamen Rider Build
+          riders:
+            - kamen_rider: Kamen Rider Build
+              user: Sento Kiryu
+            - kamen_rider: Kamen Rider Cross-Z
+              user: Ryuga Banjo
+            - kamen_rider: Kamen Rider Grease
+              user: Kazumi Sawatari
+            - kamen_rider: Kamen Rider Rogue
+              user: Gentoku Himuro
+            - kamen_rider: Kamen Rider Evol
+              user: Evolto
+            - kamen_rider: Kamen Rider MadRogue
+              user: Nariaki Utsumi
+            - kamen_rider: Kamen Rider Blood
+              user: Kengo Ino
+            - kamen_rider: Kamen Rider Killbus
+              user: Killbus
+            - kamen_rider: Kamen Rider Metal Build
+              user: Keiji Uraga
+        - name: Kamen Rider Zi-O
+          riders:
+            - kamen_rider: Kamen Rider Zi-O
+              user: Sougo Tokiwa
+            - kamen_rider: Kamen Rider Geiz
+              user: Geiz Myokoin
+            - kamen_rider: Kamen Rider Woz
+              user: Black Woz
+            - kamen_rider: Kamen Rider Shinobi
+              user: Rentaro Kagura
+            - kamen_rider: Kamen Rider Quiz
+              user: Mondo Douan
+            - kamen_rider: Kamen Rider Kikai
+              user: Rento Makina
+            - kamen_rider: Kamen Rider Hattari
+              user: Isamichi Konjo
+            - kamen_rider: Kamen Rider Ginga
+              user: Kamen Rider Ginga
+            - kamen_rider: Kamen Rider Barlckxs
+              user: SOUGO Tokiwa
+            - kamen_rider: Kamen Rider Zonjis
+              user: Kagen
+            - kamen_rider: Kamen Rider Zamonas
+              user: Jogen
+            - kamen_rider: Kamen Rider Tsukuyomi
+              user: Tsukuyomi
+      reiwa:
+        - name: Kamen Rider Zero-One
+          riders:
+            - kamen_rider: Kamen Rider Zero-One
+              user: Aruto Hiden
+            - kamen_rider: Kamen Rider Vulcan
+              user: Isamu Fuwa
+            - kamen_rider: Kamen Rider Valkyrie
+              user: Yua Yaiba
+            - kamen_rider: Kamen Rider Horobi
+              user: Horobi
+            - kamen_rider: Kamen Rider Jin
+              user: Jin
+            - kamen_rider: Kamen Rider Ikazuchi
+              user: Ikazuchi
+            - kamen_rider: Kamen Rider ZeroZero-One
+              user: Aruto Hiden
+            - kamen_rider: Kamen Rider Ichi-Gata
+              user: Soreo Hiden
+            - kamen_rider: Kamen Rider Thouser
+              user: Gai Amatsu
+            - kamen_rider: Kamen Rider Ark-Zero
+              user: Ark
+            - kamen_rider: Kamen Rider Naki
+              user: Naki
+            - kamen_rider: Kamen Rider Eden
+              user: Rihito Isshiki
+            - kamen_rider: Kamen Rider Abaddon
+              user: Behru
+            - kamen_rider: Kamen Rider Lucifer
+              user: Behru
+            - kamen_rider: Kamen Rider Zaia
+              user: Lyon Arkland
+            - kamen_rider: Kamen Rider MetsubouJinrai
+              user: MetsubouJinrai
+        - name: Kamen Rider Saber
+          riders:
+            - kamen_rider: Kamen Rider Saber
+              user: Touma Kamiyama
+            - kamen_rider: Kamen Rider Calibur
+              user: Daichi Kamijo
+            - kamen_rider: Kamen Rider Blades
+              user: Rintaro Shindo
+            - kamen_rider: Kamen Rider Buster
+              user: Ryo Ogami
+            - kamen_rider: Kamen Rider Espada
+              user: Kento Fukamiya
+            - kamen_rider: Kamen Rider Kenzan
+              user: Ren Akamichi
+            - kamen_rider: Kamen Rider Slash
+              user: Tetsuo Daishinji
+            - kamen_rider: Kamen Rider Falchion
+              user: Bahato
+            - kamen_rider: Kamen Rider Saikou
+              user: Yuri
+            - kamen_rider: Kamen Rider Sabela
+              user: Reika Shindai
+            - kamen_rider: Kamen Rider Durendal
+              user: Ryoga Shindai
+            - kamen_rider: Kamen Rider Solomon
+              user: Isaac
+            - kamen_rider: Kamen Rider Storious
+              user: Storious
+        - name: Kamen Rider Revice
+          riders:
+            - kamen_rider: Kamen Rider Revi
+              user: Ikki Igarashi
+            - kamen_rider: Kamen Rider Vice
+              user: Vice

--- a/test/faker/japanese_media/test_faker_kamen_rider.rb
+++ b/test/faker/japanese_media/test_faker_kamen_rider.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerJapaneseKamenRider < Test::Unit::TestCase
+  def setup
+    @tester = Faker::JapaneseMedia::KamenRider
+  end
+
+  def test_kamen_rider
+    assert @tester.kamen_rider.match(/\w+\.?/)
+  end
+
+  def test_kamen_rider_showa
+    assert @tester.kamen_rider(:showa).match(/\w+\.?/)
+  end
+
+  def test_kamen_rider_heisei
+    assert @tester.kamen_rider(:heisei).match(/\w+\.?/)
+  end
+
+  def test_kamen_rider_reiwa
+    assert @tester.kamen_rider(:reiwa).match(/\w+\.?/)
+  end
+
+  def test_kamen_rider_heisei_reiwa
+    assert @tester.kamen_rider(:heisei, :reiwa).match(/\w+\.?/)
+  end
+
+  def test_user_all
+    assert @tester.user.match(/\w+\.?/)
+  end
+
+  def test_user_showa
+    assert @tester.user(:showa).match(/\w+\.?/)
+  end
+
+  def test_user_heisei
+    assert @tester.user(:heisei).match(/\w+\.?/)
+  end
+
+  def test_user_reiwa
+    assert @tester.user(:reiwa).match(/\w+\.?/)
+  end
+
+  def test_user_heisei_reiwa
+    assert @tester.user(:heisei, :reiwa).match(/\w+\.?/)
+  end
+
+  def test_series_all
+    assert @tester.series.match(/\w+\.?/)
+  end
+
+  def test_series_showa
+    assert @tester.series(:showa).match(/\w+\.?/)
+  end
+
+  def test_series_heisei
+    assert @tester.series(:heisei).match(/\w+\.?/)
+  end
+
+  def test_series_reiwa
+    assert @tester.series(:reiwa).match(/\w+\.?/)
+  end
+
+  def test_series_heisei_reiwa
+    assert @tester.series(:heisei, :reiwa).match(/\w+\.?/)
+  end
+end


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------

Adds data surrounding the _Kamen Rider_ series to Faker. _Kamen Rider_ is a Japanese tokusatsu (live-action with special effects) drama series. It spans 50 years of history and three Japanese eras - Showa, Heisei, and Reiwa, and it's often talked about alongside what Western folks know as _Power Rangers_. That's actually an adaptation of _Rider_'s sister show _Super Sentai_.

As mentioned in the docs, you can return the titular Kamen Riders, the folks that transform into them, and the names of their respective series. I figured they'd make for good seed data.

---

I organized the data in this one through more of a layered structure. I don't know if that'll lead to performance or uniqueness issues.