### PR TITLE
Thread safety

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -13,23 +13,26 @@ I18n.reload! if I18n.backend.initialized?
 
 module Faker
   module Config
-    @locale = nil
-    @random = nil
-
     class << self
-      attr_writer :locale, :random
+      def locale=(new_locale)
+        Thread.current[:faker_config_locale] = new_locale
+      end
 
       def locale
         # Because I18n.locale defaults to :en, if we don't have :en in our available_locales, errors will happen
-        @locale || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
+        Thread.current[:faker_config_locale] || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
       end
 
       def own_locale
-        @locale
+        Thread.current[:faker_config_locale]
+      end
+
+      def random=(new_random)
+        Thread.current[:faker_config_random] = new_random
       end
 
       def random
-        @random || Random
+        Thread.current[:faker_config_random] || Random
       end
     end
   end

--- a/test/faker/default/test_faker_unique_generator.rb
+++ b/test/faker/default/test_faker_unique_generator.rb
@@ -121,4 +121,43 @@ class TestFakerUniqueGenerator < Test::Unit::TestCase
       assert_equal(2, generator2.test)
     end
   end
+
+  def test_thread_safety
+    stubbed_generator = Object.new
+    def stubbed_generator.test
+      1
+    end
+
+    generator = Faker::UniqueGenerator.new(stubbed_generator, 3)
+
+    Thread.new do
+      assert_equal(1, generator.test)
+
+      assert_raises Faker::UniqueGenerator::RetryLimitExceeded do
+        generator.test
+      end
+    end.join
+
+    Thread.new do
+      assert_equal(1, generator.test)
+    end.join
+
+    assert_equal(1, generator.test)
+
+    assert_raises Faker::UniqueGenerator::RetryLimitExceeded do
+      generator.test
+    end
+
+    Thread.new do
+      generator.clear
+    end.join
+
+    assert_raises Faker::UniqueGenerator::RetryLimitExceeded do
+      generator.test
+    end
+
+    generator.clear
+
+    assert_equal(1, generator.test)
+  end
 end

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -22,6 +22,26 @@ class TestDeterminism < Test::Unit::TestCase
     end
   end
 
+  def test_thread_safety
+    expected_values = 2.times.map do |index|
+      Faker::Config.random = Random.new(index)
+      Faker::Number.digit
+    end
+
+    threads = expected_values.each_with_index.map do |expected_value, index|
+      Thread.new do
+        100_000.times.each do
+          Faker::Config.random = Random.new(index)
+          output = Faker::Number.digit
+
+          assert_equal output, expected_value
+        end
+      end
+    end
+
+    threads.each(&:join)
+  end
+
   private
 
   def deterministic_random?(first, method_name)


### PR DESCRIPTION
Issue#
------

https://github.com/faker-ruby/faker/issues/1700

Description:
------

In my project, I have a lot of specs, so I run them in parallel to get quicker results, usually in a few threads. I also have some special specs dealing with mocked data, where I need a random first name, but it can't be the same as the initial data. At this point, I started to use the unique generators, something like this:

```ruby
before do
  generator = Faker::Name.unique
  generator.exclude(:first_name, [], %w[Adam]) }
  @first_name = generator.first_name
  generator.clear # have a lot of test, don't want to run out of names just because one is forbidden
end
```
It worked fine when I was running only one of the tests, but as soon as I started them in parallel, they became flaky and sometimes it even generated the excluded first name.

I saw that others also had problems with thread safety, so here I am, trying to fix it. I added two new test cases, one is checking the thread safety of the Config.random (code derived from the linked isssue), the other is covering my problem with unique generators having their own sets of exlusions.

I hope my PR helps and could be merged soon, just let me know if you need anything