### PR TITLE
Add ChileRut.full_formatted_rut

### DIFF
--- a/doc/default/chile_rut.md
+++ b/doc/default/chile_rut.md
@@ -23,9 +23,9 @@ Faker::ChileRut.check_digit #=> "5"
 # Returns full rut
 # Keyword arguments: min_rut
 # Keyword arguments: fixed
-Faker::ChileRut.full_rut #=> "30.686.957-4"
-Faker::ChileRut.full_rut(min_rut: 20890156) #=> "30.686.957-4"
-Faker::ChileRut.full_rut(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
+Faker::ChileRut.full_rut #=> "30686957-4"
+Faker::ChileRut.full_rut(min_rut: 20890156) #=> "30686957-4"
+Faker::ChileRut.full_rut(min_rut: 30686957, fixed: true) #=> "30686957-4"
 
 # Returns full formatted rut
 # Keyword arguments: min_rut

--- a/doc/default/chile_rut.md
+++ b/doc/default/chile_rut.md
@@ -24,13 +24,7 @@ Faker::ChileRut.check_digit #=> "5"
 # Keyword arguments: min_rut
 # Keyword arguments: fixed
 Faker::ChileRut.full_rut #=> "30686957-4"
-Faker::ChileRut.full_rut(min_rut: 20890156) #=> "30686957-4"
+Faker::ChileRut.full_rut(min_rut: 20890156) #=> "20890156-4"
+Faker::ChileRut.full_rut(min_rut: 20890156, formatted: true) #=> "20.890.156-4"
 Faker::ChileRut.full_rut(min_rut: 30686957, fixed: true) #=> "30686957-4"
-
-# Returns full formatted rut
-# Keyword arguments: min_rut
-# Keyword arguments: fixed
-Faker::ChileRut.full_formatted_rut #=> "30.686.957-4"
-Faker::ChileRut.full_formatted_rut(min_rut: 20890156) #=> "30.686.957-4"
-Faker::ChileRut.full_formatted_rut(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
 ```

--- a/doc/default/chile_rut.md
+++ b/doc/default/chile_rut.md
@@ -19,4 +19,18 @@ Faker::ChileRut.dv #=> "k"
 # check_digit is an alias for dv, for English speaking devs
 Faker::ChileRut.rut #=> 30528772
 Faker::ChileRut.check_digit #=> "5"
+
+# Returns full rut
+# Keyword arguments: min_rut
+# Keyword arguments: fixed
+Faker::ChileRut.full_rut #=> "30.686.957-4"
+Faker::ChileRut.full_rut(min_rut: 20890156) #=> "30.686.957-4"
+Faker::ChileRut.full_rut(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
+
+# Returns full formatted rut
+# Keyword arguments: min_rut
+# Keyword arguments: fixed
+Faker::ChileRut.full_formatted_rut #=> "30.686.957-4"
+Faker::ChileRut.full_formatted_rut(min_rut: 20890156) #=> "30.686.957-4"
+Faker::ChileRut.full_formatted_rut(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
 ```

--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -92,6 +92,29 @@ module Faker
         "#{rut(min_rut: min_rut, fixed: fixed)}-#{dv}"
       end
 
+      ##
+      # Produces a random Chilean RUT (Rol Unico Tributario, ID with 8 digits) with a dv (digito verificador, check-digit).
+      # with character passed in argument as separator.
+      #
+      # @param min_rut [Integer] Specifies the minimum value of the rut.
+      # @param fixed [Boolean] Determines if the rut is fixed (returns the min_rut value).
+      # @return [String]
+      #
+      # @example
+      #   Faker::ChileRut.full_rut_with_dots #=> "30.686.957-4"
+      #   Faker::ChileRut.full_rut_with_dots(min_rut: 20890156) #=> "30.686.957-4"
+      #   Faker::ChileRut.full_rut_with_dots(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
+      #
+      # @faker.version 1.9.2
+      def full_rut_with_dots(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
+        warn_for_deprecated_arguments do |keywords|
+          keywords << :min_rut if legacy_min_rut != NOT_GIVEN
+          keywords << :fixed if legacy_fixed != NOT_GIVEN
+        end
+
+        "#{rut(min_rut: min_rut, fixed: fixed).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse}-#{dv}"
+      end
+
       attr_reader :last_rut
     end
   end

--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -106,7 +106,7 @@ module Faker
       #   Faker::ChileRut.full_rut_with_dots(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
       #
       # @faker.version 1.9.2
-      def full_rut_with_dots(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
+      def full_formatted_rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
         warn_for_deprecated_arguments do |keywords|
           keywords << :min_rut if legacy_min_rut != NOT_GIVEN
           keywords << :fixed if legacy_fixed != NOT_GIVEN

--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -82,7 +82,7 @@ module Faker
       #   Faker::ChileRut.full_rut(min_rut: 20890156) #=> "30686957-4"
       #   Faker::ChileRut.full_rut(min_rut: 30686957, fixed: true) #=> "30686957-4"
       #
-      # @faker.version 1.9.2
+      # @faker.version next
       def full_rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false, formatted: false)
         warn_for_deprecated_arguments do |keywords|
           keywords << :min_rut if legacy_min_rut != NOT_GIVEN

--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -83,36 +83,17 @@ module Faker
       #   Faker::ChileRut.full_rut(min_rut: 30686957, fixed: true) #=> "30686957-4"
       #
       # @faker.version 1.9.2
-      def full_rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
+      def full_rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false, formatted: false)
         warn_for_deprecated_arguments do |keywords|
           keywords << :min_rut if legacy_min_rut != NOT_GIVEN
           keywords << :fixed if legacy_fixed != NOT_GIVEN
         end
 
-        "#{rut(min_rut: min_rut, fixed: fixed)}-#{dv}"
-      end
-
-      ##
-      # Produces a random Chilean RUT (Rol Unico Tributario, ID with 8 digits) with a dv (digito verificador, check-digit).
-      # with character passed in argument as separator.
-      #
-      # @param min_rut [Integer] Specifies the minimum value of the rut.
-      # @param fixed [Boolean] Determines if the rut is fixed (returns the min_rut value).
-      # @return [String]
-      #
-      # @example
-      #   Faker::ChileRut.full_rut_with_dots #=> "30.686.957-4"
-      #   Faker::ChileRut.full_rut_with_dots(min_rut: 20890156) #=> "30.686.957-4"
-      #   Faker::ChileRut.full_rut_with_dots(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
-      #
-      # @faker.version next
-      def full_formatted_rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
-        warn_for_deprecated_arguments do |keywords|
-          keywords << :min_rut if legacy_min_rut != NOT_GIVEN
-          keywords << :fixed if legacy_fixed != NOT_GIVEN
+        if formatted
+          "#{rut(min_rut: min_rut, fixed: fixed).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse}-#{dv}"
+        else
+          "#{rut(min_rut: min_rut, fixed: fixed)}-#{dv}"
         end
-
-        "#{rut(min_rut: min_rut, fixed: fixed).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse}-#{dv}"
       end
 
       attr_reader :last_rut

--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -105,7 +105,7 @@ module Faker
       #   Faker::ChileRut.full_rut_with_dots(min_rut: 20890156) #=> "30.686.957-4"
       #   Faker::ChileRut.full_rut_with_dots(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
       #
-      # @faker.version 1.9.2
+      # @faker.version next
       def full_formatted_rut(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
         warn_for_deprecated_arguments do |keywords|
           keywords << :min_rut if legacy_min_rut != NOT_GIVEN

--- a/test/faker/default/test_faker_chile_rut.rb
+++ b/test/faker/default/test_faker_chile_rut.rb
@@ -25,8 +25,8 @@ class TestChileRut < Test::Unit::TestCase
     assert @tester.dv == '4'
   end
 
-  def test_full_rut_with_dots_has_do
-    assert @tester.full_rut_with_dots(min_rut: 30_686_957, fixed: true).split('-')[0] == '30.686.957'
+  def test_full_formatted_rut_has_dv
+    assert @tester.full_formatted_rut(min_rut: 30_686_957, fixed: true).split('-')[0] == '30.686.957'
     assert @tester.dv == '4'
   end
 end

--- a/test/faker/default/test_faker_chile_rut.rb
+++ b/test/faker/default/test_faker_chile_rut.rb
@@ -24,4 +24,9 @@ class TestChileRut < Test::Unit::TestCase
     assert @tester.rut(min_rut: 30_686_957, fixed: true) == 30_686_957
     assert @tester.dv == '4'
   end
+
+  def test_full_rut_with_dots_has_do
+    assert @tester.full_rut_with_dots(min_rut: 30_686_957, fixed: true).split('-')[0] == '30.686.957'
+    assert @tester.dv == '4'
+  end
 end

--- a/test/faker/default/test_faker_chile_rut.rb
+++ b/test/faker/default/test_faker_chile_rut.rb
@@ -25,8 +25,8 @@ class TestChileRut < Test::Unit::TestCase
     assert @tester.dv == '4'
   end
 
-  def test_full_formatted_rut_has_dv
-    assert @tester.full_formatted_rut(min_rut: 30_686_957, fixed: true).split('-')[0] == '30.686.957'
+  def test_full_formatted_rut
+    assert @tester.full_rut(min_rut: 30_686_957, fixed: true, formatted: true).split('-')[0] == '30.686.957'
     assert @tester.dv == '4'
   end
 end


### PR DESCRIPTION
`No-Story`

Description:
------

In Chile, we have a RUT, kind of an ssn. The module written by oxfist was very nice and useful. But sometimes in Chile, we are asked to type RUT with a dot that separates the thousand and millions.

I've added the method `.full_formatted_rut` which will generate a RUT string with its validator digit (called `dv` on the code) and every three numbers it will have a dot separator. The example I'll write here is the same as it is written on the yard documentation of the new method.

```ruby
Faker::ChileRut.full_formatted_rut #=> "30.686.957-4"
Faker::ChileRut.full_formatted_rut(min_rut: 20890156) #=> "30.686.957-4"
Faker::ChileRut.full_formatted_rut(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
```

Anything you need I'll keep an eye on this PR.

Best regards,

Karl
