### PR TITLE
Add a new sports section for mountaineers

### DIFF
--- a/doc/sports/mountaineering.md
+++ b/doc/sports/mountaineering.md
@@ -1,0 +1,5 @@
+# Faker::Sports::Mountaineering
+
+```ruby
+Faker::Sports::Mountaineering.mountaineer #=> "Junko Tabei"
+```

--- a/lib/faker/sports/mountaineering.rb
+++ b/lib/faker/sports/mountaineering.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Faker
+  class Sports
+    class Mountaineering < Base
+      class << self
+        ##
+        # Produces the name of a Mountaineer.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Sports::Mountaineering.mountaineer #=> "Junko Tabei"
+        #
+        # @faker.version next
+        def mountaineer
+          fetch('mountaineering.mountaineer')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/mountaineering.yml
+++ b/lib/locales/en/mountaineering.yml
@@ -1,0 +1,14 @@
+en:
+  faker:
+    mountaineering:
+      mountaineer:
+        - Junko Tabei
+        - Catherine Destivelle
+        - Sasha DiGiulian
+        - Priti Wright
+        - Caroline Gleich
+        - Conrad Anker
+        - Edmund Hillary
+        - George Mallory
+        - Steve House
+        - Fred Beckey

--- a/test/faker/sports/test_faker_mountaineering.rb
+++ b/test/faker/sports/test_faker_mountaineering.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerMountaineering < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Sports::Mountaineering
+  end
+
+  def test_mountaineer
+    assert @tester.mountaineer.match(/\w+/)
+  end
+end


### PR DESCRIPTION
Issue
------

`No-Story`

Description:
------
I added a new generator that picks from a list of accomplished mountaineers. For now it's a short list but can be expanded. The idea for it came from my personal love for mountaineering and felt like adding a section for this sport would be a fun/good addition.

This could/would be used in any potential app ideas that relate to the mountaineering sport to provide a more realistic context in demo environments. This could pair nicely with the `Faker::Mountain` generator 😄 

**Generator:** `Faker::Sports::Mountaineering.mountaineer` => `Junko Tabei`

- Tests have been covered in `/test/faker/sports/test_faker_mountaineering.rb` and successfully run locally
- Documentation has been added in `/doc/sports/mountaineering.rb`
- Class has been created in `/lib/faker/sports/mountaineering.rb`
- Mountaineer names have been added in `/lib/locales/en/mountaineering.yml`