### PR TITLE
Add sports to `Faker::Sport`

### DIFF
--- a/lib/faker/sports/sport.rb
+++ b/lib/faker/sports/sport.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Faker
+  class Sport < Base
+    class << self
+      ##
+      # Produces the name of a sport from any category.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.sport #=> "Football"
+      #
+      # @faker.version next
+      def sport
+        'Football'
+      end
+
+      ##
+      # Produces a sport from the summer olympics.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.summer_olympics_sport #=> "Archery"
+      #
+      # @faker.version next
+      def summer_olympics_sport
+        'Archery'
+      end
+
+      ##
+      # Produces a sport from the winter olympics.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.winter_olympics_sport #=> "Bobsleigh"
+      #
+      # @faker.version next
+      def winter_olympics_sport
+        'Bobsleigh'
+      end
+
+      ##
+      # Produces a sport from the summer paralympics.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.summer_paralympics_sport #=> "Wheelchair Basketball"
+      #
+      # @faker.version next
+      def summer_paralympics_sport
+        'Wheelchair Basketball'
+      end
+
+      ##
+      # Produces a sport from the winter paralympics.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.winter_paralympics_sport #=> "Para Ice Hockey"
+      #
+      # @faker.version next
+      def winter_paralympics_sport
+        'Para Ice Hockey'
+      end
+
+      ##
+      # Produces an unusual sport.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.unusual_sport #=> "Camel Jumping"
+      #
+      # @faker.version next
+      def unusual_sport
+        'Camel Jumping'
+      end
+
+      ##
+      # Produces a sport from the modern olympics or paralympics, summer or winter.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.modern_olympics_sport #=> "Skeleton"
+      #
+      # @faker.version next
+      def modern_olympics_sport
+        'Skeleton'
+      end
+
+      ##
+      # Produces a sport from the ancient olympics.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Sports.ancient_olympics_sport #=> "Pankration"
+      #
+      # @faker.version next
+      def ancient_olympics_sport
+        'Pankration'
+      end
+    end
+  end
+end

--- a/lib/faker/sports/sport.rb
+++ b/lib/faker/sports/sport.rb
@@ -13,7 +13,7 @@ module Faker
       #
       # @faker.version next
       def sport
-        'Football'
+        sample(fetch_all('sport.summer_olympics') + fetch_all('sport.winter_olympics') + fetch_all('sport.summer_paralympics') + fetch_all('sport.winter_paralympics') + fetch_all('sport.ancient_olympics') + fetch_all('sport.unusual'))
       end
 
       ##
@@ -26,7 +26,7 @@ module Faker
       #
       # @faker.version next
       def summer_olympics_sport
-        'Archery'
+        fetch('sport.summer_olympics')
       end
 
       ##
@@ -39,7 +39,7 @@ module Faker
       #
       # @faker.version next
       def winter_olympics_sport
-        'Bobsleigh'
+        fetch('sport.winter_olympics')
       end
 
       ##
@@ -52,7 +52,7 @@ module Faker
       #
       # @faker.version next
       def summer_paralympics_sport
-        'Wheelchair Basketball'
+        fetch('sport.summer_paralympics')
       end
 
       ##
@@ -65,7 +65,7 @@ module Faker
       #
       # @faker.version next
       def winter_paralympics_sport
-        'Para Ice Hockey'
+        fetch('sport.winter_paralympics')
       end
 
       ##
@@ -78,7 +78,7 @@ module Faker
       #
       # @faker.version next
       def unusual_sport
-        'Camel Jumping'
+        fetch('sport.unusual')
       end
 
       ##
@@ -91,7 +91,7 @@ module Faker
       #
       # @faker.version next
       def modern_olympics_sport
-        'Skeleton'
+        sample(fetch_all('sport.summer_olympics') + fetch_all('sport.winter_olympics') + fetch_all('sport.summer_paralympics') + fetch_all('sport.winter_paralympics'))
       end
 
       ##
@@ -104,7 +104,7 @@ module Faker
       #
       # @faker.version next
       def ancient_olympics_sport
-        'Pankration'
+        fetch('sport.ancient_olympics')
       end
     end
   end

