### PR TITLE
add rspec help method for clearing special characters

### DIFF
--- a/lib/ext/string.rb
+++ b/lib/ext/string.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class String
+  ##
+  # Produces the name of a city.
+  #
+  # @param options [Hash]
+  # @option with_state [Boolean] Whether to include the state name in the output.
+  # @return [String]
+  #
+  # @example
+  #   Faker::Name.first_name #=> "F'lar'"
+  #   Faker::Name.first_name.clear_special_characters
+  #     #=> "Flar"
+  #
+  # @faker.version next
+  def clear_special_characters
+    gsub(/[^0-9A-Za-z ]/, '')
+  end
+end

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -5,6 +5,7 @@ mydir = __dir__
 require 'psych'
 require 'i18n'
 require 'set' # Fixes a bug in i18n 0.6.11
+require 'ext/string'
 
 Dir.glob(File.join(mydir, 'helpers', '*.rb')).sort.each { |file| require file }
 

--- a/test/ext/test_string.rb
+++ b/test/ext/test_string.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class TestString < Test::Unit::TestCase
+  def setup
+    @string = "Maribel's home"
+  end
+
+  def test_clear_special_characters
+    assert_equal @string.clear_special_characters, 'Maribels home'
+  end
+end


### PR DESCRIPTION
Issue#
------

`No-Story`

Description:
------
Add method, that removes special characters for rspec testing, 'cause it is a problem, when some text, like word of Lorem module generate a word with apostrophe and in next test it's a problem:
```ruby
it 'includes partner name' do
  expect(response.body).to include(partner.name) #=> when name is "F'lar" it fails, 'cause in body (not transcoded, but it is also not resolve) is "F&#39;lar"
end
```

I hope, that I did good solution for this  🙏

https://stackoverflow.com/questions/41814682/rspec-controller-test-failing-with-apostrophe-character
