### PR TITLE
Remove tags from publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   release:
     types:
       - [ created ]
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Summary

Remove tags from `publish.yml` to only push to RubyGems on a new release.