### PR TITLE
Added rake task: format all yml

### DIFF
--- a/tasks/reformat_yaml_all.rake
+++ b/tasks/reformat_yaml_all.rake
@@ -3,18 +3,18 @@
 require 'find'
 require 'yaml'
 
-# This monkey patch is related to the Ruby 3.1 / Psych 4.x incompatibility described in this issue: 
+# This monkey patch is related to the Ruby 3.1 / Psych 4.x incompatibility described in this issue:
 # https://bugs.ruby-lang.org/issues/17866
 module YAML
   class << self
-    alias_method :load, :unsafe_load if YAML.respond_to? :unsafe_load
+    alias load unsafe_load if YAML.respond_to? :unsafe_load
   end
 end
 
 desc 'Reformat all yaml files into a common format'
-task :reformat_yaml_all, [:file_name] do |t, args|
-  args.with_defaults(file_name: '.') # Default to current directory
-  reformat_yaml_enum(args[:file_name])
+task :reformat_yaml_all, [:filename] do |_t, args|
+  args.with_defaults(filename: '.') # Default to current directory
+  reformat_yaml_enum(args[:filename])
 end
 
 ##
@@ -30,8 +30,6 @@ end
 #
 # #=> true
 # @faker version next
-
-
 def reformat_yaml_enum(path_name)
   files_touched = 0
   Find.find(path_name) do |file|

--- a/tasks/reformat_yaml_all.rake
+++ b/tasks/reformat_yaml_all.rake
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'find'
+require 'yaml'
+
+desc 'Reformat all yaml files into a common format'
+task :reformat_yaml_all do
+  reformat_yaml_enum('.')
+end
+
+##
+# This method is used to format .yml files in the project into a common format
+#
+# @return [Boolean] true if files were formatted, false if not
+#
+# @example rake format_yaml_enum [/path/to/file.yml]
+# key: [value1, value2, value3] =>
+# key:
+#   - value1
+#   - value2
+#
+# #=> true
+# @faker version next
+def reformat_yaml_enum(path_name)
+  files_touched = 0
+  Find.find(path_name) do |file|
+    parent_directory = File.expand_path('..', file).split('/')
+
+    # Psych doesn't like Japanese and we don't want to mess with workflows
+    next if parent_directory.include?('.github') || parent_directory.include?('ja')
+    next unless File.file?(file) && (File.extname(file) == '.yml')
+
+    puts "Reformatting #{file}"
+
+    input = YAML.load_file(file)
+    # Psych outputs non-indented hypendated array list items.
+    output = input.to_yaml(line_width: -1)
+                  .gsub(/(^ *- .+$)/, '  \1') # Indent hypenated list items
+                  .sub(/^---\n/, '') # Remove header
+
+    File.write file, output
+    files_touched += 1
+  end
+  puts "All done! #{files_touched} files reformatted."
+  !!files_touched
+end

--- a/tasks/reformat_yaml_all.rake
+++ b/tasks/reformat_yaml_all.rake
@@ -3,15 +3,17 @@
 require 'find'
 require 'yaml'
 
+# This monkey patch is related to the Ruby 3.1 / Psych 4.x incompatibility described in this issue: 
+# https://bugs.ruby-lang.org/issues/17866
+module YAML
+  class << self
+    alias_method :load, :unsafe_load if YAML.respond_to? :unsafe_load
+  end
+end
+
 desc 'Reformat all yaml files into a common format'
 task :reformat_yaml_all, [:file_name] do |t, args|
   args.with_defaults(file_name: '.') # Default to current directory
-  module YAML
-    class << self
-      alias_method :load, :unsafe_load if YAML.respond_to? :unsafe_load
-    end
-  end
-  
   reformat_yaml_enum(args[:file_name])
 end
 

--- a/tasks/reformat_yaml_all.rake
+++ b/tasks/reformat_yaml_all.rake
@@ -4,8 +4,15 @@ require 'find'
 require 'yaml'
 
 desc 'Reformat all yaml files into a common format'
-task :reformat_yaml_all do
-  reformat_yaml_enum('.')
+task :reformat_yaml_all, [:file_name] do |t, args|
+  args.with_defaults(file_name: '.') # Default to current directory
+  module YAML
+    class << self
+      alias_method :load, :unsafe_load if YAML.respond_to? :unsafe_load
+    end
+  end
+  
+  reformat_yaml_enum(args[:file_name])
 end
 
 ##
@@ -21,6 +28,8 @@ end
 #
 # #=> true
 # @faker version next
+
+
 def reformat_yaml_enum(path_name)
   files_touched = 0
   Find.find(path_name) do |file|

