### PR TITLE
Generate vehicle vin numbers with a valid check-digit

### DIFF
--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -6,10 +6,9 @@ module Faker
 
     MILEAGE_MIN = 10_000
     MILEAGE_MAX = 90_000
-    VIN_LETTERS = 'ABCDEFGHJKLMNPRSTUVWXYZ'
-    VIN_MAP = '0123456789X'
-    VIN_WEIGHTS = '8765432X098765432'
-    VIN_REGEX = /^([A-HJ-NPR-Z0-9]){3}[A-HJ-NPR-Z0-9]{5}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-9]{1}\d{5}$/.freeze
+    VIN_KEYSPACE = %w[A B C D E F G H J K L M N P R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9].freeze
+    VIN_TRANSLITERATION = { A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9 }.freeze
+    VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
     SG_CHECKSUM_WEIGHTS = [3, 14, 2, 12, 2, 11, 1].freeze
     SG_CHECKSUM_CHARS = 'AYUSPLJGDBZXTRMKHEC'
 
@@ -23,7 +22,16 @@ module Faker
       #
       # @faker.version 1.6.4
       def vin
-        regexify(VIN_REGEX)
+        output = ''
+        total = 0
+        17.times do |index|
+          char = VIN_KEYSPACE[rand(0..32)].dup
+          output << char
+          total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
+        end
+        checksum = total % 11
+        output[8] = checksum == 10 ? 'X' : checksum.to_s
+        output
       end
 
       # Produces a random vehicle manufacturer.
@@ -298,34 +306,6 @@ module Faker
       end
 
       private
-
-      def first_eight(number)
-        return number[0...8] unless number.nil?
-
-        regexify(VIN_REGEX)
-      end
-      alias last_eight first_eight
-
-      def calculate_vin_check_digit(vin)
-        sum = 0
-
-        vin.each_char.with_index do |c, i|
-          n = vin_char_to_number(c).to_i
-          weight = VIN_WEIGHTS[i].to_i
-          sum += weight * n
-        end
-
-        mod = sum % 11
-        mod == 10 ? 'X' : mod
-      end
-
-      def vin_char_to_number(char)
-        index = VIN_LETTERS.chars.index(char)
-
-        return char.to_i if index.nil?
-
-        VIN_MAP[index]
-      end
 
       def singapore_checksum(plate_number)
         padded_alphabets = format('%3s', plate_number[/^[A-Z]+/]).tr(' ', '-').chars

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -26,7 +26,7 @@ module Faker
         output = ''
         total = 0
         17.times do |index|
-          char = VIN_KEYSPACE[rand(0..32)].dup
+          char = VIN_KEYSPACE[Faker::Config.random.rand(0..32)]
           output << char
           total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
         end

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -303,9 +303,9 @@ module Faker
         output = ''
         total = 0
         17.times do |index|
-          char = +VIN_KEYSPACE.sample(random: Faker::Config.random)
-          output << char
-          total += (char =~ /\A\d\z/ ? char.to_i : +VIN_TRANSLITERATION[char.to_sym]) * +VIN_WEIGHT[index]
+          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
+          output << +char
+          total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
         end
         checksum = total % 11
         output[8] = checksum == 10 ? 'X' : checksum.to_s

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -303,9 +303,9 @@ module Faker
         output = ''
         total = 0
         17.times do |index|
-          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
+          char = +VIN_KEYSPACE.sample(random: Faker::Config.random)
           output << char
-          total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
+          total += (char =~ /\A\d\z/ ? char.to_i : +VIN_TRANSLITERATION[char.to_sym]) * +VIN_WEIGHT[index]
         end
         checksum = total % 11
         output[8] = checksum == 10 ? 'X' : checksum.to_s

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -9,7 +9,7 @@ module Faker
     VIN_KEYSPACE = %w[A B C D E F G H J K L M N P R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9].freeze
     VIN_TRANSLITERATION = { A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9 }.freeze
     VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
