### PR TITLE
Fix formatting in internet/http.md documentation

### DIFF
--- a/doc/internet/http.md
+++ b/doc/internet/http.md
@@ -5,14 +5,9 @@ Available since version next.
 # Keyword arguments: group
 ```ruby
 Faker::Internet::HTTP.status_code #=> 418
-
 Faker::Internet::HTTP.status_code(group: :information) #=> 102
-
 Faker::Internet::HTTP.status_code(group: :successful) #=> 200
-
 Faker::Internet::HTTP.status_code(group: :redirect) #=> 306
-
 Faker::Internet::HTTP.status_code(group: :client_error) #=> 451
-
 Faker::Internet::HTTP.status_code(group: :server_error) #=> 502
 ```

--- a/doc/internet/http.md
+++ b/doc/internet/http.md
@@ -3,9 +3,16 @@
 Available since version next.
 
 # Keyword arguments: group
+```ruby
 Faker::Internet::HTTP.status_code #=> 418
+
 Faker::Internet::HTTP.status_code(group: :information) #=> 102
+
 Faker::Internet::HTTP.status_code(group: :successful) #=> 200
+
 Faker::Internet::HTTP.status_code(group: :redirect) #=> 306
+
 Faker::Internet::HTTP.status_code(group: :client_error) #=> 451
+
 Faker::Internet::HTTP.status_code(group: :server_error) #=> 502
+```


### PR DESCRIPTION
### Summary

In `doc/internet/http.md`, formatting was incorrect. There was no Ruby code formatting and as such all example code was formatted as regular text.

This has been fixed.

Thanks.