### PR TITLE
Introduce PositionalGenerator

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -62,6 +62,10 @@ module Faker
         letterify(numerify(string))
       end
 
+      def generate(as_type, &block)
+        PositionalGenerator.new(as_type, &block).generate
+      end
+
       # Given a regular expression, attempt to generate a string
       # that would match it.  This is a rather simple implementation,
       # so don't be shocked if it blows up on you in a spectacular fashion.

--- a/lib/faker/default/company.rb
+++ b/lib/faker/default/company.rb
@@ -330,7 +330,12 @@ module Faker
       #
       # @faker.version 1.9.2
       def south_african_pty_ltd_registration_number
-        regexify(%r{\d{4}/\d{4,10}/07})
+        generate(:string) do |g|
+          g.int(length: 4)
+          g.lit('/')
+          g.int(ranges: [1000..9_999_999_999])
+          g.lit('/07')
+        end
       end
 
       ##
@@ -343,7 +348,18 @@ module Faker
       #
       # @faker.version 1.9.2
       def south_african_close_corporation_registration_number
-        regexify(%r{(CK\d{2}|\d{4})/\d{4,10}/23})
+        generate(:string) do |g|
+          g.oneof do |one|
+            one.group do |g_|
+              g_.lit('CK')
+              g_.int(length: 2)
+            end
+            one.int(length: 4)
+          end
+          g.lit('/')
+          g.int(ranges: [1000..9_999_999_999])
+          g.lit('/23')
+        end
       end
 
       ##
@@ -356,7 +372,12 @@ module Faker
       #
       # @faker.version 1.9.2
       def south_african_listed_company_registration_number
-        regexify(%r{\d{4}/\d{4,10}/06})
+        generate(:string) do |g|
+          g.int(length: 4)
+          g.lit('/')
+          g.int(ranges: [1000..9_999_999_999])
+          g.lit('/06')
+        end
       end
 
       ##
@@ -369,7 +390,12 @@ module Faker
       #
       # @faker.version 1.9.2
       def south_african_trust_registration_number
-        regexify(%r{IT\d{2,4}/\d{2,10}})
+        generate(:string) do |g|
+          g.lit('IT')
+          g.int(ranges: [10..9999])
+          g.lit('/')
+          g.int(ranges: [10..9_999_999_999])
+        end
       end
 
       ##

--- a/lib/faker/default/driving_licence.rb
+++ b/lib/faker/default/driving_licence.rb
@@ -98,17 +98,28 @@ module Faker
       end
 
       def gb_licence_year(dob, gender)
-        decade = (dob.year / 10) % 10
-        year = dob.year % 10
-        month = gender == :female ? dob.month + 50 : dob.month
-        # Rubocop's preferred formatting is pretty gory
-        # rubocop:disable Style/FormatString
-        "#{decade}#{'%02d' % month}#{'%02d' % dob.day}#{year}"
-        # rubocop:enable Style/FormatString
+        generate(:string) do |g|
+          g.computed do
+            (dob.year / 10) % 10
+          end
+          g.computed do
+            gender_marker = gender == :female ? 50 : 0
+            format('%02d', (dob.month + gender_marker))
+          end
+          g.computed do
+            format('%02d', dob.day)
+          end
+          g.computed do
+            dob.year % 10
+          end
+        end
       end
 
       def gb_licence_checksum
-        regexify(/[0-9][A-Z][A-Z]/)
+        generate(:string) do |g|
+          g.int
+          g.letter(ranges: ['A'..'Z'], length: 2)
+        end
       end
     end
   end

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -46,9 +46,23 @@ module Faker
       end
 
       def ssn_valid