--- a/lib/faker/sports/sport.rb
+++ b/lib/faker/sports/sport.rb
@@ -12,13 +12,13 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Sports.sport #=> "Football"
+      #   Faker::Sport.sport #=> "Football"
       # @example
-      #   Faker::Sports.sport(include_ancient: true) #=> "Chariot racing"
+      #   Faker::Sport.sport(include_ancient: true) #=> "Chariot racing"
       # @example
-      #   Faker::Sports.sport(include_unsual: true) #=> "Flugtag/Birdman"
+      #   Faker::Sport.sport(include_unsual: true) #=> "Flugtag/Birdman"
       # @example
-      #   Faker::Sports.sport(include_ancient:true, include_unusual: true) #=> "Water polo"
+      #   Faker::Sport.sport(include_ancient:true, include_unusual: true) #=> "Water polo"
       #
       # @faker.version next
       def sport(include_ancient: false, include_unusual: false)
@@ -34,7 +34,7 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Sports.summer_olympics_sport #=> "Archery"
+      #   Faker::Sport.summer_olympics_sport #=> "Archery"
       #
       # @faker.version next
       def summer_olympics_sport
@@ -47,7 +47,7 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Sports.winter_olympics_sport #=> "Bobsleigh"
+      #   Faker::Sport.winter_olympics_sport #=> "Bobsleigh"
       #
       # @faker.version next
       def winter_olympics_sport
@@ -60,7 +60,7 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Sports.summer_paralympics_sport #=> "Wheelchair Basketball"
+      #   Faker::Sport.summer_paralympics_sport #=> "Wheelchair Basketball"
       #
       # @faker.version next
       def summer_paralympics_sport
@@ -73,7 +73,7 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Sports.winter_paralympics_sport #=> "Para Ice Hockey"
+      #   Faker::Sport.winter_paralympics_sport #=> "Para Ice Hockey"
       #
       # @faker.version next
       def winter_paralympics_sport
@@ -86,7 +86,7 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Sports.unusual_sport #=> "Camel Jumping"
+      #   Faker::Sport.unusual_sport #=> "Camel Jumping"
       #
       # @faker.version next
       def unusual_sport
@@ -99,7 +99,7 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Sports.ancient_olympics_sport #=> "Pankration"
+      #   Faker::Sport.ancient_olympics_sport #=> "Pankration"
       #
       # @faker.version next
       def ancient_olympics_sport

--- a/lib/faker/sports/sport.rb
+++ b/lib/faker/sports/sport.rb
@@ -4,16 +4,28 @@ module Faker
   class Sport < Base
     class << self
       ##
-      # Produces the name of a sport from any category.
+      # Produces a sport from the modern olympics or paralympics, summer or winter.
+      #
+      # @param include_ancient [Boolean] If true, may produce a sport from the ancient olympics
+      # @param include_unusual [Boolean] If true, may produce an unusual (definitely not olympic) sport
       #
       # @return [String]
       #
       # @example
       #   Faker::Sports.sport #=> "Football"
+      # @example
+      #   Faker::Sports.sport(include_ancient: true) #=> "Chariot racing"
+      # @example
+      #   Faker::Sports.sport(include_unsual: true) #=> "Flugtag/Birdman"
+      # @example
+      #   Faker::Sports.sport(include_ancient:true, include_unusual: true) #=> "Water polo"
       #
       # @faker.version next
-      def sport
-        sample(fetch_all('sport.summer_olympics') + fetch_all('sport.winter_olympics') + fetch_all('sport.summer_paralympics') + fetch_all('sport.winter_paralympics') + fetch_all('sport.ancient_olympics') + fetch_all('sport.unusual'))
+      def sport(include_ancient: false, include_unusual: false)
+        sports = fetch_all('sport.summer_olympics') + fetch_all('sport.winter_olympics') + fetch_all('sport.summer_paralympics') + fetch_all('sport.winter_paralympics')
+        sports << fetch_all('sport.ancient_olympics') if include_ancient
+        sports << fetch_all('sport.unusual') if include_unusual
+        sample(sports)
       end
 
       ##
