### PR TITLE
Issue-2464: Add color luminosity options

### DIFF
--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -17,7 +17,7 @@ module Faker
       # @example
       #   Faker::Color.hex_color(:dark) #=> "#665500"
       #
-      # @faker.version 1.5.0
+      # @faker.version next
       def hex_color(lightness = nil)
         lightness_lookup = { light: 0.8, dark: 0.2 }
         hsl_to_hex(hsl_color(lightness: lightness_lookup[lightness]))
@@ -66,7 +66,7 @@ module Faker
       # @example
       #   Faker::Color.hsl_color(lightness: 0.6) #=> [69.87, 0.66, 0.6]
       #
-      # @faker.version 1.5.0
+      # @faker.version next
       def hsl_color(lightness: nil)
         [sample((0..360).to_a), rand.round(2), lightness || rand.round(2)]
       end

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -9,13 +9,17 @@ module Faker
       }.freeze
       ##
       # Produces a hex color code.
+      # Clients are able to specify the hue, saturation, or lightness of the required color.
+      # Alternatively a client can simply specify that they need a light or dark color.
       #
-      # @param args [Symbol] Allows the client to specify light or dark colors
+      # @param args [Hash, Symbol] Allows the client to specify what color should be return
       #
       # @return [String]
       #
       # @example
       #   Faker::Color.hex_color #=> "#31a785"
+      # @example
+      #   Faker::Color.hex_color(hue: 118, saturation: 1,lightness: 0.53) #=> "#048700"
       # @example
       #   Faker::Color.hex_color(:light) #=> "#FFEE99"
       # @example
@@ -25,6 +29,7 @@ module Faker
       def hex_color(args = nil)
         hsl_hash = {}
         hsl_hash = { lightness: LIGHTNESS_LOOKUP[args] } if %i[dark light].include?(args)
+        hsl_hash = args if args.is_a?(Hash)
         hsl_to_hex(hsl_color(**hsl_hash))
       end
 

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -10,7 +10,7 @@ module Faker
       ##
       # Produces a hex color code.
       #
-      # @param lightness [Symbol] Allows the client to specify light or dark colors
+      # @param args [Symbol] Allows the client to specify light or dark colors
       #
       # @return [String]
       #
@@ -22,9 +22,9 @@ module Faker
       #   Faker::Color.hex_color(:dark) #=> "#665500"
       #
       # @faker.version next
-      def hex_color(lightness = nil)
+      def hex_color(args = nil)
         hsl_hash = {}
-        hsl_hash = { lightness: LIGHTNESS_LOOKUP[lightness] } if %i[dark light].include?(lightness)
+        hsl_hash = { lightness: LIGHTNESS_LOOKUP[args] } if %i[dark light].include?(args)
         hsl_to_hex(hsl_color(**hsl_hash))
       end
 

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -19,7 +19,7 @@ module Faker
       # @example
       #   Faker::Color.hex_color #=> "#31a785"
       # @example
-      #   Faker::Color.hex_color(hue: 118, saturation: 1,lightness: 0.53) #=> "#048700"
+      #   Faker::Color.hex_color(hue: 118, saturation: 1, lightness: 0.53) #=> "#048700"
       # @example
       #   Faker::Color.hex_color(:light) #=> "#FFEE99"
       # @example

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -51,14 +51,17 @@ module Faker
       # Produces an array of floats representing an HSL color.
       # The array is in the form of `[hue, saturation, lightness]`.
       #
+      # @param lightness [Float] Value to use for lightness
       # @return [Array(Float, Float, Float)]
       #
       # @example
       #   Faker::Color.hsl_color #=> [69.87, 0.66, 0.3]
+      # @example
+      #   Faker::Color.hsl_color(lightness: 0.6) #=> [69.87, 0.66, 0.6]
       #
       # @faker.version 1.5.0
-      def hsl_color
-        [sample((0..360).to_a), rand.round(2), rand.round(2)]
+      def hsl_color(lightness: nil)
+        [sample((0..360).to_a), rand.round(2), lightness || rand.round(2)]
       end
 
       ##

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -6,14 +6,21 @@ module Faker
       ##
       # Produces a hex color code.
       #
