### PR TITLE
Fixes iban checksum calculation

### DIFF
--- a/lib/faker/default/bank.rb
+++ b/lib/faker/default/bank.rb
@@ -158,7 +158,7 @@ module Faker
       end
 
       # Calculates the mandatory checksum in 3rd and 4th characters in IBAN format
-      # source: https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
+      # source: https://en.wikipedia.org/wiki/International_Bank_Account_Number#Generating_IBAN_check_digits
       def iban_checksum(country_code, account)
         # Converts letters to numbers according the iban rules, A=10..Z=35
         account_to_number = "#{account}#{country_code}00".upcase.chars.map do |d|
@@ -166,7 +166,6 @@ module Faker
         end.join.to_i
 
         # This is the correct answer to (iban_to_num + checksum) % 97 == 1
-        # See steps 6 & 7 - https://en.wikipedia.org/wiki/International_Bank_Account_Number#Generating_IBAN_check_digits
         checksum = 98 - (account_to_number % 97)
 
         # Use leftpad to make the size always to 2

--- a/lib/faker/default/bank.rb
+++ b/lib/faker/default/bank.rb
@@ -165,8 +165,9 @@ module Faker
           d =~ /[A-Z]/ ? (d.ord - 55).to_s : d
         end.join.to_i
 
-        # This is answer to (iban_to_num + checksum) % 97 == 1
-        checksum = (1 - account_to_number) % 97
+        # This is the correct answer to (iban_to_num + checksum) % 97 == 1
+        # See steps 6 & 7 - https://en.wikipedia.org/wiki/International_Bank_Account_Number#Generating_IBAN_check_digits
+        checksum = 98 - (account_to_number % 97)
 
         # Use leftpad to make the size always to 2
         checksum.to_s.rjust(2, '0')

--- a/test/faker/default/test_faker_bank.rb
+++ b/test/faker/default/test_faker_bank.rb
@@ -73,6 +73,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ad')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{12}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # United Arab Emirates
@@ -80,6 +81,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ae')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}\d{19}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Albania
@@ -87,6 +89,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'al')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Austria
@@ -94,6 +97,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'at')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Azerbaijan, Republic of
@@ -101,6 +105,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'az')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Bosnia
@@ -108,6 +113,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ba')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Belgium
@@ -115,6 +121,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'be')
     assert_equal(16, account.length)
     assert_match(/^#{IBAN_HEADER}\d{12}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Bulgaria
@@ -122,6 +129,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'bg')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{6}[A-Z0-9]{8}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Bahrain
@@ -129,6 +137,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'bh')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{14}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Brazil
@@ -136,6 +145,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'br')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}[0-9]{8}[0-9]{5}[0-9]{10}[A-Z]{1}[A-Z0-9]{1}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Switzerland
@@ -143,6 +153,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ch')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Costa Rica
@@ -150,6 +161,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'cr')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}0\d{3}\d{14}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Cyprus
@@ -157,6 +169,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'cy')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Czech Republic
@@ -164,6 +177,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'cz')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Germany
@@ -171,6 +185,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'de')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}\d{18}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Denmark
@@ -178,6 +193,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'dk')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Dominican Republic
@@ -185,6 +201,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'do')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Estonia
@@ -192,6 +209,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ee')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Spain
@@ -199,6 +217,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'es')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Finland
@@ -206,6 +225,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'fi')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Faroe Islands
@@ -213,20 +233,27 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'fo')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # France
   def test_iban_fr
-    account = @tester.iban(country_code: 'fr')
-    assert_equal(27, account.length)
-    assert_match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/, account)
+    100.times do
+      account = @tester.iban(country_code: 'fr')
+      assert_equal(27, account.length)
+      assert_match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/, account)
+      assert iban_checksum(account), 'IBAN checksum is invalid'
+    end
   end
 
   # United Kingdom
   def test_iban_gb
-    account = @tester.iban(country_code: 'gb')
-    assert_equal(22, account.length)
-    assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/, account)
+    100.times do
+      account = @tester.iban(country_code: 'gb')
+      assert_equal(22, account.length)
+      assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/, account)
+      assert iban_checksum(account), 'IBAN checksum is invalid'
+    end
   end
 
   # Georgia
