### PR TITLE
Strip extra whitespace from faker parsed output

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -143,7 +143,8 @@ module Faker
           text + etc.to_s
         end
         # If the fetched key couldn't be parsed, then fallback to numerify
-        parts.any? ? parts.join : numerify(fetched)
+
+        (parts.any? ? parts.join : numerify(fetched)).strip
       end
 
       # Call I18n.translate with our configured locale if no

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -79,6 +79,7 @@ class TestFaker < Test::Unit::TestCase
     data = {
       faker: {
         simple: { lookup: 'a value' },
+        with_missing_value: { lookup: 'a missing value here: ' },
         class: {
           call_method: "\#{TestFake.a_class_method}",
           use_translation: "\#{TestFake.use_i18n}"
@@ -89,6 +90,7 @@ class TestFaker < Test::Unit::TestCase
     I18n.backend.store_translations(Faker::Config.locale, data)
 
     assert_equal(Faker::Base.parse('simple.lookup'), 'a value')
+    assert_equal(Faker::Base.parse('with_missing_value.lookup'), 'a missing value here:')
     assert_equal(Faker::Base.parse('class.call_method'), 'called a_class_method')
     assert_equal(Faker::Base.parse('class.use_translation'), 'used i18n for translation')
   end


### PR DESCRIPTION
Issue
------

`No-Story`

Description
------------
We found that when using Faker to generate data, we'd have situations
with itermittent test failures.

The culprit was that, on occassion, Faker would generate a value that
was intened to have multiple pieces to it, but only return a string with
one of the items.

Ex:

-> coffee.yml
```yml
en:
  faker:
    coffee:
      blend_name: "#{name_1} #{name_2}"
```

```ruby
Faker::Coffee.unique.blend_name # => "Holiday Blend"
```

But sometimes we'd get a missing `name_2` value:

```ruby
Faker::Coffee.unique.blend_name # => "Holiday "
```

In this instance, we'd be checking our views to see if the `name` of the
record (using a coffee name faker) existed on the page. However, HTML
output strips whitespace from values - so the test would say:

"Find 'Holiday ' on the page", and the HTML would have the string
"Holiday" instead.

This change strips whitespace from output to ensure that, if a value is
missing from the generated fake, that there are no extra spaces.