### PR TITLE
Add mock data for Keycloak OAuth

### DIFF
--- a/doc/default/omniauth.md
+++ b/doc/default/omniauth.md
@@ -321,4 +321,63 @@ Faker::Omniauth.auth0 #=>
     }
   }
 }
+
+Faker::Omniauth.keycloak #=>
+{
+  :provider => "keycloakopenid",
+  :uid => "b8b447aa-c1c6-86b4-c53d-b6032c30bc1b",
+  :info => {
+    :name => "Malcom Kuphal",
+    :email => "kuphal_malcom@example.net",
+    :first_name => "Malcom",
+    :last_name => "Kuphal"
+  },
+  :credentials => {
+    :expires_at => 1639923870,
+    :expires => true,
+    :token => "cf0ce5029fd8fadfd2b101775e3abe21",
+    :refresh_token => "54f93d469d45abf2b6f91e6526373914"
+  },
+  :extra => {
+    :raw_info => {
+      :email => "kuphal_malcom@example.net",
+      :email_verified => true,
+      :iss => "https://example.com/auth/realms/test_realms",
+      :sub => "b8b447aa-c1c6-86b4-c53d-b6032c30bc1b",
+      :aud => "account",
+      :iat => 1647719660,
+      :exp => 1643763126,
+      :auth_time => 1668119892,
+      :typ => "Bearer",
+      :azp => "keycloakapp",
+      :jti => "d2a105c8-248d-d86d-3a11-30d3bda55648",
+      :session_state => "ac8e6c51-0161-276b-aada-8b360aa16e15",
+      :acr => "0",
+      :"allowed-origins" => [
+          "/*"
+      ],
+      :realm_access => {
+        :roles => [
+          "offline_access",
+          "uma_authorization"
+        ]
+      },
+      :resource_access => {
+        :account => {
+          :roles => [
+            "manage-account",
+            "manage-account-links",
+            "view-profile"
+          ]
+        }
+      },
+      :scope => "openid profile email",
+      :sid => "ac8e6c51-0161-276b-aada-8b360aa16e15",
+      :name => "Malcom Kuphal",
+      :preferred_username => "Malcom Kuphal",
+      :given_name => "Kuphal",
+      :family_name => "Malcom"
+    }
+  }
+}
 ```

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -534,6 +534,51 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert raw_info[:email_verified]
   end
 
+  def test_omniauth_keycloak
+    auth            = @tester.keycloak
+    info            = auth[:info]
+    credentials     = auth[:credentials]
+    extra           = auth[:extra]
+    raw_info        = extra[:raw_info]
+    first_name      = info[:first_name].downcase
+    last_name       = info[:last_name].downcase
+
+    assert_equal 'keycloakopenid', auth[:provider]
+    assert_instance_of String, auth[:uid]
+    assert_equal 36, auth[:uid].length
+    assert info[:email].match safe_email_regex(first_name, last_name)
+    assert_instance_of String, info[:first_name]
+    assert_instance_of String, info[:last_name]
+    assert_instance_of String, info[:name]
+    assert_equal true, credentials[:expires]
+    assert_instance_of String, credentials[:token]
+    assert_instance_of String, credentials[:refresh_token]
+    assert_instance_of Integer, credentials[:expires_at]
+    assert_instance_of Integer, raw_info[:exp]
+    assert_instance_of Integer, raw_info[:iat]
+    assert_instance_of Integer, raw_info[:auth_time]
+    assert_equal 'https://example.com/auth/realms/test_realms', raw_info[:iss]
+    assert_instance_of String, raw_info[:aud]
+    assert_instance_of String, raw_info[:typ]
+    assert_instance_of String, raw_info[:azp]
+    assert_instance_of String, raw_info[:jti]
+    assert_instance_of String, raw_info[:acr]
+    assert_instance_of String, raw_info[:scope]
+    assert_instance_of String, raw_info[:session_state]
+    assert_instance_of String, raw_info[:sid]
+    assert_equal raw_info[:sid], raw_info[:session_state]
+    assert_equal auth[:uid], raw_info[:sub]
+    assert_equal info[:email], raw_info[:email]
+    assert_equal info[:name], raw_info[:name]
+    assert_equal info[:name], raw_info[:preferred_username]
+    assert_equal info[:first_name], raw_info[:family_name]
+    assert_equal info[:last_name], raw_info[:given_name]
+    assert raw_info[:email_verified]
+    assert_instance_of Array, raw_info['allowed-origins'.to_sym]
+    assert_instance_of Hash, raw_info[:realm_access]
+    assert_instance_of Hash, raw_info[:resource_access]
+  end
+
   def word_count(string)
     string.split(' ').length
   end


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------
I've added a mock for Keycloak OAuth, Faker::Omniauth.keycloak. This supports testing the omniauth-keycloak gem.
It's based on PR #2411.

Thanks.