### PR TITLE
Fix computer test

### DIFF
--- a/lib/locales/en/computer.yml
+++ b/lib/locales/en/computer.yml
@@ -4,7 +4,7 @@ en:
       type:
         - server
         - workstation
-      platform: 
+      platform:
         - Linux
         - macOS
         - Windows
@@ -39,7 +39,7 @@ en:
           - OpenBSD 6
         templeos:
           - TempleOS 5.03
-        plannine:
+        plan 9:
           - Plan 9 Fourth Edition
         macos:
           - Catalina (10.15)

--- a/test/faker/default/test_faker_computer.rb
+++ b/test/faker/default/test_faker_computer.rb
@@ -17,7 +17,6 @@ class TestFakerComputer < Test::Unit::TestCase
   end
 
   def test_stack
-    # puts @tester.stack
     assert stack = @tester.stack
                           .match(/\A(?<platform>(?:[[:alnum:]]+\s?){1,5}), (?<os>(?:[[:alnum:]]+-?.?\)?\(?\s?){1,5})\z/)
 

--- a/test/faker/default/test_faker_computer.rb
+++ b/test/faker/default/test_faker_computer.rb
@@ -13,7 +13,7 @@ class TestFakerComputer < Test::Unit::TestCase
   end
 
   def test_platform
-    assert @tester.platform.match(/(\w+ ?){1,3}/)
+    assert @tester.platform.match(/(\w+ ?\d?){1,3}/)
   end
 
   def test_stack


### PR DESCRIPTION
### Summary

This PR is one fix for #2541

### Other Information

According to the [YAML Specification](https://yaml.org/spec/1.2.2/#32-information-models), spaces are allowed in keys. I changed from `plannine` to `plan 9` to match the available stacks and improved the matcher (regex) in the test. 

As always, open to suggestions.