### PR TITLE
Remove typo in ISSUE_TEMPLATE to check Faker version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 ## To Reproduce
-Describe a way to reproduce your bug. To get the Faker version, run `FAKER::VERSION`.
+Describe a way to reproduce your bug. To get the Faker version, run `Faker::VERSION`.
 
 Use the reproduction script below to reproduce the issue:
 


### PR DESCRIPTION
### Summary
Remove typo in issue template for bugs (bug-report.md), because when I use proposed code and there was an error, see screen below:
<img width="432" alt="Screenshot 2022-11-08 at 19 47 20" src="https://user-images.githubusercontent.com/49816584/200638169-fc848878-f724-40eb-a202-9cb78d8f58a0.png">
