### PR TITLE
Adjust the vin generation and validation algorithm (2) - DO NOT MERGE

### DIFF
--- a/lib/faker/default/vehicle.rb
+++ b/lib/faker/default/vehicle.rb
@@ -8,7 +8,7 @@ module Faker
     MILEAGE_MAX = 90_000
     VIN_KEYSPACE = %w[A B C D E F G H J K L M N P R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9].freeze
     VIN_TRANSLITERATION = { A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, J: 1, K: 2, L: 3, M: 4, N: 5, P: 7, R: 9, S: 2, T: 3, U: 4, V: 5, W: 6, X: 7, Y: 8, Z: 9 }.freeze
-    VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
+    VIN_WEIGHT = [8, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4, 3, 2].freeze
     VIN_REGEX = /\A[A-HJ-NPR-Z0-9]{17}\z/.freeze
     SG_CHECKSUM_WEIGHTS = [3, 14, 2, 12, 2, 11, 1].freeze
     SG_CHECKSUM_CHARS = 'AYUSPLJGDBZXTRMKHEC'

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -17,6 +17,9 @@ class TestFakerVehicle < Test::Unit::TestCase
     100.times do
       assert valid_vin(@tester.vin)
     end
+    assert valid_vin('11111111111111111') # known valid test string
+    assert valid_vin('FAKERGEM5FAKERGEM') # valid checksum
+    refute valid_vin('ABCDEFG1234567890') # invalid checksum
   end
 
   def test_manufacture


### PR DESCRIPTION
### Summary

These tests are intentionally broken.

The vehicle vin generator has been "refactored" and no longer produces valid vins, but this is a POC to show that other tests are necessary for vehicle vins, and they "catch" the issue.

### WARNING - DO NOT MERGE THIS CODE

This is a POC to show that the current tests for vehicle vins will not catch anyone refactoring the code. But #2640 fixes this issue and is ready to merge.