### PR TITLE
Update dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: test-unit
-    versions:
-    - 3.3.9
-    - 3.4.1
-  - dependency-name: i18n
-    versions:
-    - 1.8.10
-    - 1.8.7
-    - 1.8.8
-  - dependency-name: simplecov
-    versions:
-    - 0.21.2
-  - dependency-name: rubocop
-    versions:
-    - 1.10.0
-    - 1.8.1
-    - 1.9.0
-    - 1.9.1
-  - dependency-name: timecop
-    versions:
-    - 0.9.3

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rubocop', '1.38.0')
   spec.add_development_dependency('rubocop-minitest', '0.23.2')
   spec.add_development_dependency('rubocop-rake', '0.6.0')
-  spec.add_development_dependency('simplecov', '0.21')
+  spec.add_development_dependency('simplecov', '0.21.0')
   spec.add_development_dependency('test-unit', '3.5.5')
   spec.add_development_dependency('timecop', '0.9.5')
   spec.add_development_dependency('yard', '0.9.27')


### PR DESCRIPTION
This file hasn't been updated in quite some time. For instance, all of the versions included here were outdated.

Recently, we have updated all faker dependencies.

To make sure we are always in sync with our dependencies, let's configure our dependabot to always open PR for all of them.

## Extra information

I also added an explicit version for simplecov.