### PR TITLE
Danish id number

### DIFF
--- a/doc/default/id_number.md
+++ b/doc/default/id_number.md
@@ -39,4 +39,9 @@ Faker::IDNumber.chilean_id #=> "15620613-K"
 # Keyword arguments: international
 Faker::IDNumber.croatian_id #=> "88467617508"
 Faker::IDNumber.croatian_id(international: true) #=> "HR88467617508"
+
+# Generate a Danish ID number (CPR)
+# Keyword arguments: formatted, gender, birthday
+Faker::IDNumber.danish_id_number #=> "050390-9980"
+Faker::IDNumber.danish_id_number(formatted: true) #=> "050390-9980"
 ```

--- a/doc/default/id_number.md
+++ b/doc/default/id_number.md
@@ -44,4 +44,5 @@ Faker::IDNumber.croatian_id(international: true) #=> "HR88467617508"
 # Keyword arguments: formatted, gender, birthday
 Faker::IDNumber.danish_id_number #=> "050390-9980"
 Faker::IDNumber.danish_id_number(formatted: true) #=> "050390-9980"
+Faker::IDNumber.danish_id_number(birthday: Date.new(1990, 3, 5)) #=> "050390-9980"
 ```

--- a/doc/default/id_number.md
+++ b/doc/default/id_number.md
@@ -45,4 +45,5 @@ Faker::IDNumber.croatian_id(international: true) #=> "HR88467617508"
 Faker::IDNumber.danish_id_number #=> "050390-9980"
 Faker::IDNumber.danish_id_number(formatted: true) #=> "050390-9980"
 Faker::IDNumber.danish_id_number(birthday: Date.new(1990, 3, 5)) #=> "050390-9980"
