### PR TITLE
Remove a leading white-space from a StrangerThings quote

### DIFF
--- a/lib/locales/en/stranger_thing.yml
+++ b/lib/locales/en/stranger_thing.yml
@@ -27,7 +27,7 @@ en:
       "This is not yours to fix alone. You act like you’re all alone out there in the world, but you’re not. You’re not alone.",
       "My God, is she Russian?",
       "Maybe I’m crazy, maybe I’m out of my mind! But God help me, I will keep these lights up until the day I die if I think there’s a chance that Will’s still out there!",
-      " Am I dreaming, or is that you, Harrington?",
+      "Am I dreaming, or is that you, Harrington?",
       "How do you know it’s not just a lizard?....Because his face opened up and he ate my cat!",
       "Use the shampoo and conditioner and when your hair’s damp, not wet, okay? When it’s damp, you do four puffs of the Farrah Fawcett spray.",
       "She will not be able to resist these pearls. *Purrs*",


### PR DESCRIPTION
Description:
------

This quote item has an unexpected leading white-space character. Just removing it.

from: 
`" Am I dreaming, or is that you, Harrington?"`

to:
`"Am I dreaming, or is that you, Harrington?"`
