### PR TITLE
WIP: #2505 Replace LoremPixel with LoremFlickr

### DIFF
--- a/test/faker/default/test_lorem_flickr.rb
+++ b/test/faker/default/test_lorem_flickr.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestLoremFlickr < Test::Unit::TestCase
+  def setup
+    @tester = Faker::LoremFlickr
+  end
+
+  def test_loremflickr
+    assert !@tester.image.match(%r{https://loremflickr\.com/(\d+/\d+)})[1].nil?
+  end
+
+  def test_image_with_custom_size
+    assert @tester.image(size: '3x3').match(%r{https://loremflickr\.com/(\d+/\d+)})[1] == '3/3'
+  end
+
+  def test_image_with_incorrect_size
+    assert_raise ArgumentError do
+      @tester.image(size: '300x300s')
+    end
+  end
+
+  def test_image_with_search_terms
+    assert @tester.image(size: '300x300', search_terms: ['sports', 'fitness']).match(%r{https://loremflickr\.com/\d+/\d+/(.+\,.+)})[1] == 'sports,fitness'
+  end
+
+  def test_image_with_search_terms_and_match_all
+    assert @tester.image(size: '300x300', search_terms: ['sports', 'fitness'], match_all: true).match(%r{https://loremflickr\.com/\d+/\d+/.+\,.+/(all)})[1] == 'all'
+  end
+end


### PR DESCRIPTION
### Summary
Fixes: #2505

`LoremPixel` is no longer available, therefore we are replacing it with `LoremFlickr`. 

In order to mark this as resolved, we might need to complete the following:
- [ ] Add Tests for `LoremFlickr` on _test_lorem_flickr.rb_
- [ ] Replace `LoremPixel` with `LoremFlickr` [here](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/default/twitter.rb)
- [ ] Complete "TODOs"  [here](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/default/twitter.rb)

### Questions

I've added a couple tests to _test_lorem_flickr.rb_ as part of my first commit. Would it be wise to add more tests to cover the other public methods for `LoremFlickr` before we actually replace it?

A couple other stuff I don't fully understand - my apologies in advance:

1. What do we mean by "Make dimensions change" [here](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/default/twitter.rb#L26)?
2. What do we mean by "Dynamic image sizes" [here](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/default/twitter.rb#L180)?
3. What are the "indices" being referred to [here](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/default/twitter.rb#L181) and how are they defined?

Thanks! 😄 