### PR TITLE
Add Faker::Date.weekday_between

### DIFF
--- a/doc/default/date.md
+++ b/doc/default/date.md
@@ -36,4 +36,9 @@ Faker::Date.in_date_period(year: 2018, month: 2) #=> #<Date: 2018-02-26>
 # Keyword arguments: month
 Faker::Date.in_date_period(month: 2) #=> #<Date: 2019-02-26>
 
+# Random weekday within the specified range
+# Keyword arguments: from ,to
+Faker::Date.weekday_between(from: '2021-01-02', to: '2021-01-04') #=> #<Date: 2021-01-04>
+# If used with Rails (the Active Support gem), additional options are available:
+Faker::Date.weekday_between(from: 1.day.from_now, to: 1.year.from_now) #=> #<Date: 2020-11-03>
 ```

--- a/lib/faker/default/date.rb
+++ b/lib/faker/default/date.rb
@@ -161,7 +161,43 @@ module Faker
         between(from: from, to: to).to_date
       end
 
+      ##
+      # Produces a random weekday within the specified date range.
+      #
+      # @param from [Date, String] The start of the usable date range.
+      # @param to [Date, String] The end of the usable date range.
+      # @return [Date]
+      #
+      # @example if used with or without Rails (Active Support)
+      #   Faker::Date.weekday_between(from: '2021-01-02', to: '2021-01-04') #=> #<Date: 2021-01-04>
+      #
+      # @example if used with Rails (Active Support)
+      #   Faker::Date.weekday_between(from: 1.day.from_now, to: 1.year.from_now) #=> #<Date: 2020-11-03>
+      #
+      # @faker.version next
+      def weekday_between(from:, to:)
+        from = get_date_object(from)
+        to   = get_date_object(to)
+
+        raise ArgumentError, 'Date range must contain at least one weekday' unless contains_weekday?(from, to)
+
+        loop do
+          candidate_date = Faker::Base.rand_in_range(from, to)
+
+          break candidate_date if weekday?(candidate_date)
+        end
+      end
+
       private
+
+      def weekday?(day)
+        (1..5).cover?(day.wday)
+      end
+
+      def contains_weekday?(from, to)
+        from, to = to, from if to < from
+        (from..to).any? { |day| weekday?(day) }
+      end
 
       def birthday_date(date, age)
         year = date.year - age

--- a/test/faker/default/test_faker_date.rb
+++ b/test/faker/default/test_faker_date.rb
@@ -180,4 +180,33 @@ class TestFakerDate < Test::Unit::TestCase
       assert date.year == year
     end
   end
+
+  def test_weekday_between
+    from = Date.parse('2012-01-01')
+    to   = Date.parse('2013-01-01')
+
+    100.times do
+      date = @tester.weekday_between(from: from, to: to)
+      assert (1..5).cover? date.wday
+    end
+  end
+
+  def test_weekday_between_with_range_containing_no_weekdays
+    from = Date.parse('2021-01-02')
+    to   = Date.parse('2021-01-03')
+
+    assert_raise ArgumentError do
+      @tester.weekday_between(from: from, to: to)
+    end
+  end
+
+  def test_weekday_between_with_reversed_range
+    from = Date.parse('2001-01-01')
+    to   = Date.parse('1999-01-01')
+
+    25.times do
+      date = @tester.weekday_between(from: from, to: to)
+      assert (1..5).cover? date.wday
+    end
+  end
 end


### PR DESCRIPTION
Issue#
------

`No-Story`

(It partially relates to https://github.com/faker-ruby/faker/issues/1245 but is not intended to satisfy that request)

Description:
------

This PR adds `Faker::Date.weekday_between` to produce a weekday within the specified range. This is especially useful for applications that send out many notifications. The method uses the same keyword args as `.between`.