### PR TITLE
Change OHG to OG

### DIFF
--- a/lib/locales/de-AT.yml
+++ b/lib/locales/de-AT.yml
@@ -19,8 +19,8 @@ de-AT:
       default_country: [Österreich]
 
     company:
-      suffix: [GmbH, AG, Gruppe, KG, GmbH & Co. KG, UG, OHG]
-      legal_form: [GmbH, AG, Gruppe, KG, GmbH & Co. KG, UG, OHG]
+      suffix: [GmbH, AG, Gruppe, KG, GmbH & Co. KG, UG, OG]
+      legal_form: [GmbH, AG, Gruppe, KG, GmbH & Co. KG, UG, OG]
       name:
         - "#{Name.last_name} #{suffix}"
         - "#{Name.last_name}-#{Name.last_name}"


### PR DESCRIPTION
Since 2007 "OHG" (Offene Handelsgesellschaft) is called "OG" (Offene Gesellschaft) in Austria