### PR TITLE
Remove mentions to `master` and use `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -25,7 +25,7 @@ gemfile(true) do
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
+  gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main'
   gem "minitest"
 end
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ Were there any bugs you had fixed? If so, mention them: Fixes Issue #add-issue-n
 
 If you are creating a new generator, share how you are going to use it. Use cases are important to make sure that our faker generators are useful. Also, add `@faker.version next` to help users know when a generator was added. See [this example](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/music/opera.rb#L68).
 
-Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/master/CONTRIBUTING.md#documentation).
+Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).
 
 Thanks for contributing to Faker! -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,11 @@ We love pull requests. Here's a quick guide:
 
 For those of you with commit access, please check out Scott Chacon's blog post about [github flow](http://scottchacon.com/2011/08/31/github-flow.html)
 
-> * Anything in the master branch is deployable
-> * To work on something new, create a descriptively named branch off of master (ie: new-oauth2-scopes)
+> * Anything in the main branch is deployable
+> * To work on something new, create a descriptively named branch off of main (ie: new-oauth2-scopes)
 > * Commit to that branch locally and regularly push your work to the same named branch on the server
 > * When you need feedback or help, or you think the branch is ready for merging, open a pull request
-> * After someone else has reviewed and signed off on the feature, you can merge it into master
+> * After someone else has reviewed and signed off on the feature, you can merge it into main
 
 If you're reviewing a PR, you should ask yourself:
 > * Does it work as described? A PR should have a great description.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Faker
 [![Tests](https://github.com/faker-ruby/faker/workflows/Tests/badge.svg)](https://github.com/faker-ruby/faker/actions?query=workflow%3ATests)
 [![Gem Version](https://badge.fury.io/rb/faker.svg)](https://badge.fury.io/rb/faker)
-[![Inline docs](https://inch-ci.org/github/faker-ruby/faker.svg?branch=master)](https://inch-ci.org/github/faker-ruby/faker)
+[![Inline docs](https://inch-ci.org/github/faker-ruby/faker.svg?branch=main)](https://inch-ci.org/github/faker-ruby/faker)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/ef54c7f9df86e965d64b/test_coverage)](https://codeclimate.com/github/stympy/faker/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/ef54c7f9df86e965d64b/maintainability)](https://codeclimate.com/github/stympy/faker/maintainability)
 
@@ -44,7 +44,7 @@ development.
 * While Faker generates data at random, returned values are not guaranteed to be unique by default.
   You must explicitly specify when you require unique values, see [details](#ensuring-unique-values).
   Values also can be deterministic if you use the deterministic feature, see [details](#deterministic-random)
-* This is the `master` branch of Faker and may contain changes that are not yet released.
+* This is the `main` branch of Faker and may contain changes that are not yet released.
   Please refer the README of your version for the available methods.
   List of all versions is [available here](https://github.com/stympy/faker/releases).
 
@@ -55,7 +55,7 @@ gem install faker
 Note: if you are getting a `uninitialized constant Faker::[some_class]` error, your version of the gem is behind the one documented here. To make sure that your gem is the one documented here, change the line in your Gemfile to:
 
 ```ruby
-gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
+gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main'
 ```
 
 ## Usage
@@ -117,7 +117,7 @@ Faker::Company.bs #=> "cultivate viral synergies"
 **NOTE: Some of the generators below aren't released yet. If you want to use them, change the line in your gemfile to:**
 
 ```ruby
-gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
+gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main'
 ```
 
 ### Default
@@ -400,7 +400,7 @@ en-au-ocker:
 ```
 
 ## Contributing
-See [CONTRIBUTING.md](https://github.com/stympy/faker/blob/master/CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/stympy/faker/blob/main/CONTRIBUTING.md).
 
 ## Contact
 Comments and feedback are welcome. Send an email to Benjamin Curtis via the [google group](http://groups.google.com/group/ruby-faker).

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.7'
 
-  spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/master/CHANGELOG.md'
+  spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/main/CHANGELOG.md'
   spec.metadata['source_code_uri'] = 'https://github.com/faker-ruby/faker'
   spec.metadata['bug_tracker_uri'] = 'https://github.com/faker-ruby/faker/issues'
-  spec.metadata['documentation_uri'] = 'https://rubydoc.info/github/faker-ruby/faker/master'
+  spec.metadata['documentation_uri'] = 'https://rubydoc.info/github/faker-ruby/faker'
   spec.metadata['yard.run'] = 'yri'
   spec.metadata['rubygems_mfa_required'] = 'true'
 


### PR DESCRIPTION
The industry standard is to stop using `master` and use `main` instead. Faker is following this standard now and we need to reflect that in our documentation.

Thank you @vbrazo for renaming it :+1: 