### PR TITLE
fix publish action for release types

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to RubyGems
 on:
   release:
     types:
-      - [ created ]
+      - created
 
 permissions:
   contents: read


### PR DESCRIPTION
fix `types` definition of release action, see error below:

![image](https://user-images.githubusercontent.com/707418/197628532-1d6057bc-0861-4c6d-ab37-e6a92ca460dd.png)
