### PR TITLE
add chess sport

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main
 
   - [Faker::Sports](doc/sports/sports.md)
   - [Faker::Sports::Basketball](doc/sports/basketball.md)
+  - [Faker::Sports::Chess](doc/sports/chess.md)
   - [Faker::Sports::Football](doc/sports/football.md)
   - [Faker::Sports::Mountaineering](doc/sports/mountaineering.md)
   - [Faker::Sports::Volleyball](doc/sports/volleyball.md)

--- a/doc/sports/chess.md
+++ b/doc/sports/chess.md
@@ -1,0 +1,17 @@
+# Faker::Sports::Chess
+
+```ruby
+Faker::Sports::Chess.player #=> "Emanuel Lasker"
+
+Faker::Sports::Chess.federation #=> "CUB"
+
+Faker::Sports::Chess.tournament #=> "Khanty-Mansisyk (Grand Prix 2014–2015)"
+
+Faker::Sports::Chess.rating #=> "2514"
+
+Faker::Sports::Chess.rating(from: 2600, to: 2700) #=> "2688"
+
+Faker::Sports::Chess.opening #=> "Queen’s Indian Defense"
+
+Faker::Sports::Chess.title #=> "WGM"
+```

--- a/lib/faker/sports/chess.rb
+++ b/lib/faker/sports/chess.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Faker
+  class Sports
+    class Chess < Base
+      class << self
+        ##
+        # Produces the name of a chess player name.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Sports::Chess.player #=> "Golden State Warriors"
+        #
+        # @faker.version next
+        def player
+          fetch('chess.players')
+        end
+
+        ##
+        # Produces a long (alpha-3) ISO 3166 country code.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Chess.federation #=> "COL"
+        #
+        # @faker.version next
+        def federation
+          Faker::Address.country_code_long
+        end
+
+        def tournament
+          ##
+          # Produces the name of a famous chess tournament name.
+          #
+          # @return [String]
+          #
+          # @example
+          #   Faker::Chess.tournament #=> "Khanty-Mansisyk (Candidates Tournament)"
+          #
+          # @faker.version next
+          fetch('chess.tournaments')
+        end
+
+        def rating(from: 2000, to: 2900)
+          ##
+          # Produces a rating between two provided values. Boundaries are inclusive.
+          #
+          # @param from [Numeric] The lowest number to include.
+          # @param to [Numeric] The highest number to include.
+          # @return [Numeric]
+          #
+          # @example
+          #   Faker::Sports::Chess.rating #=> 2734
+          #   Faker::Sports::Chess.rating(from: 2400, to: 2700) #=> 2580
+          #
+          # @faker.version next
+          Faker::Base.rand_in_range(from, to)
+        end
+
+        ##
+        # Produces the name of a chess opening.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Sports::Chess.opening #=> "Giuoco Piano"
+        #
+        # @faker.version next
+        def opening
+          fetch('chess.openings')
+        end
+
+        ##
+        # Produces a chess title.
+        #
+        # @return [String]
+        #
+        # @example
+        #   Faker::Sports::Chess.title #=> "GM"
+        #
+        # @faker.version next
+        def title
+          fetch('chess.titles')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/chess.yml
+++ b/lib/locales/en/chess.yml
@@ -1,0 +1,103 @@
+en:
+  faker:
+    chess:
+      players: 
+        - Alexander Alekhine
+        - Alexei Shirov
+        - Alexis Vargas
+        - Anatoly Karpov
+        - Bobby Fischer
+        - Emanuel Lasker
+        - Fabiano Caruana
+        - Garry Kasparov
+        - Hikaru Nakamura
+        - Jose Raul Capablanca
+        - Levon Aronian
+        - Magnus Carlsen
+        - Mikhail Botvinnik
+        - Radjabov Teimour 
+        - Sergey Karjakin
+        - Tigran Petrosian
+        - Viswanathan Anand
+        - Vladimir Kramnik
+        - Wesley So
+        - Paul Morphy
+      tournaments:
+        - Wijk aan Zee
+        - Linares
+        - Astrakhan
+        - Dortmund
+        - Shanghai
+        - Bilbao
+        - Nanjing
+        - Moscow
+        - London
+        - Moscow
+        - Tromsø (Chess World Cup)
+        - Paris (Grand Prix 2012–2013)
+        - Bucharest
+        - Nizhny Novgorod (Russian Championship)
+        - Zurich
+        - Khanty-Mansisyk (Candidates Tournament)
+        - Tbilisi (Grand Prix 2014–2015)
+        - Khanty-Mansisyk (Grand Prix 2014–2015)
+        - Baku (Chess World Cup)
+        - London (Grand Chess Tour)
+        - Gibraltar
+      openings:
+        - Alekhine’s Defense
+        - Benko Gambit
+        - Benoni Defense
+        - Bird’s Opening
+        - Bogo-Indian Defense
+        - Budapest Gambit
+        - Catalan Opening
+        - Caro-Kann Defense
+        - Colle System
+        - Dutch Defense
+        - Giuoco Piano
+        - English Opening
+        - Evans Gambit
+        - Four Knights Game
+        - French Defense
+        - Grünfeld Defense
+        - Italian Game
+        - King’s Gambit
+        - King’s Indian Attack
+        - King’s Indian Defense
+        - King’s Pawn Game
+        - London System
+        - Modern Defense
+        - Nimzo-Indian Defense
+        - Nimzowitsch Defense
+        - Petrov’s Defense
+        - Philidor’s Defense
+        - Pirc Defense
+        - Queen’s Pawn Game
+        - Queen’s Gambit Accepted
+        - Queen’s Gambit Declined
+        - Queen’s Indian Defense
+        - Réti Opening
+        - Ruy Lopez
+        - Scandinavian Defense
+        - Scotch Game
+        - Sicilian Defense
+        - Slav Defense
+        - Torre Attack
+        - Two Knights Defense
+        - Vienna Game
+        - Wade Defense
+      titles:
+        - GM
+        - IM
+        - FM
+        - CM
+        - WGM
+        - WIM
+        - WFM
+        - WCM
+        - AGM
+        - AIM
+        - AFM
+        - ACM
+

--- a/test/faker/sports/test_faker_chess.rb
+++ b/test/faker/sports/test_faker_chess.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerChess < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Sports::Chess
+  end
+
+  def test_player
+    assert_match(/\w+/, @tester.player)
+  end
+
+  def test_federation
+    assert_match(/\w+/, @tester.federation)
+  end
+
+  def test_tournament
+    assert_match(/\w+/, @tester.tournament)
+  end
+
+  def test_rating
+    100.times do
+      random_number = @tester.rating(from: 2000, to: 2900)
+
+      assert random_number >= 2000, "Expected >= 2000, but got #{random_number}"
+      assert random_number <= 2900, "Expected <= 2900, but got #{random_number}"
+    end
+  end
+
+  def test_opening
+    assert_match(/\w+/, @tester.opening)
+  end
+
+  def test_title
+    assert_match(/\w+/, @tester.title)
+  end
+end


### PR DESCRIPTION
### Summary

Add a generator for the sport Chess.

### Other Information

Usage: I am working on [Chessfy](https://chessfy.com) development and this feature would have been quite useful