-        ssn = regexify(/[0-8]\d{2}-\d{2}-\d{4}/)
-        # We could still have all 0s in one segment or another
-        INVALID_SSN.any? { |regex| regex =~ ssn } ? ssn_valid : ssn
+        generate(:string) do |g|
+          g.computed(name: :first) do
+            range = [1..665, 667..899].sample(random: Faker::Config.random)
+            n = Faker::Base.rand(range)
+            format('%03d', n)
+          end
+          g.lit('-')
+          g.computed(name: :second) do
+            n = Faker::Base.rand(1..99)
+            format('%02d', n)
+          end
+          g.lit('-')
+          g.computed(name: :third) do
+            n = Faker::Base.rand(1..9999)
+            format('%04d', n)
+          end
+        end
       end
 
       ##

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -452,7 +452,7 @@ class PositionalGenerator
             raise ArgumentError, "unsupported range type: #{s.inspect}"
           end
         else
-         Faker::Base.sample(Faker::Base::Letters)
+        Faker::Base.sample(Faker::Base::Letters)
         end
       end
     end

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -52,7 +52,7 @@ class PositionalGenerator
     # @example a digit
     #   int
     #
-    # @example five digits named a
+    # @example five digits named :a
     #   int(name: :a, length: 5)
     #
     # @example digits of any length between 4 to 10
@@ -74,7 +74,7 @@ class PositionalGenerator
     # @example Generate a letter
     #   letter
     #
-    # @example Generate five uppercase letters named b
+    # @example Generate five uppercase letters named :b
     #   letter(name: :b, length: 5, ranges: ['A'..'Z'])
     #
     # @example Generate three-letter strings from within specific values
@@ -332,7 +332,9 @@ class PositionalGenerator
         end
       end
 
-      result.sort_by { |a| a[0] }
+      result.sort_by do |component_position, _, _|
+        component_position
+      end
     end
 
     ##
@@ -447,7 +449,7 @@ class PositionalGenerator
             raise ArgumentError, "unsupported range type: #{s.inspect}"
           end
         else
-          Faker::Base::Letters
+         Faker::Base.sample(Faker::Base::Letters)
         end
       end
     end

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -433,7 +433,10 @@ class PositionalGenerator
       end
 
       def generate(_)
