### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Description: This cop checks the length of lines in the source code. The maximum length is configurable.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,4 +67,4 @@ DEPENDENCIES
   yard (= 0.9.27)
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = ['faker']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/master/CHANGELOG.md'
   spec.metadata['source_code_uri'] = 'https://github.com/faker-ruby/faker'

--- a/lib/faker/default/bank.rb
+++ b/lib/faker/default/bank.rb
@@ -23,7 +23,7 @@ module Faker
 
         output = ''
 
-        output += rand.to_s[2..-1] while output.length < digits
+        output += rand.to_s[2..] while output.length < digits
 
         output[0...digits]
       end

--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -107,7 +107,7 @@ module Faker
 
         birthyear = Date.birthday(min_age: min_age, max_age: max_age).year
         prefix = birthyear < 2000 ? 'S' : 'T'
-        values = birthyear.to_s[-2..-1]
+        values = birthyear.to_s[-2..]
         values << regexify(/\d{5}/)
         check_alpha = generate_nric_check_alphabet(values, prefix)
         "#{prefix}#{values}#{check_alpha}"

--- a/lib/faker/religion/bible.rb
+++ b/lib/faker/religion/bible.rb
@@ -6,7 +6,6 @@ module Faker
       flexible :bible
 
       class << self
-
         ##
         ## Returns a random bible character
         ##
@@ -40,7 +39,7 @@ module Faker
         ##
         ## Returns a random quote from the location
         ##
-        ## @param 
+        ## @param
         ##
         ## @return [String]
         ##


### PR DESCRIPTION
Issue
------

`No-Story`

Description:
------

This PR drops the support for Ruby 2.5 as it arrived to EOL

Also fixes some rubocops complains appeared in the previous execution (unrelated to this PR):

![Screenshot 2021-12-21 at 19 43 05](https://user-images.githubusercontent.com/6084749/146982138-420666c4-ebe6-4985-9047-bcad258a61f0.png)