+      # @param lightness [Symbol] Allows the client to specify light or dark colors
+      #
       # @return [String]
       #
       # @example
       #   Faker::Color.hex_color #=> "#31a785"
+      # @example
+      #   Faker::Color.hex_color(:light) #=> "#FFEE99"
+      # @example
+      #   Faker::Color.hex_color(:dark) #=> "#665500"
       #
       # @faker.version 1.5.0
-      def hex_color
-        hsl_to_hex(hsl_color)
+      def hex_color(lightness = nil)
+        lightness_lookup = { light: 0.8, dark: 0.2 }
+        hsl_to_hex(hsl_color(lightness: lightness_lookup[lightness]))
       end
 
       ##

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -23,7 +23,9 @@ module Faker
       #
       # @faker.version next
       def hex_color(lightness = nil)
-        hsl_to_hex(hsl_color(lightness: LIGHTNESS_LOOKUP[lightness]))
+        hsl_hash = {}
+        hsl_hash = { lightness: LIGHTNESS_LOOKUP[lightness] } if %i[dark light].include?(lightness)
+        hsl_to_hex(hsl_color(**hsl_hash))
       end
 
       ##

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -13,7 +13,7 @@ module Faker
       #
       # @faker.version 1.5.0
       def hex_color
-        format('#%06x', (rand * 0xffffff))
+        hsl_to_hex(hsl_color)
       end
 
       ##
@@ -76,6 +76,46 @@ module Faker
       # @faker.version 1.5.0
       def hsla_color
         hsl_color << rand.round(1)
+      end
+
+      private
+
+      ##
+      # Produces a hex code representation of an HSL color
+      #
+      # @param a_hsl_color [Array(Float, Float, Float)] The array that represents the HSL color
+      #
+      # @return [String]
+      #
+      # @example
+      #   hsl_to_hex([50, 100,80]) #=> #FFEE99
+      #
+      # @see https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB
+      # @see https://github.com/jpmckinney/color-generator/blob/master/lib/color-generator.rb
+      #
+      def hsl_to_hex(a_hsl_color)
+        h, s, l = a_hsl_color
+        c = (1 - (2 * l - 1).abs) * s
+        h_prime = h / 60
+        x = c * (1 - (h_prime % 2 - 1).abs)
+        m = l - 0.5 * c
+
+        rgb = case h_prime.to_i
+              when 0 # 0 <= H' < 1
+                [c, x, 0]
+              when 1 # 1 <= H' < 2
+                [x, c, 0]
+              when 2 # 2 <= H' < 3
+                [0, c, x]
+              when 3 # 3 <= H' < 4
+                [0, x, c]
+              when 4 # 4 <= H' < 5
+                [x, 0, c]
+              else # 5 <= H' < 6
+                [c, 0, x]
+              end.map { |value| ((value + m) * 255).round }
+
+        format('#%02x%02x%02x', rgb[0], rgb[1], rgb[2])
       end
     end
   end

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -3,6 +3,10 @@
 module Faker
   class Color < Base
     class << self
+      LIGHTNESS_LOOKUP = {
+        light: 0.8,
+        dark: 0.2
+      }.freeze
       ##
       # Produces a hex color code.
       #
@@ -19,8 +23,7 @@ module Faker
       #
       # @faker.version next
       def hex_color(lightness = nil)
-        lightness_lookup = { light: 0.8, dark: 0.2 }
-        hsl_to_hex(hsl_color(lightness: lightness_lookup[lightness]))
+        hsl_to_hex(hsl_color(lightness: LIGHTNESS_LOOKUP[lightness]))
       end
 
       ##

--- a/lib/faker/default/color.rb
+++ b/lib/faker/default/color.rb
@@ -58,17 +58,28 @@ module Faker
       # Produces an array of floats representing an HSL color.
       # The array is in the form of `[hue, saturation, lightness]`.
       #
