### PR TITLE
Fix explanation what Marketing.buzzwords does

### DIFF
--- a/lib/faker/default/marketing.rb
+++ b/lib/faker/default/marketing.rb
@@ -6,7 +6,7 @@ module Faker
 
     class << self
       ##
-      # Produces the name of a video game console or platform.
+      # Produces a few marketing buzzwords.
       #
       # @return [String]
       #


### PR DESCRIPTION
### Summary

I noticed that the `Marketing.buzzwords` docs claimed it would produce Video Games: https://www.rubydoc.info/gems/faker/Faker/Marketing#buzzwords-class_method

> Produces the name of a video game console or platform.

I think this was a copy paste mistake, as this is also the (correct) description of `Games.platform`: https://www.rubydoc.info/gems/faker/Faker/Game#platform-class_method