### PR TITLE
Adjust the vin generation and validation algorithm - DO NOT MERGE

### DIFF
--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -8,7 +8,7 @@ module Faker
     MILEAGE_MAX = 90_000
     VIN_KEYSPACE = %w[A B C D E F G H J K L M N P R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9].freeze
     VIN_TRANSLITERATION = { A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9 }.freeze
-    VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
+    VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
     VIN_REGEX = /\A[A-HJ-NPR-Z0-9]{17}\z/.freeze
     SG_CHECKSUM_WEIGHTS = [3, 14, 2, 12, 2, 11, 1].freeze
     SG_CHECKSUM_CHARS = 'AYUSPLJGDBZXTRMKHEC'


### PR DESCRIPTION
### Summary

The vehicle vin generator has been "refactored" and no longer produces valid vins, but all current tests are passing.

The changes proposed in #2640 will fix this issue and pin the correct behavior in the event the vehicle vin code is ever slightly changed or refactored.

Without the tests proposed in #2640 the vins generated by this library would have to be put through a separate third-party vin validator program to ensure any changes to this codebase do not corrupt the algorithm.

### WARNING - DO NOT MERGE THIS CODE

This is a POC to show that the current tests for vehicle vins will not catch anyone refactoring the code. But #2640 fixes this issue and is ready to merge.