### PR TITLE
Add scope to unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Prefix your method call with `unique`. For example:
 Faker::Name.unique.name # This will return a unique name every time it is called
 ```
 
+You can also provide a scope for the unique generator.
+
+```ruby
+Faker::Name.unique(scope: :user).name # This will return a unique name for the :user scope
+Faker::Name.unique(scope: :customer).name # This will return a unique name for the :customer scope. This value may have already been returned in the :user scope.
+
+# The unique scope can be any ruby Object so you can make a scope for a particular class attribute like this:
+Faker::Name.unique(scope: [:customer, :name]).name
+```
+
 If too many unique values are requested from a generator that has a limited
 number of potential values, a `Faker::UniqueGenerator::RetryLimitExceeded`
 exception may be raised. It is possible to clear the record of unique values

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -217,9 +217,11 @@ module Faker
       # Return unique values from the generator every time.
       #
       # @param max_retries [Integer] The max number of retries that should be done before giving up.
+      # @param scope [Object] The scope of the unique values
       # @return [self]
-      def unique(max_retries = 10_000)
-        @unique ||= UniqueGenerator.new(self, max_retries)
+      def unique(max_retries = 10_000, scope: DefaultUniqueScope)
+        @unique ||= {}
+        @unique[scope] ||= UniqueGenerator.new(self, max_retries)
       end
 
       def sample(list, num = nil)
@@ -257,6 +259,8 @@ module Faker
       end
 
       private
+
+      class DefaultUniqueScope; end
 
       def warn_for_deprecated_arguments
         keywords = []

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -117,10 +117,28 @@ class TestFaker < Test::Unit::TestCase
   end
 
   def test_unique
+    Faker::Base.unique.clear
+
     unique_numbers = Array.new(8) do
       Faker::Base.unique.numerify('#')
     end
 
     assert_equal(unique_numbers.uniq, unique_numbers)
+  end
+
+  def test_unique_scope
+    Faker::Base.unique.clear
+    Faker::Base.unique(scope: :other).clear
+
+    unique_numbers_default_scope = Array.new(8) do
+      Faker::Base.unique.numerify('#')
+    end
+
+    unique_numbers_other_scope = Array.new(8) do
+      Faker::Base.unique(scope: :other).numerify('#')
+    end
+
+    # Assert that the intersection of the "default" scope and the "other" scope is not empty
+    assert !(unique_numbers_default_scope & unique_numbers_other_scope).empty?
   end
 end


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------
Adds an optional `scope` parameter to the `unique` method. This can be useful if you are using the same generator for multiple unique scope and don't want to run out of unique values. (Like, if you're using Pokemon names in every factory and running out of names.)