### PR TITLE
Deprecate LoremPixel

### DIFF
--- a/lib/faker/default/lorem_pixel.rb
+++ b/lib/faker/default/lorem_pixel.rb
@@ -55,7 +55,7 @@ module Faker
         # url_parts += [category, number, text].compact
         # url_parts.join('/')
         warn 'DEPRECATED, LoremPixel is going to be removed in the next release. Please use Faker::LoremFlickr instead.'
-        LoremFlickr.image(size: '300x300', search_terms: [category, number, text], match_all: false)
+        LoremFlickr.image(size: size, search_terms: [category, number, text], match_all: false)
       end
       # rubocop:enable Metrics/ParameterLists
     end

--- a/lib/faker/default/lorem_pixel.rb
+++ b/lib/faker/default/lorem_pixel.rb
@@ -55,7 +55,7 @@ module Faker
         # url_parts += [category, number, text].compact
         # url_parts.join('/')
         warn 'DEPRECATED, LoremPixel is going to be removed in the next release. Please use Faker::LoremFlickr instead.'
-        LoremFlickr.image(size: '300x300', search_terms: [], match_all: false)
+        LoremFlickr.image(size: '300x300', search_terms: [category, number, text], match_all: false)
       end
       # rubocop:enable Metrics/ParameterLists
     end

--- a/lib/faker/default/lorem_pixel.rb
+++ b/lib/faker/default/lorem_pixel.rb
@@ -4,7 +4,6 @@ module Faker
   class LoremPixel < Base
     class << self
       extend Gem::Deprecate
