### PR TITLE
[Dependabot] ignore rubocop gems patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
+  - dependency-name: rubocop-minitest
+    update-types: ["version-update:semver-patch"] # Ignore patch versions
+  - dependency-name: rubocop-rake
+    update-types: ["version-update:semver-patch"] # Ignore patch versions
   - dependency-name: test-unit
     versions:
     - 3.3.9
@@ -19,6 +23,7 @@ updates:
     versions:
     - 0.21.2
   - dependency-name: rubocop
+    update-types: ["version-update:semver-patch"] # Ignore patch versions
     versions:
     - 1.10.0
     - 1.8.1


### PR DESCRIPTION
Quite often, dependabot opens PRs whenever any of the rubocop gems (rubocop, rubocop-minitest, rubocop-rake) release patch versions.

Every time that happens, someone needs to manually bump the gem version and run the autocorrect.

To save time, we can configure dependabot to ignore patch versions releases.

That way, we only have to upgrade those gems when major and minor versions are released.