### PR TITLE
Add deprecation messages to Faker::Internet.url and Faker::Internet.email

### DIFF
--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -75,6 +75,10 @@ Faker::Internet.url #=> "http://thiel.com/chauncey_simonis"
 Faker::Internet.url(host: 'example.com') #=> "http://example.com/clotilde.swift"
 Faker::Internet.url(host: 'example.com', path: '/foobar.html') #=> "http://example.com/foobar.html"
 
+# Keyword arguments: path, scheme
+Faker::Internet.safe_url #=> "http://example.com/chauncey_simonis"
+Faker::Internet.safe_url(path: '/foobar.html') #=> "http://example.com/foobar.html"
+
 # Keyword arguments: words, glue
 Faker::Internet.slug #=> "pariatur_laudantium"
 Faker::Internet.slug(words: 'foo bar') #=> "foo.bar"

--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -78,6 +78,7 @@ Faker::Internet.url(host: 'example.com', path: '/foobar.html') #=> "http://examp
 # Keyword arguments: path, scheme
 Faker::Internet.safe_url #=> "http://example.com/chauncey_simonis"
 Faker::Internet.safe_url(path: '/foobar.html') #=> "http://example.com/foobar.html"
+Faker::Internet.safe_url(path: '/fake_test_path', scheme: 'https')  #=> "https://example.com/fake_test_path"
 
 # Keyword arguments: words, glue
 Faker::Internet.slug #=> "pariatur_laudantium"

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -573,7 +573,7 @@ module Faker
       # @faker.version next
       def user(*args)
         user_hash = {}
-        args = %w[username safe_email] if args.empty?
+        args = %w[username email] if args.empty?
         args.each { |arg| user_hash[:"#{arg}"] = send(arg) }
         user_hash
       end

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -15,6 +15,8 @@ module Faker
     ].each(&:freeze).freeze
 
     class << self
+      extend Gem::Deprecate
+
       ##
       # Returns the email address
       #
@@ -39,6 +41,7 @@ module Faker
         sanitized_local_part = sanitize_email_local_part(local_part)
         construct_email(sanitized_local_part, domain_name(domain: domain))
       end
+      deprecate :email, 'Faker::Internet.safe_email', 2023, 3
 
       ##
       # Returns the email address with domain either gmail.com, yahoo.com or hotmail.com
@@ -56,6 +59,7 @@ module Faker
           fetch('internet.free_email')
         )
       end
+      deprecate :free_email, 'Faker::Internet.safe_email', 2023, 3
 
       ##
       # Returns the email address with fixed domain name as 'example'
@@ -428,6 +432,23 @@ module Faker
       def url(host: domain_name, path: "/#{username}", scheme: 'http')
         "#{scheme}://#{host}#{path}"
       end
+      deprecate :url, 'Faker::Internet.safe_url', 2023, 3
+
+      ##
+      # Returns a URL with safe domain address (.example or .test)
+      #
+      # @return [String]
+      #
+      # @param path [String]
+      # @param scheme [String]
+      #
+      # @example
+      #   Faker::Internet.safe_url                                            #=> "http://example.com/hung.macejkovic"
+      #   Faker::Internet.safe_url(path: '/fake_test_path')                   #=> "http://example.com/fake_test_path"
+      #   Faker::Internet.safe_url(path: '/fake_test_path', scheme: 'https')  #=> "https://example.com/fake_test_path"
+      def safe_url(path: "/#{username}", scheme: 'http')
+        "#{scheme}://example.com#{path}"
+      end
 
       ##
       # Returns unique string in URL
@@ -552,7 +573,7 @@ module Faker
       # @faker.version next
       def user(*args)
         user_hash = {}
-        args = %w[username email] if args.empty?
+        args = %w[username safe_email] if args.empty?
         args.each { |arg| user_hash[:"#{arg}"] = send(arg) }
         user_hash
       end

--- a/lib/faker/default/twitter.rb
+++ b/lib/faker/default/twitter.rb
@@ -58,7 +58,7 @@ module Faker
           screen_name: screen_name,
           statuses_count: Faker::Number.between(to: 1, from: 100_000),
           time_zone: Faker::Address.time_zone,
-          url: Faker::Internet.url(host: 'example.com'),
+          url: Faker::Internet.safe_url,
           utc_offset: utc_offset,
           verified: Faker::Boolean.boolean(true_ratio: 0.1)
         }
@@ -104,7 +104,7 @@ module Faker
           retweet_count: Faker::Number.between(to: 1, from: 10_000),
           retweeted_status: nil,
           retweeted: false,
-          source: "<a href=\"#{Faker::Internet.url(host: 'example.com')}\" rel=\"nofollow\">#{Faker::Company.name}</a>",
+          source: "<a href=\"#{Faker::Internet.safe_url}\" rel=\"nofollow\">#{Faker::Company.name}</a>",
           text: Faker::Lorem.sentence,
           truncated: false
         }
@@ -174,9 +174,9 @@ module Faker
           ],
           media_url: media_url.sub('https://', 'http://'),
           media_url_https: media_url,
