### PR TITLE
Document IBAN digits validity generator

### DIFF
--- a/doc/default/bank.md
+++ b/doc/default/bank.md
@@ -6,6 +6,7 @@ Faker::Bank.account_number #=> 6738582379
 # Keyword arguments: digits
 Faker::Bank.account_number(digits: 13) #=> 673858237902
 
+# Faker generates valid IBAN check digits, but national check digits (BBAN) are not supported
 Faker::Bank.iban #=> "GB76DZJM33188515981979"
 
 # Keyword arguments: country_code


### PR DESCRIPTION
Although we would like to support all cases and have higher accuracy, it would require too much effort to accommodate.

Faker generates valid IBAN check digits but does not support national check digits used within the BBAN.

If this behavior is critical for an app, it's recommend to generate its own IBAN digits validity check.

Close #2588 