### PR TITLE
Remove outdated comment from development dependencies

### DIFF
--- a/faker.gemspec
+++ b/faker.gemspec
@@ -28,9 +28,7 @@ Gem::Specification.new do |spec|
   spec.metadata['yard.run'] = 'yri'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  # Requires Ruby I18n 1.8.11 or higher to resolve https://github.com/faker-ruby/faker/issues/2330.
   spec.add_dependency('i18n', '>= 1.8.11', '< 2')
-
   spec.add_development_dependency('minitest', '5.16.3')
   spec.add_development_dependency('pry', '0.14.1')
   spec.add_development_dependency('rake', '13.0.6')

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -4,7 +4,6 @@ mydir = __dir__
 
 require 'psych'
 require 'i18n'
-require 'set' # Fixes a bug in i18n 0.6.11
 
 Dir.glob(File.join(mydir, 'helpers', '*.rb')).sort.each { |file| require file }
 


### PR DESCRIPTION
### Summary

Second part of #2524.

This comment is outdated and can be removed. This marks the end of #2522 where the goal is to keep Faker updated.