### PR TITLE
Issue 2431

### DIFF
--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -92,6 +92,29 @@ module Faker
         "#{rut(min_rut: min_rut, fixed: fixed)}-#{dv}"
       end
 
+      ##
+      # Produces a random Chilean RUT (Rol Unico Tributario, ID with 8 digits) with a dv (digito verificador, check-digit).
+      # with character passed in argument as separator.
+      #
+      # @param min_rut [Integer] Specifies the minimum value of the rut.
+      # @param fixed [Boolean] Determines if the rut is fixed (returns the min_rut value).
+      # @return [String]
+      #
+      # @example
+      #   Faker::ChileRut.full_rut_with_dots #=> "30.686.957-4"
+      #   Faker::ChileRut.full_rut_with_dots(min_rut: 20890156) #=> "30.686.957-4"
+      #   Faker::ChileRut.full_rut_with_dots(min_rut: 30686957, fixed: true) #=> "30.686.957-4"
+      #
+      # @faker.version 1.9.2
+      def full_rut_with_dots(legacy_min_rut = NOT_GIVEN, legacy_fixed = NOT_GIVEN, min_rut: 0, fixed: false)
+        warn_for_deprecated_arguments do |keywords|
+          keywords << :min_rut if legacy_min_rut != NOT_GIVEN
+          keywords << :fixed if legacy_fixed != NOT_GIVEN
+        end
+
+        "#{rut(min_rut: min_rut, fixed: fixed).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse}-#{dv}"
+      end
+
       attr_reader :last_rut
     end
   end

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -240,11 +240,11 @@ module Faker
               .split('.')
               .map { |domain_part| Char.prepare(domain_part) }
               .tap do |domain_elements|
-                domain_elements << domain_suffix(test) if domain_elements.length < 2
+                domain_elements << domain_suffix(test: test) if domain_elements.length < 2
                 domain_elements.unshift(Char.prepare(domain_word)) if subdomain && domain_elements.length < 3
               end.join('.')
           else
-            [domain_word, domain_suffix(test)].tap do |domain_elements| # HACK
+            [domain_word, domain_suffix(test: test)].tap do |domain_elements| # HACK
               domain_elements.unshift(Char.prepare(domain_word)) if subdomain
             end.join('.')
           end
@@ -464,16 +464,20 @@ module Faker
       # @param scheme [String]
       #
       # @example
-      #   Faker::Internet.url                                                           #=> "http://sipes-okon.com/hung.macejkovic"
-      #   Faker::Internet.url(host: 'faker')                                            #=> "http://faker/shad"
-      #   Faker::Internet.url(host: 'faker', path: '/fake_test_path')                   #=> "http://faker/fake_test_path"
-      #   Faker::Internet.url(host: 'faker', path: '/fake_test_path', scheme: 'https')  #=> "https://faker/fake_test_path"
-      def url(legacy_host = NOT_GIVEN, legacy_path = NOT_GIVEN, legacy_scheme = NOT_GIVEN, host: domain_name, path: "/#{username}", scheme: 'http')
+      #   Faker::Internet.url                                                                         #=> "http://sipes-okon.test/hung.macejkovic"
+      #   Faker::Internet.url(test: false)                                                            #=> "http://sipes-okon.com/hung.macejkovic"
+      #   Faker::Internet.url(host: 'faker')                                                          #=> "http://faker/shad"
+      #   Faker::Internet.url(host: 'faker', test: false)                                             #=> "http://faker/shad"
+      #   Faker::Internet.url(host: 'faker', path: '/fake_test_path')                                 #=> "http://faker/fake_test_path"
+      #   Faker::Internet.url(host: 'faker', path: '/fake_test_path', scheme: 'https', test: false)   #=> "https://faker/fake_test_path"
+      def url(legacy_host = NOT_GIVEN, legacy_path = NOT_GIVEN, legacy_scheme = NOT_GIVEN, host: nil, path: "/#{username}", scheme: 'http', test: true)
         warn_for_deprecated_arguments do |keywords|
           keywords << :host if legacy_host != NOT_GIVEN
           keywords << :path if legacy_path != NOT_GIVEN
           keywords << :scheme if legacy_scheme != NOT_GIVEN
         end
+
+        host = domain_name(test: test) if host.nil?
 
         "#{scheme}://#{host}#{path}" # HACK
       end

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -47,7 +47,7 @@ module Faker
                      end
 
         sanitized_local_part = sanitize_email_local_part(local_part)
-        construct_email(sanitized_local_part, domain_name(domain: domain, test: test)) # HACK
+        construct_email(sanitized_local_part, domain_name(domain: domain, test: test))
       end
 
       ##
@@ -244,7 +244,7 @@ module Faker
                 domain_elements.unshift(Char.prepare(domain_word)) if subdomain && domain_elements.length < 3
               end.join('.')
           else
