### PR TITLE
Fix Cote D'Ivoire case

### DIFF
--- a/lib/locales/en/address.yml
+++ b/lib/locales/en/address.yml
@@ -59,7 +59,7 @@ en:
         CD: "Congo, The Democratic Republic Of The"
         CK: "Cook Islands"
         CR: "Costa Rica"
-        CI: "Cote D'ivoire"
+        CI: "Cote D'Ivoire"
         HR: "Croatia"
         CU: "Cuba"
         CW: "Curacao"


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------

`country_by_code` contains `Cote D'Ivoire` country with incorrect `i` letter case