### PR TITLE
Change Faker::Internet.slug method to use faker.internet.slug translation

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -479,7 +479,9 @@ module Faker
         end
 
         glue ||= sample(%w[- _])
-        (words || Faker::Lorem.words(number: 2).join(' ')).delete(',.').gsub(' ', glue).downcase
+        return words.delete(',.').gsub(' ', glue).downcase unless words.nil?
+
+        sample(translate('faker.internet.slug'), 2).join(glue)
       end
 
       ##

--- a/lib/locales/en/internet.yml
+++ b/lib/locales/en/internet.yml
@@ -1,8 +1,9 @@
 en:
   faker:
     internet:
-      free_email: [gmail.com, yahoo.com, hotmail.com]
       domain_suffix: [com, biz, info, name, net, org, io, co]
+      free_email: [gmail.com, yahoo.com, hotmail.com]
+      slug: [report, appointment, highway, premium, shock, general, guess, branch, outside, exhibition, condition, nursery, trivial, confuse, design, corn, bless, ambiguous, diagram, ample, provision, judge, strict, perception, widen, plain, strap, fruit, distant, arena, twilight, hope, turkey, deport, brown, agree, exaggerate, onion, stuff, hypothesis, whole, relationship, linger, corpse, cutting, dynamic, thirsty, authority, award, introduction, seller, push, smile, marine, academy, polish, vegetarian, drill, miscarriage, laser, satisfaction, copy, angel, rung, glow, publish, figure, scale, story, compete, galaxy, book, conglomerate, kidnap, theorist, cruelty, inspiration, doctor, freckle, transfer, dictate, thank, midnight, defend, strikebreaker, offensive, wear, minister, curriculum, capital, patience, notebook, message, horizon]
       user_agent:
         aol:
           - Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7; AOLBuild 4343.19; Windows NT 6.1; WOW64; Trident/5.0; FunWebProducts)
@@ -18,4 +19,3 @@ en:
           - Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16
         safari:
           - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A
-

--- a/lib/locales/en/internet.yml
+++ b/lib/locales/en/internet.yml
@@ -1,9 +1,114 @@
 en:
   faker:
     internet:
-      domain_suffix: [com, biz, info, name, net, org, io, co]
-      free_email: [gmail.com, yahoo.com, hotmail.com]
-      slug: [report, appointment, highway, premium, shock, general, guess, branch, outside, exhibition, condition, nursery, trivial, confuse, design, corn, bless, ambiguous, diagram, ample, provision, judge, strict, perception, widen, plain, strap, fruit, distant, arena, twilight, hope, turkey, deport, brown, agree, exaggerate, onion, stuff, hypothesis, whole, relationship, linger, corpse, cutting, dynamic, thirsty, authority, award, introduction, seller, push, smile, marine, academy, polish, vegetarian, drill, miscarriage, laser, satisfaction, copy, angel, rung, glow, publish, figure, scale, story, compete, galaxy, book, conglomerate, kidnap, theorist, cruelty, inspiration, doctor, freckle, transfer, dictate, thank, midnight, defend, strikebreaker, offensive, wear, minister, curriculum, capital, patience, notebook, message, horizon]
+      domain_suffix:
+        - com
+        - biz
+        - info
+        - name
+        - net
+        - org
+        - io
+        - co
+      free_email:
+        - gmail.com
+        - yahoo.com
+        - hotmail.com
+      slug:
+        - report
+        - appointment
+        - highway
+        - premium
+        - shock
+        - general
+        - guess
+        - branch
+        - outside
+        - exhibition
+        - condition
+        - nursery
+        - trivial
+        - confuse
+        - design
+        - corn
+        - bless
+        - ambiguous
+        - diagram
+        - ample
+        - provision
+        - judge
+        - strict
+        - perception
+        - widen
+        - plain
+        - strap
+        - fruit
+        - distant
+        - arena
+        - twilight
+        - hope
+        - turkey
+        - deport
+        - brown
+        - agree
+        - exaggerate
+        - onion
+        - stuff
+        - hypothesis
+        - whole
+        - relationship
+        - linger
+        - corpse
+        - cutting
+        - dynamic
+        - thirsty
+        - authority
+        - award
+        - introduction
+        - seller
+        - push
+        - smile
+        - marine
+        - academy
+        - polish
+        - vegetarian
+        - drill
+        - miscarriage
+        - laser
+        - satisfaction
+        - copy
+        - angel
+        - rung
+        - glow
+        - publish
+        - figure
+        - scale
+        - story
+        - compete
+        - galaxy
+        - book
+        - conglomerate
+        - kidnap
+        - theorist
+        - cruelty
+        - inspiration
+        - doctor
+        - freckle
+        - transfer
+        - dictate
+        - thank
+        - midnight
+        - defend
+        - strikebreaker
+        - offensive
+        - wear
+        - minister
+        - curriculum
+        - capital
+        - patience
+        - notebook
+        - message
+        - horizon
       user_agent:
         aol:
           - Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7; AOLBuild 4343.19; Windows NT 6.1; WOW64; Trident/5.0; FunWebProducts)

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -5,6 +5,11 @@ require_relative '../../test_helper'
 class TestFakerInternet < Test::Unit::TestCase
   def setup
     @tester = Faker::Internet
+    @default_locale = Faker::Config.locale
+  end
+
+  def teardown
+    Faker::Config.locale = @default_locale
   end
 
   def test_email
@@ -288,8 +293,18 @@ class TestFakerInternet < Test::Unit::TestCase
     end
   end
 
-  def test_slug
-    assert @tester.slug.match(/^[a-z]+(_|-)[a-z]+$/)
+  I18n.config.available_locales.each do |locale|
+    define_method("test_#{locale}_slug") do
+      Faker::Config.locale = locale
+
+      assert @tester.slug.match(/^[a-z]+(_|-)[a-z]+$/)
+    end
+
+    define_method("test_#{locale}_slug_with_glue_arg") do
+      Faker::Config.locale = locale
+
+      assert @tester.slug(words: nil, glue: '+').match(/^[a-z]+\+[a-z]+$/)
+    end
   end
 
   def test_slug_with_content_arg
@@ -298,10 +313,6 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_slug_with_unwanted_content_arg
     assert @tester.slug(words: 'Foo.. bAr., baZ,,').match(/^foo(_|\.|-)bar(_|\.|-)baz$/)
-  end
-
-  def test_slug_with_glue_arg
-    assert @tester.slug(words: nil, glue: '+').match(/^[a-z]+\+[a-z]+$/)
   end
 
   def test_url


### PR DESCRIPTION
https://github.com/faker-ruby/faker/issues/2368

Description:

The slug method may return non-ASCII characters for some languages, because internally it calls `Faker::Lorem`. The problem is that non-ASCII characters are not valid in the URL. 
The purpose of this PR is to create a URL-friendly slug library. Initially we created only for English, but we can extend to other languages as long as they are URL-friendly.