### PR TITLE
Add sports documentation and update sports

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,11 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main
 
 
 ### Sports
+  - [Faker::Sports](doc/sports/sports.md)
   - [Faker::Sports::Basketball](doc/sports/basketball.md)
   - [Faker::Sports::Football](doc/sports/football.md)
+  - [Faker::Sports::Mountaineering](doc/sports/mountaineering.md)
+  - [Faker::Sports::Volleyball](doc/sports/volleyball.md)
 
 ### Tv Shows
   - [Faker::TvShows::AquaTeenHungerForce](doc/tv_shows/aqua_teen_hunger_force.md)

--- a/doc/sports/sports.md
+++ b/doc/sports/sports.md
@@ -1,0 +1,41 @@
+# Faker::Sports
+
+## Conventional (Olympic including Paralympic) Sports
+
+```ruby
+# Any one of the below four categories:
+Faker::Sports.sport #=> "Snowboard"
+
+Faker::Sports.summer_olympics_sport #=> "Triathlon"
+
+Faker::Sports.winter_olympics_sport #=> "Luge"
+
+Faker::Sports.summer_paralympics_sport #=> "Goalball"
+
+Faker::Sports.winter_paralympics_sport #=> "Wheelchair curling"
+```
+
+## Ancient Sports
+
+```ruby
+Faker::Sports.ancient_olympics_sport #=> "Chariot racing"
+
+# Any modern or ancient olympic sport:
+Faker::Sports.sport(include_ancient: true) #=> "Rugby"
+```
+
+## Unusual Sports (just for fun)
+
+```ruby
+Faker::Sports.unusual_sport #=> "Camel wrestling"
+
+# Any modern olympic or unusual sport:
+Faker::Sports.sport(include_unusual: true) #=> "Gurning"
+```
+
+## Full list
+
+```ruby
+# Modern, ancient or unusual:
+Faker::Sports.sport(include_ancient: true, include_unusual: true) #=> "Powerlifting"
+```

--- a/lib/locales/en/sport.yml
+++ b/lib/locales/en/sport.yml
@@ -11,8 +11,8 @@ en:
         - Baseball # Technically part of "Baseball Softball" according to IOC website
         - Basketball
         - Beach volleyball
-        - BMX freestyle
-        - BMX racing
+        - BMX freestyle # Officially "Cycling BMX Freestyle"
+        - BMX racing # Officially "Cycling BMX Racing"
         - Boxing
         - Canoe/kayak flatwater
         - Canoe/kayak slalom
@@ -27,11 +27,11 @@ en:
         - Karate
         - Marathon swimming
         - Modern pentathlon
-        - Mountain bike
+        - Mountain bike # Officially "Cycling Mountain Bike"
         - Rhythmic gymnastics
-        - Road cycling
+        - Road cycling # Officially "Cycling Road"
         - Rowing
-        - Rugby
+        - Rugby # Officially "Rugby Sevens"
         - Sailing
         - Shooting
         - Skateboarding
@@ -42,7 +42,7 @@ en:
         - Table tennis
         - Taekwondo
         - Tennis
-        - Track cycling
+        - Track cycling # Officially "Cycling Track"
         - Trampoline
         - Triathlon
         - Volleyball
@@ -53,7 +53,7 @@ en:
         - Alpine skiing
         - Biathlon
         - Bobsleigh
-        - Cross-country
+        - Cross-country skiing
         - Curling
         - Figure skating
         - Freestyle skiing
@@ -63,17 +63,18 @@ en:
         - Short track speed skating
         - Skeleton
         - Ski jumping
+        - Ski mountaineering
         - Snowboard
         - Speed skating
       summer_paralympics: # Source https://www.paralympic.org/sports
         - Archery
         - Athletics
         - Badminton
+        - Blind football
         - Boccia
         - Canoe
         - Cycling
         - Equestrian
-        - Football (5-a-side)
         - Goalball
         - Judo
         - Powerlifting
@@ -110,6 +111,7 @@ en:
         - Ban'ei
         - Bathtubbing
         - Bed racing
+        - Bossaball
         - Botaoshi
         - Beer Can Regatta
         - Black pudding throwing
@@ -117,5 +119,13 @@ en:
         - Bottle kicking
         - Camel jumping
         - Camel wrestling
+        - Chess boxing
+        - Extreme ironing
         - Flugtag/Birdman
+        - Gurning
         - Kastenlauf (Beer crate running)
+        - Oil wrestling
+        - Poohsticks
+        - Wife carrying
+        - Zorbing
+        

--- a/lib/locales/en/sport.yml
+++ b/lib/locales/en/sport.yml
@@ -128,4 +128,3 @@ en:
         - Poohsticks
         - Wife carrying
         - Zorbing
-        


### PR DESCRIPTION
### Summary

Primarily a documentation change, with minor changes to the list of sports (in English):

- Added links to existing docs (Mountaineering and Volleyball)
- Added doc and link for Faker::Sports
- Updated lists of olympic sports based on latest information from the sources listed in `lib/locales/en/sport.yml`
  - Add "Ski mountaineering"
  - Replace "Football (5-a-side)" with "Blind football"
- Added a few more unusual sports from the list at https://www.wonderslist.com/top-10-unusual-sports/

### Other Information

> Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

When I first added sports, I added YARD style docs for the methods. As I write this PR I'm wondering if I shouldn't have written these docs manually? Are they supposed to be generated automatically by YARD?