@@ -234,6 +261,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ge')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{2}\d{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Gibraltar
@@ -241,6 +269,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gi')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{15}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Greenland
@@ -248,6 +277,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gl')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Greece
@@ -255,6 +285,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gr')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}\d{7}[A-Z0-9]{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Guatemala
@@ -262,6 +293,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gt')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z0-9]{4}\d{2}\d{2}[A-Z0-9]{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Croatia
@@ -269,6 +301,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'hr')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}\d{17}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Hungary
@@ -276,6 +309,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'hu')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{24}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Ireland
@@ -283,6 +317,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ie')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Israel
@@ -290,6 +325,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'il')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}\d{19}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Iceland
@@ -297,6 +333,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'is')
     assert_equal(26, account.length)
     assert_match(/^#{IBAN_HEADER}\d{22}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Italy
@@ -304,6 +341,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'it')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Kuwait
@@ -311,6 +349,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'kw')
     assert_equal(30, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{22}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Kazakhstan
@@ -318,6 +357,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'kz')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}[0-9]{3}[A-Z0-9]{13}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Lebanon
@@ -325,6 +365,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lb')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{4}[A-Z0-9]{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Liechtenstein
@@ -332,6 +373,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'li')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Lithuania
@@ -339,6 +381,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lt')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Luxembourg
@@ -346,6 +389,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lu')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{13}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Latvia
@@ -353,6 +397,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lv')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{13}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Monaco
@@ -360,6 +405,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mc')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Moldova
@@ -367,14 +413,15 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'md')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{2}[A-Z0-9]{18}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Montenegro
   def test_iban_me
     account = @tester.iban(country_code: 'me')
-
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}\d{18}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Macedonia
@@ -382,6 +429,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mk')
     assert_equal(19, account.length)
     assert_match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{10}\d{2}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Mauritania
@@ -389,6 +437,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mr')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}\d{23}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Malta
@@ -396,6 +445,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mt')
     assert_equal(31, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{5}[A-Z0-9]{18}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Mauritius
@@ -403,6 +453,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mu')
     assert_equal(30, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{19}[A-Z]{3}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Netherlands
@@ -410,6 +461,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'nl')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{10}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Norway
@@ -417,6 +469,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'no')
     assert_equal(15, account.length)
     assert_match(/^#{IBAN_HEADER}\d{11}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Pakistan
@@ -424,6 +477,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'pk')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Poland
@@ -431,6 +485,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'pl')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Palestinian Territory, Occupied
@@ -438,6 +493,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ps')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Portugal
@@ -445,6 +501,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'pt')
     assert_equal(25, account.length)
     assert_match(/^#{IBAN_HEADER}\d{21}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Qatar
@@ -452,6 +509,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'qa')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Romania
@@ -459,6 +517,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ro')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Serbia
@@ -466,6 +525,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'rs')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}\d{18}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Saudi Arabia
@@ -473,6 +533,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'sa')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{2}[A-Z0-9]{18}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Sweden
@@ -480,6 +541,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'se')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Slovenia
@@ -487,6 +549,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'si')
     assert_equal(19, account.length)
     assert_match(/^#{IBAN_HEADER}\d{15}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Slovakia
@@ -494,6 +557,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'sk')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # San Marino
@@ -501,6 +565,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'sm')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Timor-Leste
@@ -508,6 +573,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'tl')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}\d{19}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Tunisia
@@ -515,6 +581,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'tn')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Turkey
@@ -522,6 +589,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'tr')
     assert_equal(26, account.length)
     assert_match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{17}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Ukraine
@@ -529,6 +597,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ua')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}\d{25}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Virgin Islands, British
@@ -536,6 +605,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'vg')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   # Kosovo, Republic of
@@ -543,11 +613,24 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'xk')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
+    assert iban_checksum(account), 'IBAN checksum is invalid'
   end
 
   def test_iban_invalid
     assert_raise ArgumentError.new('Could not find iban details for bad') do
       @tester.iban(country_code: 'bad')
     end
+  end
+
+  private
+
+  # https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
+  def iban_checksum(iban)
+    # Check digit should be between 2..98
+    return false unless (2..98).include? iban[2, 2].to_i
+
+    iban = (iban[4..] + iban[0..3]).upcase
+    iban = iban.chars.map { |char| char =~ /[A-Z]/ ? char.ord - 55 : char }.join
+    iban.to_i % 97 == 1
   end
 end