@@ -79,19 +91,6 @@ module Faker
       # @faker.version next
       def unusual_sport
         fetch('sport.unusual')
-      end
-
-      ##
-      # Produces a sport from the modern olympics or paralympics, summer or winter.
-      #
-      # @return [String]
-      #
-      # @example
-      #   Faker::Sports.modern_olympics_sport #=> "Skeleton"
-      #
-      # @faker.version next
-      def modern_olympics_sport
-        sample(fetch_all('sport.summer_olympics') + fetch_all('sport.winter_olympics') + fetch_all('sport.summer_paralympics') + fetch_all('sport.winter_paralympics'))
       end
 
       ##

--- a/lib/locales/en/sport.yml
+++ b/lib/locales/en/sport.yml
@@ -1,0 +1,27 @@
+en:
+  faker:
+    sport:
+      summer_olympics: # Source https://olympics.com/en/sports/summer-olympics
+        - 3x3 basketball
+        - Archery
+        - Artistic gymnastics
+      winter_olympics: # Source https://olympics.com/en/sports/winter-olympics
+        - Alpine skiing
+        - Biathlon
+        - Bobsleigh
+      summer_paralympics: # Source https://www.paralympic.org/sports
+        - Archery
+        - Athletics
+        - Badminton
+      winter_paralympics: # Source https://www.paralympic.org/sports
+        - Alpine skiing
+        - Biathlon
+        - Cross-country skiing
+      ancient_olympics: # Source https://olympics.com/ioc/ancient-olympic-games/the-sports-events
+        - Boxing
+        - Chariot racing
+        - Discus
+      unusual:
+        - Apple Racing
+        - Ban'ei
+        - Bathtubbing

--- a/lib/locales/en/sport.yml
+++ b/lib/locales/en/sport.yml
@@ -5,23 +5,117 @@ en:
         - 3x3 basketball
         - Archery
         - Artistic gymnastics
+        - Artistic swimming
+        - Athletics
+        - Badminton
+        - Baseball # Technically part of "Baseball Softball" according to IOC website
+        - Basketball
+        - Beach volleyball
+        - BMX freestyle
+        - BMX racing
+        - Boxing
+        - Canoe/kayak flatwater
+        - Canoe/kayak slalom
+        - Diving
+        - Equestrian
+        - Fencing
+        - Football
+        - Golf
+        - Handball
+        - Hockey
+        - Judo
+        - Karate
+        - Marathon swimming
+        - Modern pentathlon
+        - Mountain bike
+        - Rhythmic gymnastics
+        - Road cycling
+        - Rowing
+        - Rugby
+        - Sailing
+        - Shooting
+        - Skateboarding
+        - Softball # Technically part of "Baseball Softball" according to IOC website
+        - Sport climbing
+        - Surfing
+        - Swimming
+        - Table tennis
+        - Taekwondo
+        - Tennis
+        - Track cycling
+        - Trampoline
+        - Triathlon
+        - Volleyball
+        - Water polo
+        - Weight lifting
+        - Wrestling
       winter_olympics: # Source https://olympics.com/en/sports/winter-olympics
         - Alpine skiing
         - Biathlon
         - Bobsleigh
+        - Cross-country
+        - Curling
+        - Figure skating
+        - Freestyle skiing
+        - Ice hockey
+        - Luge
+        - Nordic combined
+        - Short track speed skating
+        - Skeleton
+        - Ski jumping
+        - Snowboard
+        - Speed skating
       summer_paralympics: # Source https://www.paralympic.org/sports
         - Archery
         - Athletics
         - Badminton
+        - Boccia
+        - Canoe
+        - Cycling
+        - Equestrian
+        - Football (5-a-side)
+        - Goalball
+        - Judo
+        - Powerlifting
+        - Rowing
+        - Shooting
+        - Sitting volleyball
+        - Swimming
+        - Table tennis
+        - Taekwondo
+        - Triathlon
+        - Wheelchair basketball
+        - Wheelchair fencing
+        - Wheelchair rugby
+        - Wheelchair tennis
       winter_paralympics: # Source https://www.paralympic.org/sports
         - Alpine skiing
         - Biathlon
         - Cross-country skiing