-        (0...@length).inject('') { |acc, _| "#{acc}#{char}" }
+        @length.times.inject('') do |acc, _index|
+          generated_character = char
+          "#{acc}#{generated_character}"
+        end
       end
 
       private

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -1,0 +1,475 @@
+# frozen_string_literal: true
+
+##
+# A high level way to generate a list of generated values that fit a specific
+# format, such as an ID, postal code, or phone number.
+#
+# It provides generators for random digits and letters, hardcoded literal
+# strings, computed values based on previously-generated values, union (one-of)
+# selectors, and grouped generators.
+#
+# The generation allows for dependencies on previously generated values -- most
+# useful for computations -- and this object knows how to build that dependency
+# graph.
+#
+# See {PositionalGenerator::Builder}} for more.
+class PositionalGenerator
+  ##
+  # @param as_type [Symbol] +:string+ to generate a String
+  # @param block [Method] a function that interacts with the {Builder}
+  def initialize(as_type, &block)
+    @block = block
+    @generator_builder = Builder.new(as_type)
+  end
+
+  ##
+  # @return [String] if +as_type+ is +:string+
+  def generate
+    @block.call(@generator_builder)
+    @generator_builder.build
+  end
+
+  Component = Struct.new(:position, :name, :deps, :generator)
+
+  class Builder
+    attr_reader :as_type
+
+    def initialize(as_type)
+      @components = []
+      @as_type = as_type
+    end
+
+    ##
+    # Generate a value in the range of 0..9.
+    #
+    # @param name [Symbol] the name for this node in the group
+    # @param length [Integer] how many digits to generate
+    # @param ranges [Array<Range, Array, Set>] an array of limitations on the
+    #   generation. Elements can be a Range to select from within that range,
+    #   or an Array or Set to select an element from within the list.
+    # @return [void]
+    #
+    # @example a digit
+    #   int
+    #
+    # @example five digits named a
+    #   int(name: :a, length: 5)
+    #
+    # @example digits of any length between 4 to 10
+    #   int(ranges: [1_000 .. 9_999_999_999)
+    def int(name: nil, length: 1, ranges: nil)
+      @components << Component.new(@components.count, name, [], Int.new(length, ranges))
+    end
+
+    ##
+    # Generate a value in the range of 'a'..'Z'.
+    #
+    # @param name [Symbol] the name for this node in the group
+    # @param length [Integer, Range] how many letters to generate
+    # @param ranges [Array<Range, Array, Set>] an array of limitations on the
+    #   generation. Elements can be a Range to select from within that range,
+    #   or an Array or Set to select an element from within the list.
+    # @return [void]
+    #
+    # @example Generate a letter
+    #   letter
+    #
+    # @example Generate five uppercase letters named b
+    #   letter(name: :b, length: 5, ranges: ['A'..'Z'])
+    #
+    # @example Generate three-letter strings from within specific values
+    #   letter(ranges: ['700'..'799', '7A0'..'7F9'])
+    def letter(name: nil, length: 1, ranges: 'a'..'Z')
+      @components << Component.new(@components.count, name, [], Letter.new(length, ranges))
+    end
+
+    ##
+    # Generate a literal String
+    #
+    # @param value [String]
+    # @param name [Symbol] the name for this node in the group
+    # @return [void]
+    # @example
+    #   lit("-")
+    def lit(value, name: nil)
+      @components << Component.new(@components.count, name, [], Literal.new(value))
+    end
+
+    ##
+    # Fill the position with an arbitrary value.
+    #
+    # @param name [Symbol] the name for this node in the group
+    # @param deps [Array<Symbol>] the name of other fields that this one depends on
+    # @param block [Method] the block that yields the arbitrary value. Its
+    #   arguments are the deps.
+    # @return [void]
+    #
+    # @example Today's date
+    #   computed do
+    #     Date.today
+    #   end
+    #
+    # @example A check digit
+    #   int(name: :a, length: 5)
+    #   computed(deps: [:a]) do |a|
+    #     a.to_s.bytes.sum % 10
+    #   end
+    def computed(name: nil, deps: [], &block)
+      @components << Component.new(@components.count, name, deps, Computed.new(block))
+    end
+
+    ##
+    # Fill the position with one of the results from the given generators.
+    #
+    # @param name [Symbol] the name for this node in the group
+    # @param block [Method] subgenerator block
+    # @return [void]
+    #
+    # @example Either five digits, or two letters
+    #   oneof do |or_else|
+    #     or_else.int(length: 5)
+    #     or_else.letter(length: 2)
+    #   end
+    #
+    # @example Either one letter; or a slash, five digits, then a slash.
+    #   oneof do |or_else|
+    #     or_else.letter
+    #     or_else.group do |g_|
+    #       g_.lit("/")
+    #       g_.digit(length: 5)
+    #       g_.lit("/")
+    #     end
+    #   end
+    def oneof(name: nil, &block)
+      @components << Component.new(@components.count, name, [], Oneof.new(self, block))
+    end
+
+    ##
+    # A group of generators. Useful for {#oneof}.
+    #
+    # @param name [Symbol] the name for this node in the group
+    # @param block [Method] a subgenerator block
+    # @return [void]
+    def group(name: nil, &block)
+      @components << Component.new(@components.count, name, [], Group.new(@as_type, block))
+    end
+
+    ##
+    # Generate the value.
+    #
+    # @return [String] if +as_type+ is +:string+
+    def build
+      graph = build_graph
+      stack = build_stack(graph)
+      values = generate_values(stack)
+      convert(values)
+    end
+
+    private
+
+    ##
+    # Turn the components into a graph following dependencies.
+    #
+    # @return [Array<(Integer, Integer)>]
+    #
+    # Components can have dependencies. Here's one where a computation (b)
+    # depends on a value generated after it (c):
+    #
+    #     @components = [
+    #       Int.new(0, :a, 1, nil),
+    #       Computed.new(1, :b, [:c]) { |c| c + 1 },
+    #       Int.new(2, :c, 1, nil),
+    #     ]
+    #
+    # We can think of a graph like so:
+    #
+    #      (a)  (c)
+    #       |    |
+    #       |   (b)
+    #       \   /
+    #        end
+    #
+    # Or in Mermaid:
+    #
+    # ```mermaid
+    # stateDiagram-v2
+    #     a --> [*]
+    #     c --> b
+    #     b --> [*]
+    # ```
+    #
+    # This method builds that graph, using their positional locations as the
+    # ID. The end state is represented as +nil+. So continuing the example
+    # above, it will give this output:
+    #
+    #     [
+    #       [0, nil],
+    #       [2, 1],
+    #       [1, nil],
+    #     ]
+    #
+    # Later we can look up the appropriate component by indexing into the
+    # +@components+ array.
+    def build_graph
+      graph = []
+
+      # rubocop:disable Style/CombinableLoops
+      @components.each do |component|
+        component.deps.each do |dep|
+          dep_component = @components.detect { |c| c.name == dep }
+          raise if dep_component.nil?
+
+          graph.push([dep_component.position, component.position])
+        end
+      end
+
+      @components.each do |component|
+        graph.push([component.position, nil]) if graph.none? { |(from, _to)| from == component.position }
+      end
+      # rubocop:enable Style/CombinableLoops
+
+      graph
+    end
+
+    ##
+    # Produce a stack of components to evaluate in sequence.
+    #
+    # @param graph [Array<(Integer, Integer)>]
+    # @return [Array<Array<Int>>]
+    #
+    # Now that we have a graph, we know enough to determine how to traverse the
+    # generators such that all dependencies are met.
+    #
+    # The initial stack is an array of all the free traversals to the goal
+    # (where the +to+ is +nil+).
+    #
+    # Loop over the top of the stack:
+    # - The next array is all the nodes that lead into the nodes atop the
+    #    stack.
+    # - If the next array has values, push that onto the top of the stack.
+    # - If the next array is empty, we are done.
+    #
+    # For example, given the graph:
+    #
+    #     [
+    #       [0, nil],
+    #       [2, 1],
+    #       [1, nil],
+    #     ]
+    #
+    # The initial stack is:
+    #
+    #     [
+    #       [0, 1]
+    #     ]
+    #
+    # We loop over the top of the stack, +[0, 1]+, and find all the nodes of
+    # the graph that lead there. Nothing leads to +0+, and +2+ leads to +1+.
+    #
+    # Therefore, push +[2]+ to the top of the stack.
+    #
+    # Repeat for +[2]+. Nothing leads to +2+, so our new goal is +[]+. This is
+    # empty, so don't push it onto the stack. We are done.
+    #
+    # The final stack is:
+    #
+    #     [
+    #       [0, 1],
+    #       [2]
+    #     ]
+    def build_stack(graph)
+      require 'set'
+
+      terminals = graph.filter_map { |(from, to)| to.nil? && from }
+      stack = [terminals]
+      seen = Set.new(terminals)
+      deps = []
+
+      loop do
+        stack[-1].each do |e|
+          deps = graph.select { |(from, to)| to == e && !seen.include?(from) }.map do |from, _to|
+            seen << from
+            from
+          end
+          stack << deps if deps.any?
+        end
+
+        break if deps.empty?
+      end
+
+      stack
+    end
+
+    ##
+    # Turn a stack into a list of generated values.
+    #
+    # @param stack [Array<Array<Int>>]
+    # @return [Array<Object>] values sorted by desired order
+    #
+    # We start with a stack of components we need evaluated. We have been
+    # tracking these components by position, so first we need to look up the
+    # component in our list.
+    #
+    # From there we can get a list of all the dependencies for the component.
+    # These have already been evaluated, since +stack+ is sorted, so we fetch
+    # them.
+    #
+    # Since the stack was sorted by computation order, we must re-sort them
+    # into positional order at the end.
+    def generate_values(stack)
+      result = []
+
+      while (top = stack.pop)
+        top.each do |component_id|
+          component = @components[component_id]
+          raise if component.nil?
+
+          values = result.filter_map do |(_id, name, value)|
+            value if component.deps.include?(name)
+          end
+
+          result << [component.position, component.name, component.generator.generate(values)]
+        end
+      end
+
+      result.sort_by { |a| a[0] }
+    end
+
+    ##
+    # @param values [Array<Object>]
+    # @return [String] if +@as_type+ is +:string+
+    # @raise [ArgumentError] if +@as_type+ is unsupported
+    def convert(values)
+      case @as_type
+      when :string
+        values.inject('') do |acc, (_, _, v)|
+          "#{acc}#{v}"
+        end
+      else
+        raise ArgumentError, "unknown return type: #{@as_type}"
+      end
+    end
+
+    class Group
+      def initialize(as_type, block)
+        @as_type = as_type
+        @block = block
+      end
+
+      def generate(_)
+        builder = Builder.new(@as_type)
+        @block.call(builder)
+        builder.build
+      end
+    end
+
+    class Oneof
+      def initialize(builder, block)
+        @block = block
+        @builder = builder
+      end
+
+      def generate(...)
+        subgens = OneofSelector.new(@builder)
+        @block.call(subgens)
+        subgens.sample
+        subgens.generate(...)
+      end
+
+      class OneofSelector
+        def initialize(builder)
+          @subgens = []
+          @builder = Builder.new(builder.as_type)
+        end
+
+        def method_missing(meth, *args, **kwargs, &block)
+          @subgens << [meth, args, kwargs, block]
+        end
+
+        def respond_to_missing?(method_name, include_private = false)
+          @builder.respond_to?(method_name, include_private)
+        end
+
+        def sample
+          (meth, args, kwargs, block) = Faker::Base.sample(@subgens)
+          @builder.send(meth, *args, **kwargs, &block)
+        end
+
+        def generate(...)
+          @builder.build
+        end
+      end
+    end
+
+    class Int
+      def initialize(length, ranges)
+        # Internally we store only an Enumerable of Range values. So if we are
+        # not given any Ranges but are given a length, we need to convert the
+        # length to a Range.
+        #
+        # If the length is `5`, that means we should compute the Range `10000..99999`.
+        # We can compute the lower end with a simple exponent: 10^4 = 10000.
+        # The upper end is one less than an exponent: 10^5 - 1 = 99999.
+        if ranges.nil?
+          lower = 10**(length - 1)
+          upper = (10**length) - 1
+          ranges = [lower..upper]
+        end
+
+        @ranges = ranges
+      end
+
+      def generate(_)
+        Faker::Base.rand(@ranges.sample(random: Faker::Config.random))
+      end
+    end
+
+    class Letter
+      def initialize(length, ranges)
+        @length = length
+        @ranges = ranges
+      end
+
+      def generate(_)
+        (0...@length).inject('') { |acc, _| "#{acc}#{char}" }
+      end
+
+      private
+
+      def char
+        if @ranges
+          case s = @ranges.sample(random: Faker::Config.random)
+          when Range
+            s.to_a.sample(random: Faker::Config.random)
+          when Array, Set
+            s.sample(random: Faker::Config.random)
+          else
+            raise ArgumentError, "unsupported range type: #{s.inspect}"
+          end
+        else
+          Faker::Base::Letters
+        end
+      end
+    end
+
+    class Literal
+      def initialize(value)
+        @value = value
+      end
+
+      def generate(_)
+        @value
+      end
+    end
+
+    class Computed
+      def initialize(block)
+        @block = block
+      end
+
+      def generate(args)
+        @block.call(*args)
+      end
+    end
+  end
+end

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -79,7 +79,7 @@ class PositionalGenerator
     #
     # @example Generate three-letter strings from within specific values
     #   letter(ranges: ['700'..'799', '7A0'..'7F9'])