-      # @param lightness [Float] Value to use for lightness
+      # @param hue [FLoat] Optional value to use for hue
+      # @param saturation [Float] Optional value to use for saturation
+      # @param lightness [Float] Optional value to use for lightness
       # @return [Array(Float, Float, Float)]
       #
       # @example
       #   Faker::Color.hsl_color #=> [69.87, 0.66, 0.3]
       # @example
+      #   Faker::Color.hsl_color(hue: 70, saturation: 0.5, lightness: 0.8) #=> [70, 0.5, 0.8]
+      # @example
+      #   Faker::Color.hsl_color(hue: 70) #=> [70, 0.66, 0.6]
+      # @example
+      #   Faker::Color.hsl_color(saturation: 0.2) #=> [54, 0.2, 0.3]
+      # @example
       #   Faker::Color.hsl_color(lightness: 0.6) #=> [69.87, 0.66, 0.6]
       #
       # @faker.version next
-      def hsl_color(lightness: nil)
-        [sample((0..360).to_a), rand.round(2), lightness || rand.round(2)]
+      def hsl_color(hue: nil, saturation: nil, lightness: nil)
+        valid_hue = hue || sample((0..360).to_a)
+        valid_saturation = saturation&.clamp(0, 1) || rand.round(2)
+        valid_lightness = lightness&.clamp(0, 1) || rand.round(2)
+        [valid_hue, valid_saturation, valid_lightness]
       end
 
       ##

--- a/test/faker/default/test_faker_color.rb
+++ b/test/faker/default/test_faker_color.rb
@@ -15,6 +15,20 @@ class TestFakerColor < Test::Unit::TestCase
     assert_match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, @tester.hex_color)
   end
 
+  # @see https://www.rapidtables.com/convert/color/rgb-to-hsl.html
+  def helper_hex_lightness(hex_color)
+    result = hex_color.scan(/([A-Fa-f0-9]{2})/).flatten.map { |x| x.hex / 255.0 }
+    (result.max + result.min) / 2
+  end
+
+  def test_hex_color_light
+    assert_in_delta(0.8, helper_hex_lightness(@tester.hex_color(:light)))
+  end
+
+  def test_hex_color_dark
+    assert_in_delta(0.2, helper_hex_lightness(@tester.hex_color(:dark)))
+  end
+
   def test_single_rgb_color
     assert @tester.single_rgb_color.between?(0, 255)
   end

--- a/test/faker/default/test_faker_color.rb
+++ b/test/faker/default/test_faker_color.rb
@@ -29,6 +29,19 @@ class TestFakerColor < Test::Unit::TestCase
     assert_in_delta(0.2, helper_hex_lightness(@tester.hex_color(:dark)))
   end
 
+  def test_hex_color_with_hash_is_passed_to_hsl_color
+    mock_hsl_color = lambda do |args|
+      assert_equal(100, args[:hue])
+      assert_in_delta(0.2, args[:saturation])
+      assert_in_delta(0.8, args[:lightness])
+      [args[:hue], args[:saturation], args[:lightness]]
+    end
+    @tester.stub :hsl_color, mock_hsl_color do
+      result = @tester.hex_color(hue: 100, saturation: 0.2, lightness: 0.8)
+      assert_match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, result)
+    end
+  end
+
   def test_single_rgb_color
     assert @tester.single_rgb_color.between?(0, 255)
   end

--- a/test/faker/default/test_faker_color.rb
+++ b/test/faker/default/test_faker_color.rb
@@ -54,7 +54,7 @@ class TestFakerColor < Test::Unit::TestCase
 
   def test_hsl_color_with_a_speficied_lightness
     @result = @tester.hsl_color(lightness: 0.5)
-    assert_equal(0.5, @result[2])
+    assert_in_delta(0.5, @result[2])
   end
 
   def test_hsla_color

--- a/test/faker/default/test_faker_color.rb
+++ b/test/faker/default/test_faker_color.rb
@@ -38,6 +38,11 @@ class TestFakerColor < Test::Unit::TestCase
     assert @result[2].between?(0.0, 1.0)
   end
 
