### PR TITLE
Deprecate Faker::Stripe.ccv method and replace it with Faker::Stripe.cvc

### DIFF
--- a/doc/default/stripe.md
+++ b/doc/default/stripe.md
@@ -20,8 +20,8 @@ Faker::Stripe.month #=> "10"
 Faker::Stripe.year #=> "2018" # This will always be a year in the future
 
 # Keyword arguments: card_type
-Faker::Stripe.ccv #=> "123"
-Faker::Stripe.ccv(card_type: "amex") #=> "1234"
+Faker::Stripe.cvc #=> "123"
+Faker::Stripe.cvc(card_type: "amex") #=> "1234"
 ```
 
 ProTip:

--- a/lib/faker/default/stripe.rb
+++ b/lib/faker/default/stripe.rb
@@ -138,27 +138,7 @@ module Faker
         (card_type.to_s == 'amex' ? rand_in_range(1000, 9999) : rand_in_range(100, 999)).to_s
       end
 
-      ##
-      # Produces a random cvc number.
-      #
-      # @param card_type [String] Specific valid card type.
-      # @return [String]
-      #
-      # @example
-      #   Faker::Stripe.cvc #=> "123"
-      #   Faker::Stripe.cvc(card_type: "amex") #=> "1234"
-      #
-      # @faker.version 1.9.0
-      def cvc(legacy_card_type = NOT_GIVEN, card_type: nil)
-        warn_for_deprecated_arguments do |keywords|
-          keywords << :card_type if legacy_card_type != NOT_GIVEN
-        end
-
-        (card_type.to_s == 'amex' ? rand_in_range(1000, 9999) : rand_in_range(100, 999)).to_s
-      end
-
-      extend Gem::Deprecate
-      deprecate :ccv, :cvc, 2021, 12
+      alias cvc ccv
     end
   end
 end

--- a/lib/faker/default/stripe.rb
+++ b/lib/faker/default/stripe.rb
@@ -137,6 +137,28 @@ module Faker
 
         (card_type.to_s == 'amex' ? rand_in_range(1000, 9999) : rand_in_range(100, 999)).to_s
       end
+
+      ##
+      # Produces a random cvc number.
+      #
+      # @param card_type [String] Specific valid card type.
+      # @return [String]
+      #
+      # @example
+      #   Faker::Stripe.cvc #=> "123"
+      #   Faker::Stripe.cvc(card_type: "amex") #=> "1234"
+      #
+      # @faker.version 1.9.0
+      def cvc(legacy_card_type = NOT_GIVEN, card_type: nil)
+        warn_for_deprecated_arguments do |keywords|
+          keywords << :card_type if legacy_card_type != NOT_GIVEN
+        end
+
+        (card_type.to_s == 'amex' ? rand_in_range(1000, 9999) : rand_in_range(100, 999)).to_s
+      end
+
+      extend Gem::Deprecate
+      deprecate :ccv, :cvc, 2021, 12
     end
   end
 end

--- a/test/faker/default/test_faker_stripe.rb
+++ b/test/faker/default/test_faker_stripe.rb
@@ -55,6 +55,14 @@ class TestFakerStripe < Test::Unit::TestCase
     assert @tester.year.match(/\A\d{4}\z/)
   end
 
+  def test_valid_ccv
+    assert @tester.ccv.match(/\A\d{3}\z/)
+  end
+
+  def test_valid_amex_ccv
+    assert @tester.ccv(card_type: 'amex').match(/\A\d{4}\z/)
+  end
+
   def test_valid_cvc
     assert @tester.cvc.match(/\A\d{3}\z/)
   end

--- a/test/faker/default/test_faker_stripe.rb
+++ b/test/faker/default/test_faker_stripe.rb
@@ -55,11 +55,11 @@ class TestFakerStripe < Test::Unit::TestCase
     assert @tester.year.match(/\A\d{4}\z/)
   end
 
-  def test_valid_ccv
-    assert @tester.ccv.match(/\A\d{3}\z/)
+  def test_valid_cvc
+    assert @tester.cvc.match(/\A\d{3}\z/)
   end
 
-  def test_valid_amex_ccv
-    assert @tester.ccv(card_type: 'amex').match(/\A\d{4}\z/)
+  def test_valid_amex_cvc
+    assert @tester.cvc(card_type: 'amex').match(/\A\d{4}\z/)
   end
 end


### PR DESCRIPTION
Issue#
------

https://github.com/faker-ruby/faker/issues/2399

Description:
------
*Deprecated `Faker::Stripe.ccv` method and added `Faker::Stripe.cvc` and also updated test cases*