--- a/test/yml/test_format_yaml.rb
+++ b/test/yml/test_format_yaml.rb
@@ -5,17 +5,12 @@ require 'rake'
 require 'test_helper'
 
 class TestRakeReformatYaml < Test::Unit::TestCase
+  TEST_DIRECTORY = File.dirname(__FILE__)
+
   def setup
-    Faker::Config.locale = 'es'
-  end
+    Faker::Config.locale = 'en'
 
-  def teardown
-    Faker::Config.locale = nil
-    File.delete("#{File.dirname(__FILE__)}/format_yaml_test.yml")
-  end
-
-  def test_valid_yaml
-    File.write("#{File.dirname(__FILE__)}/format_yaml_test.yml", <<~YAML
+    File.write("#{TEST_DIRECTORY}/array_style.yml", <<~YAML
       en:
         faker:
             male_first_name:
@@ -25,11 +20,30 @@ class TestRakeReformatYaml < Test::Unit::TestCase
     YAML
     )
 
-    assert YAML.load_file("#{File.dirname(__FILE__)}/format_yaml_test.yml").is_a?(Hash)
+    File.write("#{TEST_DIRECTORY}/trailing_whitespace.yml", <<~YAML
+      en:
+        faker:
+            male_first_name:
+                ["Liam ", " Noah", " Oliver ", "Elijah  ", "  James", "  William  ", "Benjamin  ", "   Lucas"]
+            female_first_name:
+                ["Emma ", " Olivia", " Ava ", "Isabella  ", "  Sophia", "  Charlotte  ", "Mia  ", "   Amelia"]
+    YAML
+    )
   end
 
-  def test_reformat_yaml_valid
-    Rake::Task['reformat_yaml_all'].invoke
-    assert YAML.load_file("#{File.dirname(__FILE__)}/format_yaml_test.yml").is_a?(Hash)
+  def teardown
+    Faker::Config.locale = nil
+    # File.delete("#{TEST_DIRECTORY}/array_style.yml")
+    # File.delete("#{TEST_DIRECTORY}/trailing_whitespace.yml")
+  end
+
+  ARRAY_FILE = File.expand_path('array_style.yml', '../faker/test/yml')
+  TRAILING_WHITESPACE_FILE = File.expand_path('trailing_whitespace.yml', '../faker/test/yml')
+
+  def test_valid_yaml
+    Rake::Task['reformat_yaml_all'].invoke(ARRAY_FILE)
+
+    Rake::Task['reformat_yaml_all'].invoke(TRAILING_WHITESPACE_FILE)
+    assert YAML.load_file("#{TEST_DIRECTORY}/array_style.yml").is_a?(Hash)
   end
 end

--- a/test/yml/test_format_yaml.rb
+++ b/test/yml/test_format_yaml.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'rake'
+require 'test_helper'
+
+class TestRakeReformatYaml < Test::Unit::TestCase
+  def setup
+    Faker::Config.locale = 'es'
+  end
+
+  def teardown
+    Faker::Config.locale = nil
+    File.delete("#{File.dirname(__FILE__)}/format_yaml_test.yml")
+  end
+
+  def test_valid_yaml
+    File.write("#{File.dirname(__FILE__)}/format_yaml_test.yml", <<~YAML
+      en:
+        faker:
+            male_first_name:
+                [Liam, Noah, Oliver, Elijah, James, William, Benjamin, Lucas]
+            female_first_name:
+                [Emma, Olivia, Ava, Isabella, Sophia, Charlotte, Mia, Amelia]
+    YAML
+    )
+
+    assert YAML.load_file("#{File.dirname(__FILE__)}/format_yaml_test.yml").is_a?(Hash)
+  end
+
+  def test_reformat_yaml_valid
+    Rake::Task['reformat_yaml_all'].invoke
+    assert YAML.load_file("#{File.dirname(__FILE__)}/format_yaml_test.yml").is_a?(Hash)
+  end
+end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull request.
Were there any bugs you had fixed? If so, mention them: Fixes Issue #add-issue-number -->

I created a rake task to format all YML files to a common format. The current rake task requires that you escape your arguments when you call it - i.e.

```
bundle exec rake format_yml\["lib/path/to/fill"\]
```

That's why I made this rake task. It doesn't require any arguments.

I also like having a common format lol

See issue #2593

### Other Information

Psych has trouble parsing certain Japanese kanji and reformats it with extra array dashes. This may be due to the way I modify the yaml file using substrings.

### Testing

I have only done manual tests so there are definitely some edge cases that are still present--probably with other non-Latin alphabets. A little help figuring out where to start with this would be appreciated.