### PR TITLE
fix flaky user agent test

### DIFF
--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -360,6 +360,7 @@ class TestFakerInternet < Test::Unit::TestCase
   def test_user_agent_with_valid_argument
     assert @tester.user_agent(vendor: :opera).match(/Opera/)
     assert @tester.user_agent(vendor: 'opera').match(/Opera/)
+    assert @tester.user_agent(vendor: nil).match(/Mozilla|Opera/)
   end
 
   def test_user_agent_with_invalid_argument
@@ -374,6 +375,7 @@ class TestFakerInternet < Test::Unit::TestCase
   def test_bot_user_agent_with_valid_argument
     assert @tester.bot_user_agent(vendor: :duckduckbot).match(/DuckDuckBot/)
     assert @tester.bot_user_agent(vendor: 'duckduckbot').match(/DuckDuckBot/)
+    refute_empty @tester.bot_user_agent(vendor: nil)
   end
 
   def test_bot_user_agent_with_invalid_argument

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -363,12 +363,12 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_user_agent_with_invalid_argument
-    assert @tester.user_agent(vendor: :ie).match(/Mozilla|Opera/)
-    assert @tester.user_agent(vendor: 1).match(/Mozilla|Opera/)
+    refute_empty @tester.user_agent(vendor: :ie)
+    refute_empty @tester.user_agent(vendor: 1)
   end
 
   def test_bot_user_agent_with_no_argument
-    assert @tester.bot_user_agent.match(/Baiduspider|Bot|bot/)
+    refute_empty @tester.bot_user_agent
   end
 
   def test_bot_user_agent_with_valid_argument
@@ -377,8 +377,8 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_bot_user_agent_with_invalid_argument
-    assert @tester.bot_user_agent(vendor: :ie).match(/Baiduspider|Bot|bot/)
-    assert @tester.bot_user_agent(vendor: 1).match(/Baiduspider|Bot|bot/)
+    refute_empty @tester.bot_user_agent(vendor: :ie)
+    refute_empty @tester.bot_user_agent(vendor: 1)
   end
 
   def test_uuid

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -364,7 +364,6 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_user_agent_with_invalid_argument
     assert @tester.user_agent(vendor: :ie).match(/Mozilla|Opera/)
-    assert @tester.user_agent(vendor: nil).match(/Mozilla|Opera/)
     assert @tester.user_agent(vendor: 1).match(/Mozilla|Opera/)
   end
 
@@ -379,7 +378,6 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_bot_user_agent_with_invalid_argument
     assert @tester.bot_user_agent(vendor: :ie).match(/Baiduspider|Bot|bot/)
-    assert @tester.bot_user_agent(vendor: nil).match(/Baiduspider|Bot|bot/)
     assert @tester.bot_user_agent(vendor: 1).match(/Baiduspider|Bot|bot/)
   end
 


### PR DESCRIPTION
Issue#
------
Fixes #2521

Description:
------

Fixes some flaky tests on `test_faker_internet.rb` related to bot_user_agent generation.

- [test_faker_internet.rb:382](https://github.com/faker-ruby/faker/blob/15a8bc35f489b2d5e06439c664363c779b125d6c/test/faker/default/test_faker_internet.rb#L382).
- [test_faker_internet.rb:372](https://github.com/faker-ruby/faker/blob/15a8bc35f489b2d5e06439c664363c779b125d6c/test/faker/default/test_faker_internet.rb#L372)

These previous test were matching against a fixed list of options for user agents and bot user agents.

The problem appeared when a new type of user agent was added to the locales. Because the generator randomly picks an user agent, the previous test would fail at random when the agent picked didn't match the regex.

But the generator should return a string even if the vendor is not available or the argument is invalid.

We can simply verify that the agent is present. Otherwise, we would have to keep the regex and these tests updated whenever a new user agent is added to the locale.