### PR TITLE
Fix typo abreviation -> abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1167,7 +1167,7 @@ Version 2 has several `breaking changes`. We replaced positional arguments with 
 - `Faker::Types.rb_integer(from = nil, to = nil)` becomes `Faker::Types.rb_integer(from: nil, to: nil)`
 - `Faker::Types.rb_string(words = nil)` becomes `Faker::Types.rb_string(words: nil)`
 - `Faker::Vehicle.kilometrage(min = nil, max = nil)` becomes `Faker::Vehicle.kilometrage(min: nil, max: nil)`
-- `Faker::Vehicle.license_plate(state_abreviation = nil)` becomes `Faker::Vehicle.license_plate(state_abreviation: nil)`
+- `Faker::Vehicle.license_plate(state_abbreviation = nil)` becomes `Faker::Vehicle.license_plate(state_abbreviation: nil)`
 - `Faker::Vehicle.mileage(min = nil, max = nil)` becomes `Faker::Vehicle.mileage(min: nil, max: nil)`
 - `Faker::Vehicle.model(make_of_model = nil)` becomes `Faker::Vehicle.model(make_of_model: nil)`
 - `Faker::WorldCup.group(group = nil)` becomes `Faker::WorldCup.group(group: nil)`

--- a/doc/default/vehicle.md
+++ b/doc/default/vehicle.md
@@ -67,9 +67,9 @@ Faker::Vehicle.mileage(min: 50_000, max: 250_000) #=> 117503
 Faker::Vehicle.kilometrage #=> 35378
 
 # Random vehicle license plate (USA by default)
-# Keyword arguments: state_abreviation
+# Keyword arguments: state_abbreviation
 Faker::Vehicle.license_plate #=> "DEP-2483"
-Faker::Vehicle.license_plate(state_abreviation: 'FL') #=> "977 UNU"
+Faker::Vehicle.license_plate(state_abbreviation: 'FL') #=> "977 UNU"
 
 # Random vehicle license plate for Singapore (if locale is set)
 Faker::Vehicle.singapore_license_plate #=> "SLV1854M"

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -271,9 +271,9 @@ module Faker
       #   Faker::Vehicle.license_plate(state_abbreviation: 'FL') #=> "977 UNU"
       #
       # @faker.version 1.6.4
-      def license_plate(legacy_state_abreviation = NOT_GIVEN, state_abbreviation: '')
+      def license_plate(legacy_state_abbreviation = NOT_GIVEN, state_abbreviation: '')
         warn_for_deprecated_arguments do |keywords|
-          keywords << :state_abbreviation if legacy_state_abreviation != NOT_GIVEN
+          keywords << :state_abbreviation if legacy_state_abbreviation != NOT_GIVEN
         end
 
         return regexify(bothify(fetch('vehicle.license_plate'))) if state_abbreviation.empty?


### PR DESCRIPTION
### Summary

Abbreviation was spelled incorrectly in several places across the repo.

The only changes in this pull request are Find + Replace abreviation -> abbreviation

### Other Information

Thanks for maintaining this library!