### PR TITLE
Add Faker::JapaneseMedia::KamenRider#collectible_device

### DIFF
--- a/lib/faker/japanese_media/kamen_rider.rb
+++ b/lib/faker/japanese_media/kamen_rider.rb
@@ -50,6 +50,19 @@ module Faker
           from_eras(*eras, field: :series)
         end
 
+        ##
+        # Produces the name of a collectible device from a Kamen Rider series.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::KamenRider.collectible_device #=> "Vistamp"
+        #
+        # @faker.version next
+        def collectible_device(*eras)
+          from_eras(*eras, field: :collectible_devices) { |e| e.delete(:showa) }
+        end
+
         private
 
         def eras
@@ -59,11 +72,17 @@ module Faker
         def from_eras(*input_eras, field:)
           selected_eras = (ERAS & input_eras).yield_self do |selected|
             selected.empty? ? eras : selected
-          end
+          end.dup
+          yield(selected_eras) if block_given?
+
+          raise UnavailableInEra, "#{field} is unavailable in the selected eras." if selected_eras.empty?
+
           selected_eras.sample.yield_self do |era|
             fetch("kamen_rider.#{era}.#{field}")
           end
         end
+
+        class UnavailableInEra < StandardError; end
       end
     end
   end

--- a/lib/locales/en/kamen_rider.yml
+++ b/lib/locales/en/kamen_rider.yml
@@ -207,6 +207,30 @@ en:
           - Kagen
           - Jogen
           - Tsukuyomi
+        collectible_devices:
+          - Advent Card
+          - Mission Memory
+          - Rouse Card
+          - Disk Animal
+          - Zecter
+          - Rider Ticket
+          - Fuestle
+          - Rider Car
+          - Gaia Memory
+          - O Medal
+          - Astroswitch
+          - Wizard Ring
+          - Lockseed
+          - Shift Car
+          - Signal Bike
+          - Viral Core
+          - Ghost Eyecon
+          - Rider Gashat
+          - Energy Item
+          - Fullbottle
+          - Sclashjelly
+          - Ridewatch
+          - Miridewatch
       reiwa:
         series: ["Kamen Rider Zero-One", "Kamen Rider Saber", "Kamen Rider Revice"]
         kamen_riders: ["Kamen Rider Zero-One",  "Kamen Rider Vulcan",  "Kamen Rider Valkyrie",  "Kamen Rider Horobi",  "Kamen Rider Jin",  "Kamen Rider Ikazuchi",  "Kamen Rider ZeroZero-One",  "Kamen Rider Ichi-Gata",  "Kamen Rider Thouser",  "Kamen Rider Ark-Zero",  "Kamen Rider Naki",  "Kamen Rider Eden",  "Kamen Rider Abaddon",  "Kamen Rider Lucifer",  "Kamen Rider Zaia",  "Kamen Rider MetsubouJinrai",  "Kamen Rider Saber",  "Kamen Rider Calibur",  "Kamen Rider Blades",  "Kamen Rider Buster",  "Kamen Rider Espada",  "Kamen Rider Kenzan",  "Kamen Rider Slash",  "Kamen Rider Falchion",  "Kamen Rider Saikou",  "Kamen Rider Sabela",  "Kamen Rider Durendal",  "Kamen Rider Solomon",  "Kamen Rider Storious",  "Kamen Rider Revi",  "Kamen Rider Vice"]
@@ -241,3 +265,7 @@ en:
           - Storious
           - Ikki Igarashi
           - Vice
+        collectible_devices:
+          - Progrisekey
+          - Wonder Ride Book
+          - Vistamp

--- a/test/faker/japanese_media/test_faker_kamen_rider.rb
+++ b/test/faker/japanese_media/test_faker_kamen_rider.rb
@@ -66,4 +66,25 @@ class TestFakerJapaneseKamenRider < Test::Unit::TestCase
   def test_series_heisei_reiwa
     assert @tester.series(:heisei, :reiwa).match(/\w+\.?/)
   end
+
+  def test_collectible_device_all
+    assert @tester.collectible_device.match(/\w+\.?/)
+  end
+
+  # The Showa era had not introduced the concept of collectible devices.
+  def test_collectible_device_showa
+    assert_raise('Faker::JapaneseMedia::KamenRider::UnavailableInEra') { @tester.collectible_device(:showa) }
+  end
+
+  def test_collectible_device_heisei
+    assert @tester.collectible_device(:heisei).match(/\w+\.?/)
+  end
+
+  def test_collectible_device_reiwa
+    assert @tester.collectible_device(:reiwa).match(/\w+\.?/)
+  end
+
+  def test_collectible_device_heisei_reiwa
+    assert @tester.collectible_device(:heisei, :reiwa).match(/\w+\.?/)
+  end
 end


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------

Starting with *Kamen Rider Ryuki*, *Kamen Rider* has had the concept of collectible devices that allow users of the Kamen Rider system to take different forms and gain new powers. This PR introduces those to the Faker for the series.

The Showa production era didn't have the concept of these devices, so they aren't listed for it. If Showa is the only era requested when using `collectible_device`, an error will be raised. Otherwise, all other eras specified either at the class level or at the parameter level will be used.