-      singleton_methods(false).each { |method| deprecate(method, 'LoremFlickr') }
 
       SUPPORTED_CATEGORIES = %w[abstract
                                 animals
@@ -45,7 +44,6 @@ module Faker
       #
       # @faker.version 1.7.0
       def image(size: '300x300', is_gray: false, category: nil, number: nil, text: nil, secure: true)
-        warn 'DEPRECATED, LoremPixel is going to be removed in the next release. Please use Faker::LoremFlickr instead.'
         raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
         raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
         raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?
@@ -59,6 +57,7 @@ module Faker
         url_parts += [category, number, text].compact
         url_parts.join('/')
       end
+      deprecate :image, 'Faker::LoremFlickr.image', 2022, 12
       # rubocop:enable Metrics/ParameterLists
     end
   end

--- a/lib/faker/default/lorem_pixel.rb
+++ b/lib/faker/default/lorem_pixel.rb
@@ -3,6 +3,9 @@
 module Faker
   class LoremPixel < Base
     class << self
+      extend Gem::Deprecate
+      singleton_methods(false).each { |method| deprecate(method, 'LoremFlickr') }
+
       SUPPORTED_CATEGORIES = %w[abstract
                                 animals
                                 business
@@ -42,20 +45,19 @@ module Faker
       #
       # @faker.version 1.7.0
       def image(size: '300x300', is_gray: false, category: nil, number: nil, text: nil, secure: true)
-        # raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
-        # raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
-        # raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?
-        # raise ArgumentError, 'Number must be between 1 and 10' unless number.nil? || (1..10).cover?(number)
-        # raise ArgumentError, 'Category and number must be passed when text is passed' if !text.nil? && number.nil? && category.nil?
-
-        # url_parts = secure ? ['https:/'] : ['http:/']
-        # url_parts << ['lorempixel.com']
-        # url_parts << 'g' if is_gray
-        # url_parts += size.split('x')
-        # url_parts += [category, number, text].compact
-        # url_parts.join('/')
         warn 'DEPRECATED, LoremPixel is going to be removed in the next release. Please use Faker::LoremFlickr instead.'
-        LoremFlickr.image(size: size, search_terms: [category, number, text], match_all: false)
+        raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
+        raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
+        raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?
+        raise ArgumentError, 'Number must be between 1 and 10' unless number.nil? || (1..10).cover?(number)
+        raise ArgumentError, 'Category and number must be passed when text is passed' if !text.nil? && number.nil? && category.nil?
+
+        url_parts = secure ? ['https:/'] : ['http:/']
+        url_parts << ['lorempixel.com']
+        url_parts << 'g' if is_gray
+        url_parts += size.split('x')
+        url_parts += [category, number, text].compact
+        url_parts.join('/')
       end
       # rubocop:enable Metrics/ParameterLists
     end

--- a/lib/faker/default/lorem_pixel.rb
+++ b/lib/faker/default/lorem_pixel.rb
@@ -42,18 +42,20 @@ module Faker
       #
       # @faker.version 1.7.0
       def image(size: '300x300', is_gray: false, category: nil, number: nil, text: nil, secure: true)
-        raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
-        raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
-        raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?
-        raise ArgumentError, 'Number must be between 1 and 10' unless number.nil? || (1..10).cover?(number)
-        raise ArgumentError, 'Category and number must be passed when text is passed' if !text.nil? && number.nil? && category.nil?
+        # raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
+        # raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
+        # raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?
+        # raise ArgumentError, 'Number must be between 1 and 10' unless number.nil? || (1..10).cover?(number)
+        # raise ArgumentError, 'Category and number must be passed when text is passed' if !text.nil? && number.nil? && category.nil?
 
-        url_parts = secure ? ['https:/'] : ['http:/']
-        url_parts << ['lorempixel.com']
-        url_parts << 'g' if is_gray
-        url_parts += size.split('x')
-        url_parts += [category, number, text].compact
-        url_parts.join('/')
+        # url_parts = secure ? ['https:/'] : ['http:/']
+        # url_parts << ['lorempixel.com']
+        # url_parts << 'g' if is_gray
+        # url_parts += size.split('x')
+        # url_parts += [category, number, text].compact
+        # url_parts.join('/')
+        warn 'DEPRECATED, LoremPixel is going to be removed in the next release. Please use Faker::LoremFlickr instead.'
+        LoremFlickr.image(size: '300x300', search_terms: [], match_all: false)
       end
       # rubocop:enable Metrics/ParameterLists
     end

--- a/test/faker/default/test_lorem_pixel.rb
+++ b/test/faker/default/test_lorem_pixel.rb
@@ -1,34 +1,17 @@
 # frozen_string_literal: true
 
 require_relative '../../test_helper'
-class FakeStdErr
-  attr_accessor :messages
-
-  def initialize
-    @messages = []
-  end
-
-  def write(msg)
-    @messages << msg
-  end
-end
 
 class TestLoremPixel < Test::Unit::TestCase
   def setup
     @tester = Faker::LoremPixel
   end
 
-  def test_deprecation_message
-    # rubocop:disable Style/GlobalVars
-    original_stderr = $stderr
-    fake_std_err    = FakeStdErr.new
-    $stderr         = fake_std_err
-    @tester.image
-    warn_message = 'NOTE: Faker::LoremPixel.image is deprecated; use Faker::LoremFlickr.image instead. It will be removed on or after 2022-12'
-    assert_includes(fake_std_err.messages[0], warn_message)
-  ensure
-    $std_err = original_stderr
-    # rubocop:enable Style/GlobalVars
+  def test_image_deprecation_message
+    _out, err = capture_output do
+      @tester.image(size: '3x3')
+    end
+    assert_match(/Faker::LoremPixel.image is deprecated; use Faker::LoremFlickr.image instead\./, err)
   end
 
   def test_lorempixel

--- a/test/faker/default/test_lorem_pixel.rb
+++ b/test/faker/default/test_lorem_pixel.rb
@@ -19,16 +19,16 @@ class TestLoremPixel < Test::Unit::TestCase
   end
 
   def test_deprecation_message
-    begin
-      original_stderr = $stderr
-      fake_std_err    = FakeStdErr.new
-      $stderr         = fake_std_err
-      @tester.image
-      warn_message = "NOTE: Faker::LoremPixel.image is deprecated; use Faker::LoremFlickr.image instead. It will be removed on or after 2022-12"
-      assert(fake_std_err.messages[0].include?(warn_message))
-    ensure
-      $std_err = original_stderr
-    end
+    # rubocop:disable Style/GlobalVars
+    original_stderr = $stderr
+    fake_std_err    = FakeStdErr.new
+    $stderr         = fake_std_err
+    @tester.image
+    warn_message = 'NOTE: Faker::LoremPixel.image is deprecated; use Faker::LoremFlickr.image instead. It will be removed on or after 2022-12'
+    assert_includes(fake_std_err.messages[0], warn_message)
+  ensure
+    $std_err = original_stderr
+    # rubocop:enable Style/GlobalVars
   end
 
   def test_lorempixel

--- a/test/faker/default/test_lorem_pixel.rb
+++ b/test/faker/default/test_lorem_pixel.rb
@@ -7,73 +7,65 @@ class TestLoremPixel < Test::Unit::TestCase
     @tester = Faker::LoremPixel
   end
 
-  def test_lorempixel_deprecation
-    assert_match %r{https://loremflickr.com/300/300}, @tester.image
+  def test_lorempixel
+    refute_nil @tester.image.match(%r{https://lorempixel\.com/(\d+/\d+)})[1]
   end
 
-  def test_lorempixel_options_conversion_to_loremflickr_search_terms
-    assert_match %r{https://loremflickr.com/300/400/sports,3,lebron}, @tester.image(size: '300x400', category: 'sports', number: 3, text: 'lebron')
+  def test_lorempixel_insecure
+    refute_nil @tester.image(size: '300x300', is_gray: nil, category: nil, number: nil, text: nil, secure: false).match(%r{http://lorempixel\.com/(\d+/\d+)})[1]
   end
 
-  # def test_lorempixel
-  #   refute_nil @tester.image.match(%r{https://lorempixel\.com/(\d+/\d+)})[1]
-  # end
+  def test_image_with_custom_size
+    assert_equal('3/3', @tester.image(size: '3x3').match(%r{https://lorempixel\.com/(\d+/\d+)})[1])
+  end
 
-  # def test_lorempixel_insecure
-  #   refute_nil @tester.image(size: '300x300', is_gray: nil, category: nil, number: nil, text: nil, secure: false).match(%r{http://lorempixel\.com/(\d+/\d+)})[1]
-  # end
+  def test_image_with_incorrect_size
+    assert_raise ArgumentError do
+      @tester.image(size: '300x300s')
+    end
+  end
 
-  # def test_image_with_custom_size
-  #   assert_equal('3/3', @tester.image(size: '3x3').match(%r{https://lorempixel\.com/(\d+/\d+)})[1])
-  # end
+  def test_image_gray
+    assert_match %r{https://lorempixel\.com/g/\d+/\d+}, @tester.image(size: '300x300', is_gray: true)
+  end
 
-  # def test_image_with_incorrect_size
-  #   assert_raise ArgumentError do
-  #     @tester.image(size: '300x300s')
-  #   end
-  # end
+  def test_image_with_supported_category
+    assert_equal('animals', @tester.image(size: '300x300', is_gray: false, category: 'animals').match(%r{https://lorempixel\.com/\d+/\d+/(.*)})[1])
+  end
 
-  # def test_image_gray
-  #   assert_match %r{https://lorempixel\.com/g/\d+/\d+}, @tester.image(size: '300x300', is_gray: true)
-  # end
+  def test_image_with_incorrect_category
+    assert_raise ArgumentError do
+      @tester.image(size: '300x300', is_gray: false, category: 'wrong_category')
+    end
+  end
 
-  # def test_image_with_supported_category
-  #   assert_equal('animals', @tester.image(size: '300x300', is_gray: false, category: 'animals').match(%r{https://lorempixel\.com/\d+/\d+/(.*)})[1])
-  # end
+  def test_image_with_supported_category_and_correct_number
+    assert_equal('3', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3).match(%r{https://lorempixel\.com/\d+/\d+/.+/(\d+)})[1])
+  end
 
-  # def test_image_with_incorrect_category
-  #   assert_raise ArgumentError do
-  #     @tester.image(size: '300x300', is_gray: false, category: 'wrong_category')
-  #   end
-  # end
+  def test_image_with_supported_category_and_incorrect_number
+    assert_raise ArgumentError do
+      @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 11)
+    end
+  end
 
-  # def test_image_with_supported_category_and_correct_number
-  #   assert_equal('3', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3).match(%r{https://lorempixel\.com/\d+/\d+/.+/(\d+)})[1])
-  # end
+  def test_image_with_correct_number_and_without_category
+    assert_raise ArgumentError do
+      @tester.image(size: '300x300', is_gray: false, category: 'wrong_category', number: 3)
+    end
+  end
 
-  # def test_image_with_supported_category_and_incorrect_number
-  #   assert_raise ArgumentError do
-  #     @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 11)
-  #   end
-  # end
+  def test_image_with_text_correct_number_and_supported_category
+    assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/3/(.+)})[1])
+  end
 
-  # def test_image_with_correct_number_and_without_category
-  #   assert_raise ArgumentError do
-  #     @tester.image(size: '300x300', is_gray: false, category: 'wrong_category', number: 3)
-  #   end
-  # end
+  def test_image_with_text_supported_category_and_text_without_number
+    assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: nil, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/(.+)})[1])
+  end
 
-  # def test_image_with_text_correct_number_and_supported_category
-  #   assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/3/(.+)})[1])
-  # end
-
-  # def test_image_with_text_supported_category_and_text_without_number
-  #   assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: nil, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/(.+)})[1])
-  # end
-
-  # def test_image_with_text_without_number_and_category
-  #   assert_raise ArgumentError do
-  #     @tester.image(size: '300x300', is_gray: false, category: nil, number: nil, text: 'Dummy-text')
-  #   end
-  # end
+  def test_image_with_text_without_number_and_category
+    assert_raise ArgumentError do
+      @tester.image(size: '300x300', is_gray: false, category: nil, number: nil, text: 'Dummy-text')
+    end
+  end
 end

--- a/test/faker/default/test_lorem_pixel.rb
+++ b/test/faker/default/test_lorem_pixel.rb
@@ -7,65 +7,73 @@ class TestLoremPixel < Test::Unit::TestCase
     @tester = Faker::LoremPixel
   end
 
-  def test_lorempixel
-    refute_nil @tester.image.match(%r{https://lorempixel\.com/(\d+/\d+)})[1]
+  def test_lorempixel_deprecation
+    assert_match %r{https://loremflickr.com/300/300}, @tester.image
   end
 
-  def test_lorempixel_insecure
-    refute_nil @tester.image(size: '300x300', is_gray: nil, category: nil, number: nil, text: nil, secure: false).match(%r{http://lorempixel\.com/(\d+/\d+)})[1]
+  def test_lorempixel_options_conversion_to_loremflickr_search_terms
+    assert_match %r{https://loremflickr.com/300/400/sports,3,lebron}, @tester.image(size: '300x400', category: 'sports', number: 3, text: 'lebron')
   end
 
-  def test_image_with_custom_size
-    assert_equal('3/3', @tester.image(size: '3x3').match(%r{https://lorempixel\.com/(\d+/\d+)})[1])
-  end
+  # def test_lorempixel
+  #   refute_nil @tester.image.match(%r{https://lorempixel\.com/(\d+/\d+)})[1]
+  # end
 
-  def test_image_with_incorrect_size
-    assert_raise ArgumentError do
-      @tester.image(size: '300x300s')
-    end
-  end
+  # def test_lorempixel_insecure
+  #   refute_nil @tester.image(size: '300x300', is_gray: nil, category: nil, number: nil, text: nil, secure: false).match(%r{http://lorempixel\.com/(\d+/\d+)})[1]
+  # end
 
-  def test_image_gray
-    assert_match %r{https://lorempixel\.com/g/\d+/\d+}, @tester.image(size: '300x300', is_gray: true)
-  end
+  # def test_image_with_custom_size
+  #   assert_equal('3/3', @tester.image(size: '3x3').match(%r{https://lorempixel\.com/(\d+/\d+)})[1])
+  # end
 
-  def test_image_with_supported_category
-    assert_equal('animals', @tester.image(size: '300x300', is_gray: false, category: 'animals').match(%r{https://lorempixel\.com/\d+/\d+/(.*)})[1])
-  end
+  # def test_image_with_incorrect_size
+  #   assert_raise ArgumentError do
+  #     @tester.image(size: '300x300s')
+  #   end
+  # end
 
-  def test_image_with_incorrect_category
-    assert_raise ArgumentError do
-      @tester.image(size: '300x300', is_gray: false, category: 'wrong_category')
-    end
-  end
+  # def test_image_gray
+  #   assert_match %r{https://lorempixel\.com/g/\d+/\d+}, @tester.image(size: '300x300', is_gray: true)
+  # end
 
-  def test_image_with_supported_category_and_correct_number
-    assert_equal('3', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3).match(%r{https://lorempixel\.com/\d+/\d+/.+/(\d+)})[1])
-  end
+  # def test_image_with_supported_category
+  #   assert_equal('animals', @tester.image(size: '300x300', is_gray: false, category: 'animals').match(%r{https://lorempixel\.com/\d+/\d+/(.*)})[1])
+  # end
 
-  def test_image_with_supported_category_and_incorrect_number
-    assert_raise ArgumentError do
-      @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 11)
-    end
-  end
+  # def test_image_with_incorrect_category
+  #   assert_raise ArgumentError do
+  #     @tester.image(size: '300x300', is_gray: false, category: 'wrong_category')
+  #   end
+  # end
 
-  def test_image_with_correct_number_and_without_category
-    assert_raise ArgumentError do
-      @tester.image(size: '300x300', is_gray: false, category: 'wrong_category', number: 3)
-    end
-  end
+  # def test_image_with_supported_category_and_correct_number
+  #   assert_equal('3', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3).match(%r{https://lorempixel\.com/\d+/\d+/.+/(\d+)})[1])
+  # end
 
-  def test_image_with_text_correct_number_and_supported_category
-    assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/3/(.+)})[1])
-  end
+  # def test_image_with_supported_category_and_incorrect_number
+  #   assert_raise ArgumentError do
+  #     @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 11)
+  #   end
+  # end
 
-  def test_image_with_text_supported_category_and_text_without_number
-    assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: nil, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/(.+)})[1])
-  end
+  # def test_image_with_correct_number_and_without_category
+  #   assert_raise ArgumentError do
+  #     @tester.image(size: '300x300', is_gray: false, category: 'wrong_category', number: 3)
+  #   end
+  # end
 
-  def test_image_with_text_without_number_and_category
-    assert_raise ArgumentError do
-      @tester.image(size: '300x300', is_gray: false, category: nil, number: nil, text: 'Dummy-text')
-    end
-  end
+  # def test_image_with_text_correct_number_and_supported_category
+  #   assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: 3, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/3/(.+)})[1])
+  # end
+
+  # def test_image_with_text_supported_category_and_text_without_number
+  #   assert_equal('Dummy-text', @tester.image(size: '300x300', is_gray: false, category: 'animals', number: nil, text: 'Dummy-text').match(%r{https://lorempixel\.com/\d+/\d+/.+/(.+)})[1])
+  # end
+
+  # def test_image_with_text_without_number_and_category
+  #   assert_raise ArgumentError do
+  #     @tester.image(size: '300x300', is_gray: false, category: nil, number: nil, text: 'Dummy-text')
+  #   end
+  # end
 end

--- a/test/faker/default/test_lorem_pixel.rb
+++ b/test/faker/default/test_lorem_pixel.rb
@@ -1,10 +1,34 @@
 # frozen_string_literal: true
 
 require_relative '../../test_helper'
+class FakeStdErr
+  attr_accessor :messages
+
+  def initialize
+    @messages = []
+  end
+
+  def write(msg)
+    @messages << msg
+  end
+end
 
 class TestLoremPixel < Test::Unit::TestCase
   def setup
     @tester = Faker::LoremPixel
+  end
+
+  def test_deprecation_message
+    begin
+      original_stderr = $stderr
+      fake_std_err    = FakeStdErr.new
+      $stderr         = fake_std_err
+      @tester.image
+      warn_message = "NOTE: Faker::LoremPixel.image is deprecated; use Faker::LoremFlickr.image instead. It will be removed on or after 2022-12"
+      assert(fake_std_err.messages[0].include?(warn_message))
+    ensure
+      $std_err = original_stderr
+    end
   end
 
   def test_lorempixel

--- a/test/faker/default/test_lorem_pixel.rb
+++ b/test/faker/default/test_lorem_pixel.rb
@@ -11,6 +11,7 @@ class TestLoremPixel < Test::Unit::TestCase
     _out, err = capture_output do
       @tester.image(size: '3x3')
     end
+
     assert_match(/Faker::LoremPixel.image is deprecated; use Faker::LoremFlickr.image instead\./, err)
   end
 


### PR DESCRIPTION
- [x] Add a deprecation warning that LoremPixel is going to be removed in the next release.
- [x] Add Tests for LoremPixel to confirm referral to LoremFlickr

When Faker::LoremPixel.image is called, user is warned that `NOTE: Faker::LoremPixel.image is deprecated; use Faker::LoremFlickr.image instead. It will be removed on or after 2022-12.`

@stefannibrasil

Corresponding issue #2505 