+        - Para ice hockey
+        - Snowboard
+        - Wheelchair curling
       ancient_olympics: # Source https://olympics.com/ioc/ancient-olympic-games/the-sports-events
         - Boxing
         - Chariot racing
         - Discus
+        - Horse racing
+        - Long jump
+        - Pankration
+        - Pentathlon
+        - Running
+        - Wrestling
       unusual:
         - Apple Racing
         - Ban'ei
         - Bathtubbing
+        - Bed racing
+        - Botaoshi
+        - Beer Can Regatta
+        - Black pudding throwing
+        - Bog snorkelling
+        - Bottle kicking
+        - Camel jumping
+        - Camel wrestling
+        - Flugtag/Birdman
+        - Kastenlauf (Beer crate running)

--- a/test/faker/sports/test_faker_sports.rb
+++ b/test/faker/sports/test_faker_sports.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerSports < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Sport
+  end
+
+  def test_sport
+    assert @tester.sport.match(/\w+/)
+  end
+
+  def test_summer_olympics
+    assert @tester.summer_olympics_sport.match(/\w+/)
+  end
+
+  def test_winter_olympics
+    assert @tester.winter_olympics_sport.match(/\w+/)
+  end
+
+  def test_summer_paralympics
+    assert @tester.summer_paralympics_sport.match(/\w+/)
+  end
+
+  def test_winter_paralympics
+    assert @tester.winter_paralympics_sport.match(/\w+/)
+  end
+
+  def test_unusual_sports
+    assert @tester.unusual_sport.match(/\w+/)
+  end
+
+  def test_modern_olympics
+    assert @tester.modern_olympics_sport.match(/\w+/)
+  end
+
+  def test_ancient_olympics
+    assert @tester.ancient_olympics_sport.match(/\w+/)
+  end
+end

--- a/test/faker/sports/test_faker_sports.rb
+++ b/test/faker/sports/test_faker_sports.rb
@@ -11,6 +11,18 @@ class TestFakerSports < Test::Unit::TestCase
     assert @tester.sport.match(/\w+/)
   end
 
+  def test_sport_with_ancient_allowed
+    assert @tester.sport(include_ancient: true).match(/\w+/)
+  end
+
+  def test_sport_with_unusual_allowed
+    assert @tester.sport(include_unusual: true).match(/\w+/)
+  end
+
+  def test_sport_with_ancient_and_unusual_allowed
+    assert @tester.sport(include_ancient: true, include_unusual: true).match(/\w+/)
+  end
+
   def test_summer_olympics
     assert @tester.summer_olympics_sport.match(/\w+/)
   end
@@ -29,10 +41,6 @@ class TestFakerSports < Test::Unit::TestCase
 
   def test_unusual_sports
     assert @tester.unusual_sport.match(/\w+/)
-  end
-
-  def test_modern_olympics
-    assert @tester.modern_olympics_sport.match(/\w+/)
   end
 
   def test_ancient_olympics


### PR DESCRIPTION
`No-Story`

Description:
------
Add the ability to produce sports in Faker, useful for dummy data in apps to do with sports or co-curricular activities in schools (my use case).

To keep it globally applicable, it returns a modern Olympic sport (including Paralympics) by default. You can also fetch any of the sub categories individually (or optionally include them in the main method):
- Summer Olympics
- Summer Paralympics
- Winter Olympics
- Winter Paralympics
- Ancient Olympics
- Unusual sports (just for fun)

Possible issues/opportunities:
------
- Does this overlap with `Faker::Hobby`?
- Do I need to do commit any other files for documentation or does it get generated automatically from the YARD annotations I included?
- My tests seem a bit week/limited but they're consistent with many other tests. Is there an exemplar for how to do them well or is checking for one or more word characters the best we can do given the output is pseudorandom?
- Does it make sense to have the categories as separate methods or should there just be a `category:` argument on a single method? `Faker::Sport.winter_olympics_sport` or `Faker::Sport.sport(category: :winter_olympics)`
