### PR TITLE
Add mock data for Auth0 OAuth

### DIFF
--- a/doc/default/omniauth.md
+++ b/doc/default/omniauth.md
@@ -290,4 +290,35 @@ Faker::Omniauth.apple #=>
     }
   }
 }
+
+Faker::Omniauth.auth0 #=>
+{
+  :provider => "auth0",
+  :uid => "auth0|d0584e3ab2d3816be9518a56",
+  :info=> {
+    :name => "auth0|d0584e3ab2d3816be9518a56",
+    :nickname => "Thurman DuBuque",
+    :email => "dubuque_thurman@example.com",
+    :image => "https://via.placeholder.com/300x300.png"
+  },
+  :credentials=> {
+    :expires_at => 1654345109,
+    :expires => true,
+    :token_type => "Bearer",
+    :id_token=> "fcc25a5b606dbf3211b792b634cf92f3857da4cce725a019b2c492c4845fd63f",
+    :token => "8e668c5b994f3bfc38e3067e6ed960c5",
+    :refresh_token => "19f82075f7c69133452614bd177f4380"
+  },
+  :extra=> {
+    :raw_info=> {
+      :email => "dubuque_thurman@example.com",
+      :email_verified => true,
+      :iss => "https://auth0.com/",
+      :sub => "auth0|d0584e3ab2d3816be9518a56",
+      :aud => "Auth012345",
+      :iat => 1663896480,
+      :exp => 1640375502
+    }
+  }
+}
 ```

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -431,6 +431,50 @@ module Faker
         }
       end
 
+      ##
+      # Generate a mock Omniauth response from Auth0.
+      #
+      # @param name [String] A specific name to return in the response.
+      # @param email [String] A specific email to return in the response.
+      # @param uid [String] A specific UID to return in the response.
+      #
+      # @return [Hash] An auth hash in the format provided by omniauth-auth0.
+      #
+      # @faker.version next
+      def auth0(name: nil, email: nil, uid: nil)
+        uid ||= "auth0|#{Number.hexadecimal(digits: 24)}"
+        auth = Omniauth.new(name: name, email: email)
+        {
+          provider: 'auth0',
+          uid: uid,
+          info: {
+            name: uid,
+            nickname: auth.name,
+            email: auth.email,
+            image: image
+          },
+          credentials: {
+            expires_at: Time.forward.to_i,
+            expires: true,
+            token_type: 'Bearer',
+            id_token: Crypto.sha256,
+            token: Crypto.md5,
+            refresh_token: Crypto.md5
+          },
+          extra: {
+            raw_info: {
+              email: auth.email,
+              email_verified: true,
+              iss: 'https://auth0.com/',
+              sub: uid,
+              aud: 'Auth012345',
+              iat: Time.forward.to_i,
+              exp: Time.forward.to_i
+            }
+          }
+        }
+      end
+
       private
 
       def gender

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -500,6 +500,40 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert raw_info[:email_verified]
   end
 
+  def test_omniauth_auth0
+    auth            = @tester.auth0
+    info            = auth[:info]
+    credentials     = auth[:credentials]
+    extra           = auth[:extra]
+    raw_info        = extra[:raw_info]
+    nick_name       = info[:nickname].downcase
+    first_name      = nick_name.split(' ').first
+    last_name       = nick_name.split(' ').last
+
+    assert_equal 'auth0', auth[:provider]
+    assert_instance_of String, auth[:uid]
+    assert_equal 30, auth[:uid].length
+    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert_equal auth[:uid], info[:name]
+    assert_instance_of String, info[:image]
+    assert_instance_of String, info[:nickname]
+    assert_instance_of String, info[:name]
+    assert_equal auth[:uid], info[:name]
+    assert_equal true, credentials[:expires]
+    assert_instance_of String, credentials[:token]
+    assert_instance_of String, credentials[:token_type]
+    assert_instance_of String, credentials[:id_token]
+    assert_instance_of String, credentials[:refresh_token]
+    assert_instance_of Integer, credentials[:expires_at]
+    assert_instance_of Integer, raw_info[:exp]
+    assert_instance_of Integer, raw_info[:iat]
+    assert_equal 'https://auth0.com/', raw_info[:iss]
+    assert_instance_of String, raw_info[:aud]
+    assert_equal auth[:uid], raw_info[:sub]
+    assert_equal info[:email], raw_info[:email]
+    assert raw_info[:email_verified]
+  end
+
   def word_count(string)
     string.split(' ').length
   end


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------

Hi, great developers.
I've added a mock for Auth0 OAuth, Faker::Omniauth.auth0. This supports testing the omniauth-auth0 gem.
It's based on PR #1738.

Thanks.
