### PR TITLE
Adds Ruby 3.2 to the CI matrix. Updates checkout action version.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,6 +41,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
           - 'head'
           - truffleruby-head
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}


### PR DESCRIPTION
### Summary

Adds Ruby 3.2 the CI matrix.  Runs green on my fork.

Also updates the version of a checkout action that got missed.