-    def letter(name: nil, length: 1, ranges: 'a'..'Z')
+    def letter(name: nil, length: 1, ranges: ['a'..'z', 'A'..'Z'])
       @components << Component.new(@components.count, name, [], Letter.new(length, ranges))
     end
 

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -12,7 +12,7 @@
 # useful for computations -- and this object knows how to build that dependency
 # graph.
 #
-# See {PositionalGenerator::Builder}} for more.
+# See {PositionalGenerator::Builder} for more.
 class PositionalGenerator
   ##
   # @param as_type [Symbol] +:string+ to generate a String

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -452,7 +452,7 @@ class PositionalGenerator
             raise ArgumentError, "unsupported range type: #{s.inspect}"
           end
         else
-        Faker::Base.sample(Faker::Base::Letters)
+          Faker::Base.sample(Faker::Base::Letters)
         end
       end
     end


### PR DESCRIPTION
One of the more common complaints among programmers is memorizing and understanding the regular expression syntax. It is concise but dense.

The `regexify` method uses a _subset_ of regex language to generate values. Since it is not exactly the Ruby regex language, this means that it is an additional mini-language to learn, with its own quirks.

The PositionalGenerator attempts to solve the same problem but more clearly. It is used for generating fixed-length strings where each byte has a specific value, such as postal codes, VINs, business IDs, and so on.

