### PR TITLE
Ignore Regex comments

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -80,6 +80,7 @@ module Faker
       def regexify(reg)
         reg = reg.source if reg.respond_to?(:source) # Handle either a Regexp or a String that looks like a Regexp
         reg
+          .gsub(/((#\s).*$)/, '') # Remove Regexp comments
           .gsub(%r{^/?\^?}, '').gsub(%r{\$?/?$}, '') # Ditch the anchors
           .gsub(/\{(\d+)\}/, '{\1,\1}').gsub(/\?/, '{0,1}') # All {2} become {2,2} and ? become {0,1}
           .gsub(/(\[[^\]]+\])\{(\d+),(\d+)\}/) { |_match| Regexp.last_match(1) * sample(Array(Range.new(Regexp.last_match(2).to_i, Regexp.last_match(3).to_i))) }                # [12]{1,2} becomes [12] or [12][12]

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -26,7 +26,8 @@ class TestFaker < Test::Unit::TestCase
   def test_regexify
     {
       'uk post code' => /^([A-PR-UWYZ0-9][A-HK-Y0-9][AEHMNPRTVXY0-9]?[ABEHMNPRVWXY0-9]? {1,2}[0-9][ABD-HJLN-UW-Z]{2}|GIR 0AA)$/,
-      'us phone' => /^(1-?)[2-8][0-1][0-9]-\d{3}-\d{4}$/
+      'us phone' => /^(1-?)[2-8][0-1][0-9]-\d{3}-\d{4}$/,
+      '8NE # this comment should be ignored' => /[A-Za-z0-9]{3}/
     }.each do |label, re|
       10.times do
         assert re.match(result = Faker::Base.regexify(re)), "#{result} is not a match for #{label}"


### PR DESCRIPTION
Issue #2390
------

https://github.com/faker-ruby/faker/issues/2390

This improves `regexify` method by ignoring Regexp comments