### PR TITLE
add digits to password

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -174,6 +174,10 @@ module Faker
         password << lower_chars[rand(lower_chars.count - 1)]
         character_bag += lower_chars
 
+        digits = ('1'..'9').to_a
+        password << digits[rand(digits.count - 1)]
+        character_bag += digits
+
         if character_types.include?(:mix_case)
           upper_chars = ('A'..'Z').to_a
           password << upper_chars[rand(upper_chars.count - 1)]

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -117,7 +117,12 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_password
-    assert_match(/\w{3}/, @tester.password)
+    password = @tester.password
+
+    assert_match(/\w{3}/, password)
+    assert_match(/\d/, password)
+    assert_match(/[a-z]/, password)
+    assert_match(/[A-Z]/, password)
   end
 
   def test_password_with_integer_arg


### PR DESCRIPTION
### Summary

Adds digits to generated passwords

Fixes Issue #2704

### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

If you are creating a new generator, share how you are going to use it. Use cases are important to make sure that our faker generators are useful. Also, add `@faker.version next` to help users know when a generator was added. See [this example](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/music/opera.rb#L68).

Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

Thanks for contributing to Faker! -->