Three examples to show the tradeoffs:

`gb_licence_checksum`
---------------------

With `regexify`:

```ruby
regexify(/[0-9][A-Z][A-Z]/)
```

With `PositionalGenerator`:

```ruby
generate(:string) do |g|
  g.int
  g.letter(ranges: ['A'..'Z'], length: 2)
end
```

`ssn_valid`
-----------

With `regexify`:

```ruby
ssn = regexify(/[0-8]\d{2}-\d{2}-\d{4}/)
INVALID_SSN.any? { |regex| regex =~ ssn } ? ssn_valid : ssn
```

With `PositionalGenerator`:

```ruby
generate(:string) do |g|
  g.int(ranges: [100..665, 667..899])
  g.lit('-')
  g.int(ranges: [10..99])
  g.lit('-')
  g.int(ranges: [1000..9999])
end
```

`vin`
-----

With `regexify`:

```ruby
front = 8.times.map { VIN_KEYSPACE.sample(random: Faker::Config.random) }.join
back = 8.times.map { VIN_KEYSPACE.sample(random: Faker::Config.random) }.join
checksum = "#{front}A#{back}".chars.each_with_index.map do |char, i|
  value = (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym])
  value * VIN_WEIGHT[i]
end.inject(:+) % 11
checksum = 'X' if checksum == 10
"#{front}#{checksum}#{back}"
```