--- a/test/faker/default/test_faker_bank.rb
+++ b/test/faker/default/test_faker_bank.rb
@@ -68,6 +68,37 @@ class TestFakerBank < Test::Unit::TestCase
     assert_match(/^[A-Z]{2}\d{2}[A-Z\d]{10,30}$/, @tester.iban(country_code: nil))
   end
 
+  def test_iban_checksum
+    # Sourced IBANs from https://www.iban.com/structure
+    accounts = {
+      AL: { account: '202111090000000001234567', check_digit: '35' }, # AL35202111090000000001234567
+      BY: { account: 'AKBB10100000002966000000', check_digit: '86' }, # BY86AKBB10100000002966000000
+      CY: { account: '002001950000357001234567', check_digit: '21' }, # CY21002001950000357001234567
+      DO: { account: 'ACAU00000000000123456789', check_digit: '22' }, # DO22ACAU00000000000123456789
+      EG: { account: '0002000156789012345180002', check_digit: '80' }, # EG800002000156789012345180002
+      FR: { account: '30006000011234567890189', check_digit: '76' }, # FR7630006000011234567890189
+      GB: { account: 'BUKB20201555555555', check_digit: '33' }, # GB33BUKB20201555555555
+      HU: { account: '116000060000000012345676', check_digit: '93' }, # HU93116000060000000012345676
+      IT: { account: 'X0542811101000000123456', check_digit: '60' }, # IT60X0542811101000000123456
+      JO: { account: 'CBJO0000000000001234567890', check_digit: '71' }, # JO71CBJO0000000000001234567890
+      KW: { account: 'CBKU0000000000001234560101', check_digit: '81' }, # KW81CBKU0000000000001234560101
+      LB: { account: '000700000000123123456123', check_digit: '92' }, # LB92000700000000123123456123
+      MD: { account: 'EX000000000001234567', check_digit: '21' }, # MD21EX000000000001234567
+      NL: { account: 'ABNA0123456789', check_digit: '02' }, # NL02ABNA0123456789
+      PL: { account: '105000997603123456789123', check_digit: '10' }, # PL10105000997603123456789123
+      QA: { account: 'QNBA000000000000693123456', check_digit: '54' }, # QA54QNBA000000000000693123456
+      RU: { account: '04452560040702810412345678901', check_digit: '02' }, # RU0204452560040702810412345678901
+      SC: { account: 'MCBL01031234567890123456USD', check_digit: '74' }, # SC74MCBL01031234567890123456USD
+      TR: { account: '0010009999901234567890', check_digit: '32' }, # TR320010009999901234567890
+      UA: { account: '3052992990004149123456789', check_digit: '90' }, # UA903052992990004149123456789
+      VG: { account: 'ABVI0000000123456789', check_digit: '07' } # VG07ABVI0000000123456789
+    }
+
+    accounts.each do |country_code, data|
+      assert_equal data[:check_digit], @tester.send(:iban_checksum, country_code.to_s, data[:account])
+    end
+  end
+
   # Andorra
   def test_iban_ad
     account = @tester.iban(country_code: 'ad')

--- a/test/faker/default/test_faker_bank.rb
+++ b/test/faker/default/test_faker_bank.rb
@@ -73,7 +73,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ad')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{12}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # United Arab Emirates
@@ -81,7 +81,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ae')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}\d{19}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Albania
@@ -89,7 +89,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'al')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Austria
@@ -97,7 +97,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'at')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Azerbaijan, Republic of
@@ -105,7 +105,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'az')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Bosnia
@@ -113,7 +113,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ba')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Belgium
@@ -121,7 +121,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'be')
     assert_equal(16, account.length)
     assert_match(/^#{IBAN_HEADER}\d{12}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Bulgaria
@@ -129,7 +129,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'bg')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{6}[A-Z0-9]{8}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Bahrain
@@ -137,7 +137,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'bh')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{14}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Brazil
@@ -145,7 +145,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'br')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}[0-9]{8}[0-9]{5}[0-9]{10}[A-Z]{1}[A-Z0-9]{1}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Switzerland
@@ -153,7 +153,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ch')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Costa Rica
@@ -161,7 +161,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'cr')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}0\d{3}\d{14}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Cyprus
@@ -169,7 +169,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'cy')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Czech Republic
@@ -177,7 +177,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'cz')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Germany
@@ -185,7 +185,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'de')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}\d{18}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Denmark
@@ -193,7 +193,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'dk')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Dominican Republic
@@ -201,7 +201,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'do')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Estonia
@@ -209,7 +209,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ee')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Spain
@@ -217,7 +217,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'es')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Finland
@@ -225,7 +225,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'fi')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Faroe Islands
@@ -233,7 +233,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'fo')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # France
@@ -242,7 +242,7 @@ class TestFakerBank < Test::Unit::TestCase
       account = @tester.iban(country_code: 'fr')
       assert_equal(27, account.length)
       assert_match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/, account)