+  def test_hsl_color_with_a_speficied_lightness
+    @result = @tester.hsl_color(lightness: 0.5)
+    assert_equal(0.5, @result[2])
+  end
+
   def test_hsla_color
     @result = @tester.hsla_color
     assert_equal(4, @result.length)

--- a/test/faker/default/test_faker_color.rb
+++ b/test/faker/default/test_faker_color.rb
@@ -52,9 +52,29 @@ class TestFakerColor < Test::Unit::TestCase
     assert @result[2].between?(0.0, 1.0)
   end
 
+  def test_hsl_color_with_a_speficied_hue
+    @result = @tester.hsl_color(hue: 5)
+    assert_in_delta(5, @result[0])
+  end
+
+  def test_hsl_color_with_a_speficied_saturation
+    @result = @tester.hsl_color(saturation: 0.35)
+    assert_in_delta(0.35, @result[1])
+  end
+
+  def test_hsl_color_with_a_speficied_but_invalid_saturation
+    @result = @tester.hsl_color(saturation: 3.05)
+    assert_in_delta(1, @result[1])
+  end
+
   def test_hsl_color_with_a_speficied_lightness
     @result = @tester.hsl_color(lightness: 0.5)
     assert_in_delta(0.5, @result[2])
+  end
+
+  def test_hsl_color_with_a_speficied_but_invalid_lightness
+    @result = @tester.hsl_color(lightness: -2.5)
+    assert_in_delta(0, @result[2])
   end
 
   def test_hsla_color


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull request.

Were there any bugs you had fixed? If so, mention them: Fixes Issue #add-issue-number -->

Closes: https://github.com/faker-ruby/faker/issues/2464

We added 3 new config options.

1. Ability to specify `light` or `dark` a hex color.
2. Ability to specify `hue`, `saturation` or `lightness` when generating a hex color.
3. Ability to specify `hue`, `saturation` or `lightness` when generating an HSL color.

The change to the HSL color generator enables us to easily generate a light / dark color since the lightness (In HSL) directly affect the color's luminosity. 

We added a private method (not directly tested) that converts and HSL value into a HEX color value.
The conversion algorithm was heavily inspired by:

- https://github.com/jpmckinney/color-generator/blob/e4ffecf799ec475878ed34533f3d6dc7b4ed0362/lib/color-generator.rb#L97-L115
- https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB

The original issue suggested we implement it as follows:
- `Faker::Color.hex_color(luminosity: 'dark')`
- `Faker::Color.hex_color(luminosity: 'light')`

Instead I implemented with a slightly less verbose syntax, but I am open to changing it.
- `Faker::Color.hex_color(:dark)` -> generates a color with lightness set to 20%
- `Faker::Color.hex_color(:light)`-> generates a color with lightness set to 80%

A side effect of this change is that you can now also (optionally) provide a specific HSL values when generating a hex or hsl color.

- `Faker::Color.hex_color(hue: 100, saturation: 0.52, lightness: 0.3)` will generate the specified color.
- `Faker::Color.hsl_color(hue: 100, saturation: 0.52, lightness: 0.3)` will generate the specified color.

### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

If you are creating a new generator, share how you are going to use it. Use cases are important to make sure that our faker generators are useful. Also, add `@faker.version next` to help users know when a generator was added. See [this example](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/music/opera.rb#L68).

Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/master/CONTRIBUTING.md#documentation).

Thanks for contributing to Faker! -->

If you would like to manually verify that the generated color is light/dark.

1. Output the generated value with something like this: `puts @tester.hex_color(:light)`
2. Then insert the generated hex value here: https://colordesigner.io/convert/hextohsl
4. Confirm that the color is light (with a lightness of 80% / 0.8)
5. Similar process can be followed for `:dark: colors.
6. Generate a new hex_color, by specifying the hue, saturation or lightness - use this color picker to confirm that the generated color is correct: https://duckduckgo.com/?q=color+picker+%23ee54f8&atb=v341-3&ia=answer
7. Generate a new hsl_color, by specifying the hue, saturation or lightness - use this color picker to confirm that the generated color is correct: https://duckduckgo.com/?q=color+picker+%23ee54f8&atb=v341-3&ia=answer