### PR TITLE
Fix `fma_brotherhood` usage example

### DIFF
--- a/doc/japanese_media/fullmetal_alchemist_brotherhood.md
+++ b/doc/japanese_media/fullmetal_alchemist_brotherhood.md
@@ -5,5 +5,5 @@ Faker::JapaneseMedia::FmaBrotherhood.character #=> "Edward Elric"
 
 Faker::JapaneseMedia::FmaBrotherhood.city #=> "Central City"
 
-Faker::JapaneseMedia::fma_brotherhood.country #=> "Xing"
+Faker::JapaneseMedia::FmaBrotherhood.country #=> "Xing"
 ```


### PR DESCRIPTION
### Summary

The usage example written in the readme was wrong, so I fixed it.

```ruby
pry(main)> Faker::JapaneseMedia.fma_brotherhood.country
NoMethodError: undefined method `fma_brotherhood' for Faker::JapaneseMedia:Class

pry(main)> Faker::JapaneseMedia::FmaBrotherhood.country
=> "Aerugo"
```