### PR TITLE
fix: ensure generated passwords have correct characters when mix_case & special_characters enabled

### DIFF
--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -32,10 +32,15 @@ Faker::Internet.username(specifier: 5..8)
 Faker::Internet.username(specifier: 8)
 
 # Keyword arguments: min_length, max_length, mix_case, special_characters
+# Default configuration is mix_case: true && special_characters: false
 Faker::Internet.password #=> "Vg5mSvY1UeRg7"
 Faker::Internet.password(min_length: 8) #=> "YfGjIk0hGzDqS0"
 Faker::Internet.password(min_length: 10, max_length: 20) #=> "EoC9ShWd1hWq4vBgFw"
+# min_length must be at least 1 if mix_case: false && special_characters: true
+Faker::Internet.password(min_length: 10, max_length: 20, mix_case: false, special_characters: true) #=> "$1109mw31h8359jm0!oo"
+# min_length must be at least 2 if mix_case: true && special_characters: false
 Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true) #=> "3k5qS15aNmG"
+# min_length must be at least 3 if mix_case: true && special_characters: true
 Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true, special_characters: true) #=> "*%NkOnJsH4"
 
 # Keyword arguments: subdomain, domain


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull request.

Were there any bugs you had fixed? If so, mention them: Fixes Issue #add-issue-number -->

Previously, when mix_case and special_characters were enabled, the generated password would sometimes exclude the mix_case characters because they were being overwritten by special characters instead.

This PR ensures that when mix_case and special_characters are both true (unless the generated password length is not enough to include all), the generated password includes at least:

- 1 upper case letter
- 1 lower case letter
- 1 special character

Should the generated password not allow for this (e.g. max_length is 3 or less), then raise an error.

Fixes Issue #2512

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

If you are creating a new generator, share how you are going to use it. Use cases are important to make sure that our faker generators are useful. Also, add `@faker.version next` to help users know when a generator was added. See [this example](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/music/opera.rb#L68).

Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/master/CONTRIBUTING.md#documentation).

Thanks for contributing to Faker! -->