### PR TITLE
Remove full-stop from some titles in en-GB locale

### DIFF
--- a/lib/locales/en-GB.yml
+++ b/lib/locales/en-GB.yml
@@ -8,6 +8,8 @@ en-GB:
       default_country: [England, Scotland, Wales, Northern Ireland]
     internet:
       domain_suffix: [co.uk, com, biz, info, name]
+    name:
+      prefix: [Mr, Mrs, Ms, Miss, Dr, Rev., Fr, Gov., Rep., Prof., Sen., The Hon., Pres., Msgr, Amb.]
     phone_number:
       formats: ['01#### #####', '01### ######', '01#1 ### ####', '011# ### ####', '02# #### ####', '03## ### ####', '055 #### ####', '056 #### ####', '0800 ### ####', '08## ### ####', '09## ### ####', '016977 ####', '01### #####', '0500 ######', '0800 ######']
     cell_phone:


### PR DESCRIPTION
This PR adds a `name/prefix` section for the `en-GB` local to allow for the UK convention of not including a full-stop (period) after contractions. See https://www.grammar-monster.com/lessons/abbreviations_contractions_full_stops_periods.htm

Before accepting this change it would be helpful to get the input from other British users. In particular, it might make sense for the list to include some different titles such as;

* Remove Gov., Rep., Sen., Pres. and Amb.
* Include 'The Rt Hon.' in addition to 'The Hon.'
* Include some noble and honorific titles; Lord, Lady, Sir, Dame, etc.