### PR TITLE
Drop support for EOL Ruby versions (`2.5` and `2.6`)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,8 +35,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '2.5'
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 Layout/LineLength:
   Description: This cop checks the length of lines in the source code. The maximum length is configurable.

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = ['faker']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/master/CHANGELOG.md'
   spec.metadata['source_code_uri'] = 'https://github.com/faker-ruby/faker'

--- a/lib/faker/default/bank.rb
+++ b/lib/faker/default/bank.rb
@@ -23,7 +23,7 @@ module Faker
 
         output = ''
 
-        output += rand.to_s[2..-1] while output.length < digits
+        output += rand.to_s[2..] while output.length < digits
 
         output[0...digits]
       end

--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -107,7 +107,7 @@ module Faker
 
         birthyear = Date.birthday(min_age: min_age, max_age: max_age).year
         prefix = birthyear < 2000 ? 'S' : 'T'
-        values = birthyear.to_s[-2..-1]
+        values = birthyear.to_s[-2..]
         values << regexify(/\d{5}/)
         check_alpha = generate_nric_check_alphabet(values, prefix)
         "#{prefix}#{values}#{check_alpha}"

--- a/test/faker/default/test_faker_birthday_in_leap_year.rb
+++ b/test/faker/default/test_faker_birthday_in_leap_year.rb
@@ -19,24 +19,5 @@ class TestFakerBirthdayInLeapYear < Test::Unit::TestCase
     assert_nothing_raised ArgumentError do
       @tester.birthday
     end
-
-    # The error raised here is changed in Ruby 2.7.
-    if RUBY_VERSION < '2.7'
-      assert_raise ArgumentError do
-        ::Date.new(@today.year - @min, @today.month, @today.day)
-      end
-
-      assert_raise ArgumentError do
-        ::Date.new(@today.year - @max, @today.month, @today.day)
-      end
-    elsif RUBY_VERSION >= '2.7'
-      assert_raise Date::Error do
-        ::Date.new(@today.year - @min, @today.month, @today.day)
-      end
-
-      assert_raise Date::Error do
-        ::Date.new(@today.year - @max, @today.month, @today.day)
-      end
-    end
   end
 end

--- a/test/faker/default/test_faker_birthday_in_leap_year.rb
+++ b/test/faker/default/test_faker_birthday_in_leap_year.rb
@@ -19,5 +19,13 @@ class TestFakerBirthdayInLeapYear < Test::Unit::TestCase
     assert_nothing_raised ArgumentError do
       @tester.birthday
     end
+    
+    assert_raise Date::Error do
+      ::Date.new(@today.year - @min, @today.month, @today.day)
+    end
+
+    assert_raise Date::Error do
+      ::Date.new(@today.year - @max, @today.month, @today.day)
+    end
   end
 end

--- a/test/faker/default/test_faker_birthday_in_leap_year.rb
+++ b/test/faker/default/test_faker_birthday_in_leap_year.rb
@@ -19,7 +19,7 @@ class TestFakerBirthdayInLeapYear < Test::Unit::TestCase
     assert_nothing_raised ArgumentError do
       @tester.birthday
     end
-    
+
     assert_raise Date::Error do
       ::Date.new(@today.year - @min, @today.month, @today.day)
     end

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -68,7 +68,6 @@ class TestFakerIdNumber < Test::Unit::TestCase
     sample = @tester.brazilian_citizen_number
     assert_match(/^\d{11}$/, sample)
     assert_match(/(\d)((?!\1)\d)+/, sample)
-    
   end
 
   def test_brazilian_citizen_number_formatted

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -58,17 +58,6 @@ class TestFakerIdNumber < Test::Unit::TestCase
 
   def test_invalid_south_african_id_number
     sample = @tester.invalid_south_african_id_number
-
-    # The error raised here is changed in Ruby 2.7.
-    if RUBY_VERSION < '2.7'
-      assert_raises ArgumentError do
-        Date.parse(south_african_id_number_to_date_of_birth_string(sample))
-      end
-    elsif RUBY_VERSION >= '2.7'
-      assert_raises Date::Error do
-        Date.parse(south_african_id_number_to_date_of_birth_string(sample))
-      end
-    end
   end
 
   def test_brazilian_citizen_number

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -58,12 +58,20 @@ class TestFakerIdNumber < Test::Unit::TestCase
 
   def test_invalid_south_african_id_number
     sample = @tester.invalid_south_african_id_number
+    
+    assert_raises Date::Error do
+      Date.parse(south_african_id_number_to_date_of_birth_string(sample))
+    end
   end
 
   def test_brazilian_citizen_number
     sample = @tester.brazilian_citizen_number
     assert_match(/^\d{11}$/, sample)
     assert_match(/(\d)((?!\1)\d)+/, sample)
+
+    assert_raises Date::Error do
+      Date.parse(south_african_id_number_to_date_of_birth_string(sample))
+    end
   end
 
   def test_brazilian_citizen_number_formatted

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -58,7 +58,7 @@ class TestFakerIdNumber < Test::Unit::TestCase
 
   def test_invalid_south_african_id_number
     sample = @tester.invalid_south_african_id_number
-    
+
     assert_raises Date::Error do
       Date.parse(south_african_id_number_to_date_of_birth_string(sample))
     end
@@ -68,10 +68,7 @@ class TestFakerIdNumber < Test::Unit::TestCase
     sample = @tester.brazilian_citizen_number
     assert_match(/^\d{11}$/, sample)
     assert_match(/(\d)((?!\1)\d)+/, sample)
-
-    assert_raises Date::Error do
-      Date.parse(south_african_id_number_to_date_of_birth_string(sample))
-    end
+    
   end
 
   def test_brazilian_citizen_number_formatted


### PR DESCRIPTION
### Summary

I Completed the 3 tasks in Issue #2529
- removed version checks in test_faker_birthday_in_leap_year.rb and test_faker_id_number.rb
- Updated Targeted Ruby Version for Rubocop to 2.7
- Updated spec.required_ruby_version = '>= 2.5' to 2.7

### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

If you are creating a new generator, share how you are going to use it. Use cases are important to make sure that our faker generators are useful. Also, add `@faker.version next` to help users know when a generator was added. See [this example](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/music/opera.rb#L68).

Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/master/CONTRIBUTING.md#documentation).

Thanks for contributing to Faker! -->