### PR TITLE
add Faker::JapaneseMedia::FmaBrotherhood

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'mast
   - [Faker::JapaneseMedia::Naruto](doc/japanese_media/naruto.md)
   - [Faker::JapaneseMedia::Doraemon](doc/japanese_media/doraemon.md)
   - [Faker::JapaneseMedia::Conan](doc/japanese_media/conan.md)
+  - [Faker::JapaneseMedia::FmaBrotherhood](doc/japanese_media/fullmetal_alchemist_brotherhood.md)
 
 ### Movies
   - [Faker::Movie](doc/movies/movie.md)

--- a/doc/japanese_media/fullmetal_alchemist_brotherhood.md
+++ b/doc/japanese_media/fullmetal_alchemist_brotherhood.md
@@ -1,0 +1,9 @@
+# Faker::JapaneseMedia::FmaBrotherhood
+
+```ruby
+Faker::JapaneseMedia::FmaBrotherhood.character #=> "Edward Elric"
+
+Faker::JapaneseMedia::FmaBrotherhood.city #=> "Central City"
+
+Faker::JapaneseMedia::fma_brotherhood.country #=> "Xing"
+```

--- a/lib/faker/japanese_media/fullmetal_alchemist_brotherhood.rb
+++ b/lib/faker/japanese_media/fullmetal_alchemist_brotherhood.rb
@@ -18,7 +18,7 @@ module Faker
         end
 
         ##
-        # Produces a village from Naruto.
+        # Produces a cities from FmaBrotherhood.
         #
         # @return [String]
         #
@@ -31,7 +31,7 @@ module Faker
         end
 
         ##
-        # Produces a eye from Naruto.
+        # Produces a country from FmaBrotherhood.
         #
         # @return [String]
         #

--- a/lib/faker/japanese_media/fullmetal_alchemist_brotherhood.rb
+++ b/lib/faker/japanese_media/fullmetal_alchemist_brotherhood.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Faker
+  class JapaneseMedia
+    class FmaBrotherhood < Base
+      class << self
+        ##
+        # Produces a character from FmaBrotherhood.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::FmaBrotherhood.character #=> "Edward Elric"
+        #
+        # @faker.version next
+        def character
+          fetch('fma_brotherhood.characters')
+        end
+
+        ##
+        # Produces a village from Naruto.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::FmaBrotherhood.city #=> "Central City"
+        #
+        # @faker.version next
+        def city
+          fetch('fma_brotherhood.cities')
+        end
+
+        ##
+        # Produces a eye from Naruto.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::JapaneseMedia::FmaBrotherhood.country #=> "Xing"
+        #
+        # @faker.version next
+        def country
+          fetch('fma_brotherhood.countries')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/fma_brotherhood.yml
+++ b/lib/locales/en/fma_brotherhood.yml
@@ -69,3 +69,10 @@ en:
         - Lior
         - Pendleton
         - Riviere
+      countries:
+        - Amestris
+        - Aerugo
+        - Creta
+        - Drachma
+        - Xerxes
+        - Xing

--- a/lib/locales/en/fma_brotherhood.yml
+++ b/lib/locales/en/fma_brotherhood.yml
@@ -1,0 +1,12 @@
+en:
+  faker:
+    fma_brotherhood:
+      characters:
+        - Edward Elric
+        - Alphonse Elric
+        - Roy Mustang
+        - Riza Hawkeye
+        - Scar
+        - Winry Rockbell
+        - May Chang 
+        

--- a/lib/locales/en/fma_brotherhood.yml
+++ b/lib/locales/en/fma_brotherhood.yml
@@ -57,3 +57,15 @@ en:
         - Rose
         - Nina
         - Sheska
+      cities:
+        - East City
+        - Rush Valley
+        - Resembool
+        - Dublith
+        - Central City
+        - Ishval
+        - Youswell
+        - North City
+        - Lior
+        - Pendleton
+        - Riviere

--- a/lib/locales/en/fma_brotherhood.yml
+++ b/lib/locales/en/fma_brotherhood.yml
@@ -9,4 +9,51 @@ en:
         - Scar
         - Winry Rockbell
         - May Chang 
-        
+        - Maes Hughes
+        - Alex Louis Armstrong
+        - Jean Havoc
+        - Heymans Breda
+        - Vato Fallman
+        - Kain Feury
+        - Führer King Bradley
+        - Maria Ross
+        - Denny Brosh
+        - Yoki
+        - Izumi Curtis
+        - Sig Curtis
+        - Pinako Rockbell
+        - Den The Dog
+        - Shou Tucker
+        - Tim Marco
+        - Lust
+        - Gluttony
+        - Envy
+        - Greed
+        - Sloth
+        - Pride
+        - Wrath
+        - Selim Bradley
+        - Roa
+        - Martel
+        - Dolceto
+        - Number 66
+        - Number 48
+        - Scar
+        - Father
+        - Dominic
+        - Garfield
+        - Giolio Comanche
+        - Basque Grand
+        - Isaac McDougal
+        - Solf J. Kimblee
+        - Van Hohenheim
+        - Fu 
+        - Ling Yao
+        - Lan Fan
+        - Olivier Mira Armstrong
+        - Buccaneer
+        - Major Miles
+        - Trisha Elric
+        - Rose
+        - Nina
+        - Sheska

--- a/test/faker/japanese_media/test_faker_fullmetal_alchemist_brotherhood.rb
+++ b/test/faker/japanese_media/test_faker_fullmetal_alchemist_brotherhood.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerFmaBrotherhood < Test::Unit::TestCase
+  def setup
+    @tester = Faker::JapaneseMedia::FmaBrotherhood
+  end
+
+  def test_character
+    assert @tester.character.match(/\w+/)
+  end
+end

--- a/test/faker/japanese_media/test_faker_fullmetal_alchemist_brotherhood.rb
+++ b/test/faker/japanese_media/test_faker_fullmetal_alchemist_brotherhood.rb
@@ -14,4 +14,8 @@ class TestFakerFmaBrotherhood < Test::Unit::TestCase
   def test_city
     assert @tester.city.match(/\w+/)
   end
+
+  def test_country
+    assert @tester.country.match(/\w+/)
+  end
 end

--- a/test/faker/japanese_media/test_faker_fullmetal_alchemist_brotherhood.rb
+++ b/test/faker/japanese_media/test_faker_fullmetal_alchemist_brotherhood.rb
@@ -10,4 +10,8 @@ class TestFakerFmaBrotherhood < Test::Unit::TestCase
   def test_character
     assert @tester.character.match(/\w+/)
   end
+
+  def test_city
+    assert @tester.city.match(/\w+/)
+  end
 end


### PR DESCRIPTION
Adds characters, cities and countries names from the Fullmetal Alchemist Brotherhood anime. 

The Faker::JapaneseMedia::FmaBrotherhood can make it more fun to populate databases, create factories and design tests.

The following options are available in this PR:
   - `Faker::JapaneseMedia::FmaBrotherhood.character`
   - `Faker::JapaneseMedia::FmaBrotherhood.city`
   - `Faker::JapaneseMedia::FmaBrotherhood.country`

In addition to the documentation file, inclusion of the link in README.md and unit testing.