-          url: Faker::Internet.url(host: 'example.com'),
+          url: Faker::Internet.safe_url,
           display_url: 'example.com',
-          expanded_url: Faker::Internet.url(host: 'example.com'),
+          expanded_url: Faker::Internet.safe_url,
           type: 'photo',
           sizes: {
             medium: {

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -467,7 +467,7 @@ class TestFakerInternet < Test::Unit::TestCase
     user = @tester.user
 
     assert_match(/[a-z]+((_|\.)[a-z]+)?/, user[:username])
-    assert_match(/.+@.+\.\w+/, user[:safe_email])
+    assert_match(/.+@.+\.\w+/, user[:email])
   end
 
   def test_user_with_invalid_args

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -13,31 +13,45 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_email
-    assert_match(/.+@.+\.\w+/, @tester.email)
+    Gem::Deprecate.skip_during do
+      assert_match(/.+@.+\.\w+/, @tester.email)
+    end
   end
 
   def test_email_with_non_permitted_characters
-    assert_match(/mart#n@.+\.\w+/, @tester.email(name: 'martín'))
+    Gem::Deprecate.skip_during do
+      assert_match(/mart#n@.+\.\w+/, @tester.email(name: 'martín'))
+    end
   end
 
   def test_email_with_separators
-    assert_match(/.+\+.+@.+\.\w+/, @tester.email(name: 'jane doe', separators: '+'))
+    Gem::Deprecate.skip_during do
+      assert_match(/.+\+.+@.+\.\w+/, @tester.email(name: 'jane doe', separators: '+'))
+    end
   end
 
   def test_email_with_domain_option_given
-    assert_match(/.+@customdomain\.\w+/, @tester.email(name: 'jane doe', domain: 'customdomain'))
+    Gem::Deprecate.skip_during do
+      assert_match(/.+@customdomain\.\w+/, @tester.email(name: 'jane doe', domain: 'customdomain'))
+    end
   end
 
   def test_email_with_domain_option_given_with_domain_suffix
-    assert_match(/.+@customdomain\.customdomainsuffix/, @tester.email(name: 'jane doe', domain: 'customdomain.customdomainsuffix'))
+    Gem::Deprecate.skip_during do
+      assert_match(/.+@customdomain\.customdomainsuffix/, @tester.email(name: 'jane doe', domain: 'customdomain.customdomainsuffix'))
+    end
   end
 
   def test_free_email
-    assert_match(/.+@(gmail|hotmail|yahoo)\.com/, @tester.free_email)
+    Gem::Deprecate.skip_during do
+      assert_match(/.+@(gmail|hotmail|yahoo)\.com/, @tester.free_email)
+    end
   end
 
   def test_free_email_with_non_permitted_characters
-    assert_match(/mart#n@.+\.\w+/, @tester.free_email(name: 'martín'))
+    Gem::Deprecate.skip_during do
+      assert_match(/mart#n@.+\.\w+/, @tester.free_email(name: 'martín'))
+    end
   end
 
   def test_safe_email
@@ -383,8 +397,14 @@ class TestFakerInternet < Test::Unit::TestCase
     assert_match(/^foo(_|\.|-)bar(_|\.|-)baz$/, @tester.slug(words: 'Foo.. bAr., baZ,,'))
   end
 
+  def test_safe_url
+    assert_match %r{^https://example\.com/username$}, @tester.safe_url(path: '/username', scheme: 'https')
+  end
+
   def test_url
-    assert_match %r{^https://domain\.com/username$}, @tester.url(host: 'domain.com', path: '/username', scheme: 'https')
+    Gem::Deprecate.skip_during do
+      assert_match %r{^https://domain\.com/username$}, @tester.url(host: 'domain.com', path: '/username', scheme: 'https')
+    end
   end
 
   def test_device_token
@@ -447,7 +467,7 @@ class TestFakerInternet < Test::Unit::TestCase
     user = @tester.user
 
     assert_match(/[a-z]+((_|\.)[a-z]+)?/, user[:username])
-    assert_match(/.+@.+\.\w+/, user[:email])
+    assert_match(/.+@.+\.\w+/, user[:safe_email])
   end
 
   def test_user_with_invalid_args


### PR DESCRIPTION
### Summary

`Faker::Internet.url` and `Faker::Internet.email` are not following RFC2606
recommendations for using reserved Top Level DNS Names.

Faker is moving in the direction of only generating safe emails and url
addresses, i.e., with `test` and `example` top level domains only.

To help users transition to this breaking change, we need to notify them.
This commit adds deprecation messages to `Faker::Internet.url` and `Faker::Internet.email` generators.

Next, `Faker::Internet.url`, and `Faker::Internet.email` will be updated
to only generate safe results.

This PR is the first part that closes #2431 

### Other Information

I didn't add the skip block for the locale tests because there are a lot of files that use these generators. So we will have verbose test logs until the deprecation is removed.

`Faker::Internet.safe_url` and `Faker::Internet.safe_email` will be removed and the existing `Faker::Internet.url` and `Faker::Internet.email` generators will generate safe values only. `Faker::Internet.free_email` will also be removed.