### PR TITLE
fix: Typo in Faker::Travel::Airport docs

### DIFF
--- a/doc/travel/airport.md
+++ b/doc/travel/airport.md
@@ -1,6 +1,6 @@
 # Faker::Travel::Airport
 
 ```ruby
-Faker::Movies::Travel::Airport.name(size: 'large', region: 'united_states') #=> "Los Angeles International Airport"
-Faker::Movies::Travel::Airport.iata(size: 'large', region: 'united_states') #=> "LAX"
+Faker::Travel::Airport.name(size: 'large', region: 'united_states') #=> "Los Angeles International Airport"
+Faker::Travel::Airport.iata(size: 'large', region: 'united_states') #=> "LAX"
 ```


### PR DESCRIPTION
Thank you for the awesome (and super fun) gem!. Found a small typo in the docs so I thought I'd put in a PR fixing it.

