### PR TITLE
Add Faker::Gender.short_type

### DIFF
--- a/doc/default/gender.md
+++ b/doc/default/gender.md
@@ -5,6 +5,8 @@ Available since version 1.9.0.
 ```ruby
 Faker::Gender.type #=> "Non-binary"
 
+Faker::Gender.short_type #=> "x"
+
 Faker::Gender.binary_type #=> "Female"
 
 Faker::Gender.short_binary_type #=> "f"

--- a/lib/faker/default/gender.rb
+++ b/lib/faker/default/gender.rb
@@ -17,6 +17,19 @@ module Faker
       end
 
       ##
+      # Produces a gender marker.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Gender.short_type #=> "x"
+      #
+      # @faker.version 1.9.0
+      def short_type
+        fetch('gender.short_types')
+      end
+
+      ##
       # Produces either 'Male' or 'Female'.
       #
       # @return [String]

--- a/lib/faker/default/gender.rb
+++ b/lib/faker/default/gender.rb
@@ -24,7 +24,7 @@ module Faker
       # @example
       #   Faker::Gender.short_type #=> "x"
       #
-      # @faker.version 1.9.0
+      # @faker.version next
       def short_type
         fetch('gender.short_types')
       end

--- a/lib/locales/en/gender.yml
+++ b/lib/locales/en/gender.yml
@@ -2,5 +2,6 @@ en:
   faker:
     gender:
       types: ["Female", "Male", "Non-binary", "Agender", "Genderfluid", "Genderqueer", "Bigender", "Polygender"]
+      short_types: ["f", "m", "x"]
       binary_types: ["Female", "Male"]
       short_binary_types: ["f", "m"]

--- a/test/faker/default/test_faker_gender.rb
+++ b/test/faker/default/test_faker_gender.rb
@@ -11,6 +11,10 @@ class TestFakerGender < Test::Unit::TestCase
     assert @tester.type.match(/\w+/)
   end
 
+  def test_short_type
+    assert @tester.short_type.match(/f|m|x/)
+  end
+
   def test_binary_type
     assert @tester.binary_type.match(/\w+/)
   end


### PR DESCRIPTION
`No-Story`

Description:
------

While building a database seeds generator, I noticed there wasn't a non-binary counterpoint of the existing `Faker::Gender.short_binary_type` for gender markers.

This PR introduces that option using the most common values (`f`, `m`, `x`) and should be able to fulfill similar use cases as the ones described in the [original PR](https://github.com/faker-ruby/faker/pull/1863).

Let me know if there's anything missing! I reviewed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/master/CONTRIBUTING.md) and I _think_ I followed them but let me know if I forgot something 🙏 . 

Have a great day!

