### PR TITLE
Re-add the `Faker::Internet.base64` method

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -531,6 +531,33 @@ module Faker
       end
 
       ##
+      # Produces a random string of alphabetic characters, (no digits)
+      #
+      # @param length [Integer] The length of the string to generate
+      # @param padding [Boolean] Toggles if a final equal '=' will be added.
+      # @param urlsafe [Boolean] Toggles charset to '-' and '_' instead of '+' and '/'.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Internet.base64
+      #     #=> "r_hbZ2DSD-ZACzZT"
+      # @example
+      #   Faker::Internet.base64(length: 4, padding: true, urlsafe: false)
+      #     #=> "x1/R="
+      def base64(length: 16, padding: false, urlsafe: true)
+        char_range = [
+          Array('0'..'9'),
+          Array('A'..'Z'),
+          Array('a'..'z'),
+          urlsafe ? %w[- _] : %w[+ /]
+        ].flatten
+        s = Array.new(length) { sample(char_range) }.join
+        s += '=' if padding
+        s
+      end
+
+      ##
       # Produces a randomized hash of internet user details
       # @example
       #   Faker::Internet.user #=> { username: 'alexie', email: 'alexie@example.net' }

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -545,6 +545,8 @@ module Faker
       # @example
       #   Faker::Internet.base64(length: 4, padding: true, urlsafe: false)
       #     #=> "x1/R="
+      #
+      # @faker.version 2.11.0
       def base64(length: 16, padding: false, urlsafe: true)
         char_range = [
           Array('0'..'9'),

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -333,6 +333,13 @@ class TestFakerInternet < Test::Unit::TestCase
     assert_match(/\A\h{8}-\h{4}-4\h{3}-\h{4}-\h{12}\z/, uuid)
   end
 
+  def test_base64
+    assert_match(/[[[:alnum:]]\-_]{16}/, @tester.base64)
+    assert_match(/[[[:alnum:]]\-_]{4}/, @tester.base64(length: 4))
+    assert_match(/[[[:alnum:]]\-_]{16}=/, @tester.base64(padding: true))
+    assert_match(/[[[:alnum:]]+\/]{16}/, @tester.base64(urlsafe: false))
+  end
+
   def test_user_with_args
     user = @tester.user('username', 'email', 'password')
     assert user[:username].match(/[a-z]+((_|\.)[a-z]+)?/)


### PR DESCRIPTION
https://github.com/faker-ruby/faker/issues/2375

Description:
------
This PR re-adds the `Faker::Internet.base64` method which was accidentally removed during the conflict resolution in 
https://github.com/faker-ruby/faker/pull/1730.
