### PR TITLE
Fix warning instance variable uninitialized

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -44,6 +44,8 @@ module Faker
     Letters = ULetters + LLetters
 
     class << self
+      attr_reader :flexible_key
+
       NOT_GIVEN = Object.new
 
       ## by default numerify results do not start with a zero
@@ -188,9 +190,9 @@ module Faker
       #     girls_name: ["Alice", "Cheryl", "Tatiana"]
       # Then you can call Faker::Name.girls_name and it will act like #first_name
       def method_missing(mth, *args, &block)
-        super unless @flexible_key
+        super unless flexible_key
 
-        if (translation = translate("faker.#{@flexible_key}.#{mth}"))
+        if (translation = translate("faker.#{flexible_key}.#{mth}"))
           sample(translation)
         else
           super

--- a/test/faker/default/test_faker_food.rb
+++ b/test/faker/default/test_faker_food.rb
@@ -8,9 +8,7 @@ class TestFakerFood < Test::Unit::TestCase
   end
 
   def test_flexible_key
-    flexible_key = @tester.instance_variable_get('@flexible_key')
-
-    assert flexible_key == :food
+    assert @tester.flexible_key == :food
   end
 
   def test_dish

--- a/test/faker/default/test_faker_hobby.rb
+++ b/test/faker/default/test_faker_hobby.rb
@@ -8,9 +8,7 @@ class TestFakerHobby < Test::Unit::TestCase
   end
 
   def test_flexible_key
-    flexible_key = @tester.instance_variable_get('@flexible_key')
-
-    assert flexible_key == :hobby
+    assert @tester.flexible_key == :hobby
   end
 
   def test_activity

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -27,9 +27,7 @@ class TestFakerVehicle < Test::Unit::TestCase
   end
 
   def test_flexible_key
-    flexible_key = @tester.instance_variable_get('@flexible_key')
-
-    assert flexible_key == :vehicle
+    assert @tester.flexible_key == :vehicle
   end
 
   def test_transmission


### PR DESCRIPTION
### Summary

Fixed the warning instance variable `@flexible_key` is not initialized 

### Other Information
Running the tests, I found warning down below and fix it : )

```sh
/faker/lib/faker.rb:191: warning: instance variable @flexible_key not initialized
```