### PR TITLE
LV locale - cell phone numbers should be 8 symbols

### DIFF
--- a/lib/locales/lv.yml
+++ b/lib/locales/lv.yml
@@ -52,4 +52,4 @@ lv:
     phone_number:
       formats: ["5# ### ###", "6# ### ###", "7# ### ###"]
     cell_phone:
-      formats: ["2## ### ###"]
+      formats: ["2# ### ###"]


### PR DESCRIPTION
`No-Story`

Description:
------
Update LV locale cell phone format mask, so that generated numbers are 8 symbols instead of 9. All phone numbers, except emergency services, are currently 8 symbols long in Latvia.

Note: wiki states that the mask should be `2xx xx xxx`, but in practice there are no strict formatting rules - no spaces, a space after every two symbols, and some combination of 3 + 3 + 2 symbol blocks are about equally common. This way the formatting is consistent with landlines, and least amount of change gets introduced to fix the issue.