### PR TITLE
Require Ruby I18n 1.8.11 or higher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     faker (2.19.0)
-      i18n (>= 1.6, < 2)
+      i18n (>= 1.8.11, < 2)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     docile (1.3.2)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
     method_source (1.0.0)

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |spec|
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/github/faker-ruby/faker/master'
   spec.metadata['yard.run'] = 'yri'
 
-  spec.add_dependency('i18n', '>= 1.6', '< 2')
+  # Requires Ruby I18n 1.8.11 or higher to resolve https://github.com/faker-ruby/faker/issues/2330.
+  spec.add_dependency('i18n', '>= 1.8.11', '< 2')
 
   spec.add_development_dependency('minitest', '5.14.4')
   spec.add_development_dependency('pry', '0.14.1')


### PR DESCRIPTION
Resolves https://github.com/faker-ruby/faker/issues/2330.

This PR makes Faker require Ruby I18n 1.8.11 or higher to resolve https://github.com/faker-ruby/faker/issues/2330.