-      assert iban_checksum(account), 'IBAN checksum is invalid'
+      assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
     end
   end
 
@@ -252,7 +252,7 @@ class TestFakerBank < Test::Unit::TestCase
       account = @tester.iban(country_code: 'gb')
       assert_equal(22, account.length)
       assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/, account)
-      assert iban_checksum(account), 'IBAN checksum is invalid'
+      assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
     end
   end
 
@@ -261,7 +261,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ge')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{2}\d{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Gibraltar
@@ -269,7 +269,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gi')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{15}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Greenland
@@ -277,7 +277,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gl')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}\d{14}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Greece
@@ -285,7 +285,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gr')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}\d{7}[A-Z0-9]{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Guatemala
@@ -293,7 +293,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'gt')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z0-9]{4}\d{2}\d{2}[A-Z0-9]{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Croatia
@@ -301,7 +301,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'hr')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}\d{17}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Hungary
@@ -309,7 +309,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'hu')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{24}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Ireland
@@ -317,7 +317,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ie')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Israel
@@ -325,7 +325,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'il')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}\d{19}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Iceland
@@ -333,7 +333,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'is')
     assert_equal(26, account.length)
     assert_match(/^#{IBAN_HEADER}\d{22}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Italy
@@ -341,7 +341,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'it')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Kuwait
@@ -349,7 +349,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'kw')
     assert_equal(30, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{22}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Kazakhstan
@@ -357,7 +357,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'kz')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}[0-9]{3}[A-Z0-9]{13}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Lebanon
@@ -365,7 +365,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lb')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{4}[A-Z0-9]{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Liechtenstein
@@ -373,7 +373,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'li')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Lithuania
@@ -381,7 +381,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lt')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Luxembourg
@@ -389,7 +389,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lu')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{13}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Latvia
@@ -397,7 +397,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'lv')
     assert_equal(21, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{13}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Monaco
@@ -405,7 +405,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mc')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Moldova
@@ -413,7 +413,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'md')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{2}[A-Z0-9]{18}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Montenegro
@@ -421,7 +421,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'me')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}\d{18}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Macedonia
@@ -429,7 +429,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mk')
     assert_equal(19, account.length)
     assert_match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{10}\d{2}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Mauritania
@@ -437,7 +437,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mr')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}\d{23}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Malta
@@ -445,7 +445,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mt')
     assert_equal(31, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{5}[A-Z0-9]{18}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Mauritius
@@ -453,7 +453,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'mu')
     assert_equal(30, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{19}[A-Z]{3}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Netherlands
@@ -461,7 +461,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'nl')
     assert_equal(18, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{10}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Norway
@@ -469,7 +469,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'no')
     assert_equal(15, account.length)
     assert_match(/^#{IBAN_HEADER}\d{11}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Pakistan
@@ -477,7 +477,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'pk')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Poland
@@ -485,7 +485,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'pl')
     assert_equal(28, account.length)
     assert_match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Palestinian Territory, Occupied
@@ -493,7 +493,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ps')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Portugal
@@ -501,7 +501,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'pt')
     assert_equal(25, account.length)
     assert_match(/^#{IBAN_HEADER}\d{21}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Qatar
@@ -509,7 +509,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'qa')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Romania
@@ -517,7 +517,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ro')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Serbia
@@ -525,7 +525,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'rs')
     assert_equal(22, account.length)
     assert_match(/^#{IBAN_HEADER}\d{18}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Saudi Arabia
@@ -533,7 +533,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'sa')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{2}[A-Z0-9]{18}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Sweden
@@ -541,7 +541,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'se')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Slovenia
@@ -549,7 +549,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'si')
     assert_equal(19, account.length)
     assert_match(/^#{IBAN_HEADER}\d{15}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Slovakia
@@ -557,7 +557,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'sk')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # San Marino
@@ -565,7 +565,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'sm')
     assert_equal(27, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Timor-Leste
@@ -573,7 +573,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'tl')
     assert_equal(23, account.length)
     assert_match(/^#{IBAN_HEADER}\d{19}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Tunisia
@@ -581,7 +581,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'tn')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}\d{20}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Turkey
@@ -589,7 +589,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'tr')
     assert_equal(26, account.length)
     assert_match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{17}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Ukraine