-    VIN_REGEX = /^[A-HJ-NPR-Z0-9]{17}$/.freeze
+    VIN_REGEX = /\A[A-HJ-NPR-Z0-9]{17}\z/.freeze
     SG_CHECKSUM_WEIGHTS = [3, 14, 2, 12, 2, 11, 1].freeze
     SG_CHECKSUM_CHARS = 'AYUSPLJGDBZXTRMKHEC'
 
@@ -23,16 +23,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def vin
-        output = ''
-        total = 0
-        17.times do |index|
-          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
-          output << char
-          total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
-        end
-        checksum = total % 11
-        output[8] = checksum == 10 ? 'X' : checksum.to_s
-        output
+        random_vin
       end
 
       # Produces a random vehicle manufacturer.
@@ -307,6 +298,19 @@ module Faker
       end
 
       private
+
+      def random_vin
+        output = ''
+        total = 0
+        17.times do |index|
+          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
+          output << char
+          total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
+        end
+        checksum = total % 11
+        output[8] = checksum == 10 ? 'X' : checksum.to_s
+        output
+      end
 
       def singapore_checksum(plate_number)
         padded_alphabets = format('%3s', plate_number[/^[A-Z]+/]).tr(' ', '-').chars

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -300,16 +300,16 @@ module Faker
       private
 
       def random_vin
-        output = ''
-        total = 0
+        _vin = ''
+        _total = 0
         17.times do |index|
-          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
-          output << +char
-          total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
+          _char = VIN_KEYSPACE.sample(random: Faker::Config.random)
+          _vin << _char
+          _total += (_char =~ /\A\d\z/ ? _char.to_i : VIN_TRANSLITERATION[_char.to_sym]) * VIN_WEIGHT[index]
         end
-        checksum = total % 11
-        output[8] = checksum == 10 ? 'X' : checksum.to_s
-        output
+        _checksum = _total % 11
+        _vin[8] = _checksum == 10 ? 'X' : _checksum.to_s
+        _vin
       end
 
       def singapore_checksum(plate_number)

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -26,7 +26,7 @@ module Faker
         output = ''
         total = 0
         17.times do |index|
-          char = VIN_KEYSPACE[Faker::Config.random.rand(0..32)]
+          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
           output << char
           total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
         end

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -26,13 +26,13 @@ module Faker
         output = ''
         total = 0
         17.times do |index|
-          char = +VIN_KEYSPACE.sample(random: Faker::Config.random)
+          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
           output << char
           total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
         end
         checksum = total % 11
         output[8] = checksum == 10 ? 'X' : checksum.to_s
-        output
+        +output
       end
 
       # Produces a random vehicle manufacturer.

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -9,7 +9,7 @@ module Faker
     VIN_KEYSPACE = %w[A B C D E F G H J K L M N P R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9].freeze
     VIN_TRANSLITERATION = { A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9 }.freeze
     VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
-    VIN_REGEX = /\A[A-HJ-NPR-Z0-9]{17}\z/.freeze
+    VIN_REGEX = /^[A-HJ-NPR-Z0-9]{17}$/.freeze
     SG_CHECKSUM_WEIGHTS = [3, 14, 2, 12, 2, 11, 1].freeze
     SG_CHECKSUM_CHARS = 'AYUSPLJGDBZXTRMKHEC'
 
@@ -32,7 +32,7 @@ module Faker
         end
         checksum = total % 11
         output[8] = checksum == 10 ? 'X' : checksum.to_s
-        +output
+        output
       end
 
       # Produces a random vehicle manufacturer.

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -26,7 +26,7 @@ module Faker
         output = ''
         total = 0
         17.times do |index|
-          char = VIN_KEYSPACE.sample(random: Faker::Config.random)
+          char = +VIN_KEYSPACE.sample(random: Faker::Config.random)
           output << char
           total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
         end

