### PR TITLE
Fix quote including a colon

### DIFF
--- a/lib/locales/en/bible.yml
+++ b/lib/locales/en/bible.yml
@@ -80,7 +80,7 @@ en:
         - But seek first his kingdom and his righteousness, and all these things will be given to you as well.
         - In the same way, let your light shine before others, that they may see your good deeds and glorify your Father in heaven.
         - Ask and it will be given to you; seek and you will find; knock and the door will be opened to you. For everyone who asks receives; the one who seeks finds; and to the one who knocks, the door will be opened.
-        - Love the Lord your God with all your heart and with all your soul and with all your mind.This is the first and greatest commandment. And the second is like it: Love your neighbor as yourself. All the Law and the Prophets hang on these two commandments.
+        - 'Love the Lord your God with all your heart and with all your soul and with all your mind. This is the first and greatest commandment. And the second is like it: Love your neighbor as yourself. All the Law and the Prophets hang on these two commandments.'
         - Whatever you do, work at it with all your heart.
         - For when I am powerless, it is then that I am strong.
         - Love is patient, love is kind, and is not jealous; love does not brag and is not arrogant, does not act unbecomingly; it does not seek its own [will], is not provoked, does not take into account a wrong suffered, does not rejoice in unrighteousness, but rejoices with the truth; bears all things, believes all things, hopes all things, endures all things.


### PR DESCRIPTION
I noticed this bug when it caused an automated test to fail in [another PR I opened](https://github.com/faker-ruby/faker/pull/2439)

A quote in `lib/locales/en/bible.yml` contains a colon and in a YAML file this is interpreted as a key/value pair rather than a string. This can be fixed by quoting the string.