### PR TITLE
Fix Faker::Omniauth.google locale

### DIFF
--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -65,7 +65,7 @@ module Faker
               picture: image,
               gender: gender,
               birthday: Date.backward(days: 36_400).strftime('%Y-%m-%d'),
-              local: 'en',
+              locale: 'en',
               hd: "#{Company.name.downcase}.com"
             },
             id_info: {

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -37,7 +37,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, extra_raw_info[:picture]
     assert gender?(extra_raw_info[:gender])
     assert_instance_of String, extra_raw_info[:birthday]
-    assert_equal 'en', extra_raw_info[:local]
+    assert_equal 'en', extra_raw_info[:locale]
     assert_instance_of String, extra_raw_info[:hd]
     assert_equal 'accounts.google.com', id_info[:iss]
     assert_instance_of String, id_info[:at_hash]


### PR DESCRIPTION
Issue#
------
`No-Story`

Description:
------
I found `Faker::Omniauth.google`'s `local` key in raw_info is actually `locale`. I've replace them.

Thanks.


