### PR TITLE
Set true to `rubygems_mfa_required` gemspec metadata

### DIFF
--- a/faker.gemspec
+++ b/faker.gemspec
@@ -3,7 +3,6 @@
 $LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'faker/version'
 
-# rubocop:todo Gemspec/RequireMFA
 Gem::Specification.new do |spec|
   spec.name        = 'faker'
   spec.version     = Faker::VERSION
@@ -27,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.metadata['bug_tracker_uri'] = 'https://github.com/faker-ruby/faker/issues'
   spec.metadata['documentation_uri'] = 'https://rubydoc.info/github/faker-ruby/faker/master'
   spec.metadata['yard.run'] = 'yri'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   # Requires Ruby I18n 1.8.11 or higher to resolve https://github.com/faker-ruby/faker/issues/2330.
   spec.add_dependency('i18n', '>= 1.8.11', '< 2')
@@ -43,4 +43,3 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('timecop', '0.9.5')
   spec.add_development_dependency('yard', '0.9.27')
 end
-# rubocop:enable Gemspec/RequireMFA


### PR DESCRIPTION
This PR sets `true` to `rubygems_mfa_required` gemspec metadata. It's important for security. Please note that MFA will be required upon release.
https://guides.rubygems.org/setting-up-multifactor-authentication/

cc @vbrazo 