+Faker::IDNumber.danish_id_number(gender: :female) #=> "050390-9980"
 ```

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -219,6 +219,34 @@ module Faker
         "#{prefix}#{digits}#{checksum_digit}"
       end
 
+      ##
+      # Produces a random Danish ID Number (CPR number).
+      # CPR number is 10 digits. Digit 1-6 is the birthdate (format "DDMMYY").
+      # Digit 7-10 is a sequence number.
+      # Digit 7 digit is a control digit that determines the century of birth.
+      # Digit 10 reveals the gender: # even is female, odd is male.
+      #
+      # @param formatted [Boolean] Specifies if the number is formatted with dividers.
+      # @return [String]
+      #
+      # @example
+      #   Faker::IDNumber.danish_id_number #=> "0503909980"
+      #   Faker::IDNumber.danish_id_number(formatted: true) #=> "050390-9980"
+      #
+      # @faker.version next
+      def danish_id_number(formatted: false)
+        birthday = Faker::Date.birthday
+        valid_control_digits = danish_control_digits(birthday)
+        control_digit = sample(valid_control_digits)
+
+        [
+          birthday.strftime('%d%m%y'),
+          formatted ? '-' : '',
+          control_digit,
+          Faker::Number.number(digits: 3)
+        ].join
+      end
+
       private
 
       def croatian_id_checksum_digit(digits)
@@ -303,6 +331,45 @@ module Faker
         subtraction = 11 - remainder.to_i
         digits = { 10 => 'X', 11 => '0' }
         digits.include?(subtraction) ? digits[subtraction] : subtraction.to_s
+      end
+
+      def danish_control_digits(birthday)
+        year = birthday.year
+        century = year.to_s.slice(0, 2).to_i
+        year_digits = year.to_s.slice(2, 2).to_i
+        error_message = "Invalid birthday: #{birthday}. Danish CPR numbers are only distributed to persons born between 1858 and 2057."
+
+        case century
+        when 18
+          # If 5, 6, 7 or 8 and the year numbers are greater than or equal to 58, you were born in 18XX.
+          case year_digits
+          when 58..99
+            [5, 6, 7, 8]
+          else
+            raise ArgumentError, error_message
+          end
+        when 19
+          # If 0, 1, 2 or 3, you are always born in 19XX.
+          # If 4 or 9, you are born in 19XX if the year digits are greater than 36.
+
+          case year_digits
+          when 0..36
+            [0, 1, 2, 3]
+          else # 37..99
+            [0, 1, 2, 3, 4, 9]
+          end
+        else
+          # If 4, 5, 6, 7, 8 or 9 and the year digits are less than or equal to 36, you were born in 20XX.
+          # 5, 6, 7 and 8 are not distributed to persons, with year digits from and including 37 to and including 57.
+          case year_digits
+          when 0..36
+            [4, 5, 6, 7, 8, 9]
+          when 37..57
+            [5, 6, 7, 8]
+          else
+            raise ArgumentError, error_message
+          end
+        end
       end
 
       def _translate(key)

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -227,15 +227,16 @@ module Faker
       # Digit 10 reveals the gender: # even is female, odd is male.
       #
       # @param formatted [Boolean] Specifies if the number is formatted with dividers.
+      # @param birthday [Date] Specifies the birthday for the id number.
       # @return [String]
       #
       # @example
       #   Faker::IDNumber.danish_id_number #=> "0503909980"
       #   Faker::IDNumber.danish_id_number(formatted: true) #=> "050390-9980"
+      #   Faker::IDNumber.danish_id_number(birthday: Date.new(1990, 3, 5)) #=> "0503909980"
       #
       # @faker.version next
-      def danish_id_number(formatted: false)
-        birthday = Faker::Date.birthday
+      def danish_id_number(formatted: false, birthday: Faker::Date.birthday)
         valid_control_digits = danish_control_digits(birthday)
         control_digit = sample(valid_control_digits)
 

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -228,23 +228,38 @@ module Faker
       #
       # @param formatted [Boolean] Specifies if the number is formatted with dividers.
       # @param birthday [Date] Specifies the birthday for the id number.
+      # @param gender [Symbol] Specifies the gender for the id number. Must be one :male or :female if present.
       # @return [String]
       #
       # @example
       #   Faker::IDNumber.danish_id_number #=> "0503909980"
       #   Faker::IDNumber.danish_id_number(formatted: true) #=> "050390-9980"
       #   Faker::IDNumber.danish_id_number(birthday: Date.new(1990, 3, 5)) #=> "0503909980"
+      #   Faker::IDNumber.danish_id_number(gender: :female) #=> "0503909980"
       #
       # @faker.version next
-      def danish_id_number(formatted: false, birthday: Faker::Date.birthday)
+      def danish_id_number(formatted: false, birthday: Faker::Date.birthday, gender: nil)
         valid_control_digits = danish_control_digits(birthday)
         control_digit = sample(valid_control_digits)
+        digits = (0..9).to_a
+        gender = gender.to_sym if gender.respond_to?(:to_sym)
+        gender_digit = case gender
+                       when nil
+                         sample(digits)
+                       when :male
+                         sample(digits.select(&:odd?))
+                       when :female
+                         sample(digits.select(&:even?))
+                       else
+                         raise ArgumentError, "Invalid gender #{gender}. Must be one of male, female, or be omitted."
+                       end
 
         [
           birthday.strftime('%d%m%y'),
           formatted ? '-' : '',
           control_digit,
-          Faker::Number.number(digits: 3)
+          Faker::Number.number(digits: 2),
+          gender_digit
         ].join
       end
 

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -186,6 +186,48 @@ class TestFakerIdNumber < Test::Unit::TestCase
     assert_match(/^\d{6}-\d{4}$/, sample)
   end
 
+  def test_danish_id_number_birthday
+    sample = @tester.danish_id_number(birthday: Date.new(1995, 1, 2))
+    assert_match(/^020195\d{4}$/, sample)
+  end
+
+  def test_danish_id_number_birthday_early_1800
+    assert_raises ArgumentError do
+      @tester.danish_id_number(birthday: Date.new(1815, 1, 2))
+    end
+  end
+
+  def test_danish_id_number_birthday_late_1800
+    sample = @tester.danish_id_number(birthday: Date.new(1895, 1, 2))
+    assert_match(/^020195[5678]\d{3}$/, sample)
+  end
+
+  def test_danish_id_number_birthday_early_1900
+    sample = @tester.danish_id_number(birthday: Date.new(1915, 1, 2))
+    assert_match(/^020115[0123]\d{3}$/, sample)
+  end
+
+  def test_danish_id_number_birthday_late_1900
+    sample = @tester.danish_id_number(birthday: Date.new(1995, 1, 2))
+    assert_match(/^020195[012349]\d{3}$/, sample)
+  end
+
+  def test_danish_id_number_birthday_early_2000
+    sample = @tester.danish_id_number(birthday: Date.new(2015, 1, 2))
+    assert_match(/^020115[456789]\d{3}$/, sample)
+  end
+
+  def test_danish_id_number_birthday_mid_2000
+    sample = @tester.danish_id_number(birthday: Date.new(2055, 1, 2))
+    assert_match(/^020155[5678]\d{3}$/, sample)
+  end
+
+  def test_danish_id_number_birthday_late_2000
+    assert_raises ArgumentError do
+      @tester.danish_id_number(birthday: Date.new(2095, 1, 2))
+    end
+  end
+
   private
 
   def south_african_id_number_to_date_of_birth_string(sample)

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -176,6 +176,16 @@ class TestFakerIdNumber < Test::Unit::TestCase
     assert_equal checksum_digit, 5
   end
 
+  def test_danish_id_number
+    sample = @tester.danish_id_number
+    assert_match(/^\d{10}$/, sample)
+  end
+
+  def test_danish_id_number_formatted
+    sample = @tester.danish_id_number(formatted: true)
+    assert_match(/^\d{6}-\d{4}$/, sample)
+  end
+
   private
 
   def south_african_id_number_to_date_of_birth_string(sample)

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -228,6 +228,22 @@ class TestFakerIdNumber < Test::Unit::TestCase
     end
   end
 
+  def test_danish_id_number_gender_female
+    sample = @tester.danish_id_number(gender: :female)
+    assert sample.chars.last.to_i.even?
+  end
+
+  def test_danish_id_number_gender_male
+    sample = @tester.danish_id_number(gender: :male)
+    assert sample.chars.last.to_i.odd?
+  end
+
+  def test_danish_id_number_invalid_gender
+    assert_raises ArgumentError do
+      @tester.danish_id_number(gender: :invalid)
+    end
+  end
+
   private
 
   def south_african_id_number_to_date_of_birth_string(sample)


### PR DESCRIPTION
This PR adds a new method: `Faker::IDNumber.danish_id_number`, which returns a valid Danish national identification number (also called CPR number, for "the Central Person Register number").