### PR TITLE
Remove unneeded require in lib/faker.rb

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -4,7 +4,6 @@ mydir = __dir__
 
 require 'psych'
 require 'i18n'
-require 'set' # Fixes a bug in i18n 0.6.11
 
 Dir.glob(File.join(mydir, 'helpers', '*.rb')).sort.each { |file| require file }
 


### PR DESCRIPTION
### Summary

The version of the dependency [i18n](https://github.com/faker-ruby/faker/blob/f54db334a271b22121e54de77a3a231b5f3c4ca9/faker.gemspec#L31-L32) has to be at least 1.8.11, so this `require` can be safely removed.

Fixes Issue #2524