@@ -597,7 +597,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'ua')
     assert_equal(29, account.length)
     assert_match(/^#{IBAN_HEADER}\d{25}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Virgin Islands, British
@@ -605,7 +605,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'vg')
     assert_equal(24, account.length)
     assert_match(/^#{IBAN_HEADER}[A-Z]{4}\d{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   # Kosovo, Republic of
@@ -613,7 +613,7 @@ class TestFakerBank < Test::Unit::TestCase
     account = @tester.iban(country_code: 'xk')
     assert_equal(20, account.length)
     assert_match(/^#{IBAN_HEADER}\d{16}$/, account)
-    assert iban_checksum(account), 'IBAN checksum is invalid'
+    assert valid_iban_checksum?(account), 'IBAN checksum is invalid'
   end
 
   def test_iban_invalid
@@ -625,7 +625,7 @@ class TestFakerBank < Test::Unit::TestCase
   private
 
   # https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
-  def iban_checksum(iban)
+  def valid_iban_checksum?(iban)
     # Check digit should be between 2..98
     return false unless (2..98).include? iban[2, 2].to_i
 


### PR DESCRIPTION
### Summary

Fixes Issue #2588 

IBAN check digit can be incorrectly calculated to fall outside the proper range of `2-98`. This would cause some IBAN validator libraries(ex: https://github.com/gocardless/ibandit) to mark the IBANs as invalid.

This change calculates the check digit correctly and adds checksum asserts to each country's IBAN test.

### Other Information

While this change resolves the IBAN check digit issue, there is another issue lurking in Faker's IBAN generation code. Some countries implement a national check digit _in addition_ to the standard IBAN check digit. This can cause Faker generated IBANs to fail full validations where the national check digit is taken into account. This means that while an IBAN might be considered valid with a library such as `ibandit`, it could be flagged as invalid with more strict validators such as https://www.iban.com/iban-checker.

Valid according to `ibandit`:
```ruby
require 'ibandit' #=> true
iban = Faker::Bank.iban(country_code: 'fr') #=> "FR8942372847507891Y7GYUJ162"
ibandit = Ibandit::IBAN.new(iban) #=> #<Ibandit::IBAN:0x000000010812ef90...
ibandit.valid? #=> true
```

Invalid according to https://www.iban.com:

<img width="754" alt="Screen Shot 2022-10-16 at 3 09 58 PM" src="https://user-images.githubusercontent.com/157061/196053449-9eec564a-0f3f-494f-a4a1-2d4b5f0c94e5.png">

To complicate matters, the algorithm for calculating a national check digit varies country to country. France, for instance, make use of the standard `ISO 7064 MOD-97-10`, but has their own variation for encoding account letters to numbers. Some countries don't use the `ISO 7064 MOD-97-10` standard at all, but instead opt for Luhn, "conversion + sum",  or 
"weighted sum" algorithms.

When I started working on this issue, I overlooked the IBAN check digit calculation bug that this pull request aims to solve, and instead thought the invalid IBANs were a result of Faker not calculating a valid _national check digit_. It took me a while to discover there were two separate issues, and I spent some time attempting to properly calculate national check digits focusing firstly on the `ISO 7064 MOD-97-10` algorithm and France's variant.

You can see the progress I was making here: https://github.com/faker-ruby/faker/compare/main...srcoley:faker:iban_national_check_digit_support

I'd be happy to continue adding national check digit support(at least for `ISO 7064 MOD-97-10` and variants), but I figure the maintainers have some decisions to make first:
1. Is this type of IBAN accuracy worth it?
1. If it is worth it, are all of the edge cases(variants) worth it?
1. Since `ibandit`(and no other lib I could find) properly validates national check digits, what should the testing strategy look like?

For more information on national check digits, see: https://en.wikipedia.org/wiki/International_Bank_Account_Number#National_check_digits
