### PR TITLE
change mccree to cassidy. update or remove references to mccree/jesse

### DIFF
--- a/lib/locales/en/overwatch.yml
+++ b/lib/locales/en/overwatch.yml
@@ -8,13 +8,13 @@ en:
           - Baptiste
           - Bastion
           - Brigitte
+          - Cassidy
           - D.va
           - Doomfist
           - Genji
           - Hanzo
           - Junkrat
           - Lucio
-          - McCree
           - Mei
           - Mercy
           - Moira
@@ -265,9 +265,8 @@ en:
           - No one likes a squealer
           - Ready for the fireworks
           - You that sound like a bad thing
-          - Brave of you to show your face around here, Jesse
+          - Brave of you to show your face around here, Cole
           - On the dartboard
-          - What did you do with it Jesse
           - Too competent
           - Ultimate - Light Em Up
           - Ultimate - Vide Bal Sou Yo
@@ -1048,7 +1047,7 @@ en:
           - Bastion, you would make the perfect research assistant
           - Youre just no good bully
           - Look somewhere else
-          - Hey, McCree, do you know what time it is
+          - Hey, Cole, do you know what time it is
           - I love your glasses, so cute!
           - We should compare notes some time
           - Zarya How can you even pick up all that weight
@@ -1340,7 +1339,6 @@ en:
           - Target Eliminated
           - Final Blow - You Got Served
           - Sorry, Reinhardt
-          - "(vs McCree) Got you this time, Jesse"
           - You made a tactical error
           - I Always Get My Prey
           - Operating At Maximum Efficiency
@@ -1393,7 +1391,7 @@ en:
           - Try me
           - Then I have nothing to worry about
           - I always dreamed of the day we would fight together
-          - McCree, where did you learn to shoot like that
+          - Cassidy, where did you learn to shoot like that?
           - See you in the air
           - I had a poster of you on my wall when I was younger
           - I lost many good soldiers here
@@ -1897,7 +1895,7 @@ en:
           - If you hold the information, you hold all the cards
           - You trying to be scary
           - I can be nice
-          - Pleasure working with you McCree. If that is your real name
+          - Pleasure working with you, Cassidy... if that is your real name
           - So what are we doing here, boss
           - What can I say. A girl just has to have the latest tech
           - Your friend, Katya Volskaya. What will you say when you learn the truth


### PR DESCRIPTION
### Summary

Update Overwatch generator to change character Jesse McCree to Cole Cassidy. Also remove or update all voicelines/quotes that reference "Jesse" or "McCree".

### Other Information

Overwatch developer Blizzard made these changes after the real-life employee who this character was named after was named in allegations of sexual harassment and discrimination toward women at Blizzard. See more here: https://dotesports.com/overwatch/news/overwatch-removes-most-voice-lines-that-include-the-name-jesse-mccree