### PR TITLE
Remove deprecated ru paul documentation

### DIFF
--- a/doc/default/rupaul.md
+++ b/doc/default/rupaul.md
@@ -1,9 +1,0 @@
-# Faker::RuPaul
-
-Available since version 1.8.0.
-
-```ruby
-Faker::RuPaul.quote #=> "That's Funny, Tell Another One"
-
-Faker::RuPaul.queen #=> "Latrice Royale"
-```


### PR DESCRIPTION
### Summary

- Fix for #2649 

Once RuPaul generator is changed to Faker::TvShows::RuPaul, Faker::RuPaul is deprecated. It will remove deprecated Faker::RuPaul documentation file.

@stefannibrasil 