With `PositionalGenerator`:

```ruby
generate(:string) do |g|
  g.letter(name: :wmi, ranges: ['100'..'199', '400'..'499', '500'..'599', '700'..'799', '7A0'..'7F9'])
  g.letter(name: :vds, length: 5, ranges: [VIN_KEYSPACE])
  g.computed(name: :checksum, deps: %i[wmi vds model_year plant_code vis]) do |wmi, vds, model_year, plant_code, vis|
    checksum = "#{wmi}#{vds}0#{model_year}#{plant_code}#{vis}".chars.each_with_index.map do |char, i|
      value = (char =~ /\A\d\z/ ? char.to_i : VIN_TRANSLITERATION[char.to_sym])
      value * VIN_WEIGHT[i]
    end.inject(:+) % 11

    if checksum == 10
      'X'
    else
      checksum
    end
  end
  g.letter(name: :model_year, length: 1, ranges: [VIN_KEYSPACE - %w[U Z 0]])
  g.letter(name: :plant_code, length: 1, ranges: [VIN_KEYSPACE])
  g.int(name: :vis, length: 6)
end
```

Summary
-------

As you can see, the `PositionalGenerator` is much more verbose than `regexify`.  The tradeoff is understanding and readability.

In this commit I replaced all simple uses of `regexify`. The method is still used as part of the i18n framework, though.