### PR TITLE
Fix: ensure sport generator produces single sport unless a number of sports is requested

### DIFF
--- a/lib/faker/sports/sport.rb
+++ b/lib/faker/sports/sport.rb
@@ -22,9 +22,15 @@ module Faker
       #
       # @faker.version next
       def sport(include_ancient: false, include_unusual: false)
-        sports = fetch_all('sport.summer_olympics') + fetch_all('sport.winter_olympics') + fetch_all('sport.summer_paralympics') + fetch_all('sport.winter_paralympics')
-        sports << fetch_all('sport.ancient_olympics') if include_ancient
-        sports << fetch_all('sport.unusual') if include_unusual
+        sports = []
+        sports.concat(
+          fetch_all('sport.summer_olympics'),
+          fetch_all('sport.summer_paralympics'),
+          fetch_all('sport.winter_olympics'),
+          fetch_all('sport.winter_paralympics')
+        )
+        sports.concat(fetch_all('sport.ancient_olympics')) if include_ancient
+        sports.concat(fetch_all('sport.unusual')) if include_unusual
         sample(sports)
       end
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull request.

Were there any bugs you had fixed? If so, mention them: Fixes Issue #add-issue-number -->

Fixes Issue #2608 
there was a bug that resulted in `Faker::Sport.sport(include_ancient: true)` generating an array of sports instead of a single sport.
The problem was caused by [this line](https://github.com/faker-ruby/faker/blob/main/lib/faker/sports/sport.rb#L26). 
When using << to add ancient_olympics sports to the `sports` array we were creating a nested array that looked like that:
```
      ['3x3 basketball', 'Archery', 'Artistic gymnastics', 'Artistic swimming', 'Athletics',
       'Badminton', 'Baseball', 'Basketball', 'Beach volleyball', 'BMX freestyle', 'BMX racing',
       'Boxing', 'Canoe/kayak flatwater', 'Canoe/kayak slalom', 'Diving', 'Equestrian', 'Fencing',
       'Football', 'Golf', 'Handball', 'Hockey', 'Judo', 'Karate', 'Marathon swimming', 'Modern pentathlon',
       'Mountain bike', 'Rhythmic gymnastics', 'Road cycling', 'Rowing', 'Rugby', 'Sailing', 'Shooting',
       'Skateboarding', 'Softball', 'Sport climbing', 'Surfing', 'Swimming', 'Table tennis', 'Taekwondo',
       'Tennis', 'Track cycling', 'Trampoline', 'Triathlon', 'Volleyball', 'Water polo', 'Weight lifting', 'Wrestling',
       'Alpine skiing', 'Biathlon', 'Bobsleigh', 'Cross-country', 'Curling', 'Figure skating', 'Freestyle skiing',
       'Ice hockey', 'Luge', 'Nordic combined', 'Short track speed skating', 'Skeleton', 'Ski jumping', 'Snowboard',
       'Speed skating', 'Archery', 'Athletics', 'Badminton', 'Boccia', 'Canoe', 'Cycling', 'Equestrian',
       'Football (5-a-side)', 'Goalball', 'Judo', 'Powerlifting', 'Rowing', 'Shooting', 'Sitting volleyball',
       'Swimming', 'Table tennis', 'Taekwondo', 'Triathlon', 'Wheelchair basketball', 'Wheelchair fencing',
       'Wheelchair rugby', 'Wheelchair tennis', 'Alpine skiing', 'Biathlon', 'Cross-country skiing',
       'Para ice hockey', 'Snowboard', 'Wheelchair curling',
       ['Boxing', 'Chariot racing', 'Discus', 'Horse racing', 'Long jump', 'Pankration', 'Pentathlon', 'Running', 'Wrestling']]
```
So once in a while, this last element was picked by the `.sample` method and caused the problem.

I changed the sport method to use concat method to combine arrays correctly.
### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

If you are creating a new generator, share how you are going to use it. Use cases are important to make sure that our faker generators are useful. Also, add `@faker.version next` to help users know when a generator was added. See [this example](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/music/opera.rb#L68).

Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

Thanks for contributing to Faker! -->