--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -9,6 +9,7 @@ module Faker
     VIN_KEYSPACE = %w[A B C D E F G H J K L M N P R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9].freeze
     VIN_TRANSLITERATION = { A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9 }.freeze
     VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
+    VIN_REGEX = /\A[A-HJ-NPR-Z0-9]{17}\z/.freeze
     SG_CHECKSUM_WEIGHTS = [3, 14, 2, 12, 2, 11, 1].freeze
     SG_CHECKSUM_CHARS = 'AYUSPLJGDBZXTRMKHEC'
 

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -130,7 +130,7 @@ class TestFakerVehicle < Test::Unit::TestCase
         total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
       end
       checksum = total % 11
-      checksum = "X" if checksum == 10
+      checksum = 'X' if checksum == 10
       return vin[8] == checksum.to_s
     end
     false

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -3,8 +3,6 @@
 require_relative '../../test_helper'
 
 class TestFakerVehicle < Test::Unit::TestCase
-  VIN_TRANSLITERATION = { A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9 }.freeze
-  VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
   WORD_MATCH = /\w+\.?/.freeze
   VALIDITY_MATCH = /^([A-HJ-NPR-Z0-9]){17}$/.freeze
 
@@ -127,7 +125,7 @@ class TestFakerVehicle < Test::Unit::TestCase
     if vin.present? && vin =~ /\A[A-HJ-NPR-Z0-9]{17}\z/
       total = 0
       vin.chars.each_with_index do |char, index|
-        total += (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym]) * VIN_WEIGHT[index]
+        total += (char =~ /\A\d\z/ ? char.to_i : Faker::Vehicle::VIN_TRANSLITERATION[char.to_sym]) * Faker::Vehicle::VIN_WEIGHT[index]
       end
       checksum = total % 11
       checksum = 'X' if checksum == 10

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -125,7 +125,7 @@ class TestFakerVehicle < Test::Unit::TestCase
     if vin.present? && vin =~ /\A[A-HJ-NPR-Z0-9]{17}\z/
       total = 0
       vin.chars.each_with_index do |char, index|
-        total += (char =~ /\A\d\z/ ? char.to_i : Faker::Vehicle::VIN_TRANSLITERATION[char.to_sym]) * Faker::Vehicle::VIN_WEIGHT[index]
+        total += (char =~ /\A\d\z/ ? char.to_i : +Faker::Vehicle::VIN_TRANSLITERATION[char.to_sym]) * +Faker::Vehicle::VIN_WEIGHT[index]
       end
       checksum = total % 11
       checksum = 'X' if checksum == 10

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -125,7 +125,7 @@ class TestFakerVehicle < Test::Unit::TestCase
     if vin.present? && vin =~ /\A[A-HJ-NPR-Z0-9]{17}\z/
       total = 0
       vin.chars.each_with_index do |char, index|
-        total += (char =~ /\A\d\z/ ? char.to_i : +Faker::Vehicle::VIN_TRANSLITERATION[char.to_sym]) * +Faker::Vehicle::VIN_WEIGHT[index]
+        total += (char =~ /\A\d\z/ ? char.to_i : Faker::Vehicle::VIN_TRANSLITERATION[char.to_sym]) * Faker::Vehicle::VIN_WEIGHT[index]
       end
       checksum = total % 11
       checksum = 'X' if checksum == 10


### PR DESCRIPTION
### Summary

* The currently generated Vehicle VIN numbers are invalid when put through a VIN checker. (The 9th check-digit is incorrect).
* There is dead code in the ruby class that looks like it was attempting to generate a valid 9th check-digit, but it's not currently implemented.
* This PR changes the way this library generates and validates VIN numbers with the correct 9th check digit (see https://en.wikibooks.org/wiki/Vehicle_Identification_Numbers_(VIN_codes)/Check_digit)

### Other Information

* The previous regular expression in this library assumed the last 5 characters of the VIN are digits, but in the real world there are characters in the "Vehicle Serial Number" as well. The new generator takes this into consideration.
* This random generator has been benchmarked and optimized.