-            [domain_word, domain_suffix(test: test)].tap do |domain_elements| # HACK
+            [domain_word, domain_suffix(test: test)].tap do |domain_elements|
               domain_elements.unshift(Char.prepare(domain_word)) if subdomain
             end.join('.')
           end
@@ -277,7 +277,7 @@ module Faker
       #
       # @example
       #   Faker::Internet.domain_word   #=> "senger"
-      def domain_word # HACK
+      def domain_word
         with_locale(:en) { Char.prepare(Company.name.split(' ').first) }
       end
 
@@ -292,7 +292,7 @@ module Faker
       # @example
       #   Faker::Internet.domain_suffix   #=> "com"
       #   Faker::Internet.domain_suffix   #=> "biz"
-      def domain_suffix(legacy_string = NOT_GIVEN, test: true) # HACK suffix like .com, .org, etc.
+      def domain_suffix(test: true)
         fetch(test ? 'internet.domain_suffix_test' : 'internet.domain_suffix')
       end
 
@@ -479,7 +479,7 @@ module Faker
 
         host = domain_name(test: test) if host.nil?
 
-        "#{scheme}://#{host}#{path}" # HACK
+        "#{scheme}://#{host}#{path}"
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/lib/locales/en/internet.yml
+++ b/lib/locales/en/internet.yml
@@ -1,6 +1,11 @@
 en:
   faker:
     internet:
+      domain_suffix_test:
+        - test
+        - example
+        - invalid
+        - localhost
       domain_suffix:
         - com
         - biz

--- a/test/faker/default/test_faker_chile_rut.rb
+++ b/test/faker/default/test_faker_chile_rut.rb
@@ -24,4 +24,9 @@ class TestChileRut < Test::Unit::TestCase
     assert @tester.rut(min_rut: 30_686_957, fixed: true) == 30_686_957
     assert @tester.dv == '4'
   end
+
+  def test_full_rut_with_dots_has_do
+    assert @tester.full_rut_with_dots(min_rut: 30_686_957, fixed: true).split('-')[0] == '30.686.957'
+    assert @tester.dv == '4'
+  end
 end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -16,6 +16,20 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.email.match(/.+@.+\.\w+/)
   end
 
+  def test_email_test_default
+    assert_includes(
+      I18n.translate('faker.internet.domain_suffix_test'),
+      @tester.email.split('.')[-1]
+    )
+  end
+
+  def test_email_test_false
+    assert_includes(
+      I18n.translate('faker.internet.domain_suffix'),
+      @tester.email(test: false).split('.')[-1]
+    )
+  end
+
   def test_email_with_non_permitted_characters
     assert @tester.email(name: 'martín').match(/mart#n@.+\.\w+/)
   end
@@ -317,6 +331,27 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_url
     assert @tester.url(host: 'domain.com', path: '/username', scheme: 'https').match(%r{^https://domain\.com/username$})
+  end
+
+  def test_url_domain_suffix_test_default
+    assert_includes(
+      %w[test example invalid localhost],
+      @tester.url(path: '/username', scheme: 'https').split('//')[1].split('/')[0].split('.')[1]
+    )
+  end
+
+  def test_url_domain_suffix_test_default_2
+    assert_includes(
+      I18n.translate('faker.internet.domain_suffix_test'),
+      @tester.url(path: '/username', scheme: 'https').split('//')[1].split('/')[0].split('.')[1]
+    )
+  end
+
+  def test_url_domain_suffix_test_false
+    assert_includes(
+      I18n.translate('faker.internet.domain_suffix'),
+      @tester.url(path: '/username', scheme: 'https', test: false).split('//')[1].split('/')[0].split('.')[1]
+    )
   end
 
   def test_device_token


### PR DESCRIPTION
Issue #2431 
------

Example:

https://github.com/faker-ruby/faker/issues/2431

Description:
------

I've added a new argument to the methods `def url` and `def email` defined on the file `lib/faker/default/internet.rb` . The new argument is called `test`, and it must be a boolean value. If `test` is true (the default value) then it means I am using the method to make tests, so it must have a domain_suffix meant for test: one of these 4 reserved words:

- .test
- .example
- .invalid
- .localhost

[RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606)

If `test` is false, then the domain_suffix could be `.com`, `.org`, etc.

The new testing domains are defined in `lib/locales/en/internet.yml` , I've put them previous to `domain_suffix` with the name `domain_suffix_test`

The `test` param is passed as an argument down to every other method untill it arrives to the method `def domain_suffix` . Kinda it passes as a pipe down to this method. And this method does call the `fetch` method with the I18n string to get the translation.

Any comment or feedback is welcome.

Best regards,

Karl