### PR TITLE
fix(phone-number): remove leading zero from cell_phone_with_country_code

### DIFF
--- a/lib/faker/default/phone_number.rb
+++ b/lib/faker/default/phone_number.rb
@@ -65,7 +65,7 @@ module Faker
       #
       # @faker.version 1.9.2
       def cell_phone_with_country_code
-        "#{country_code} #{cell_phone}"
+        "#{country_code} #{cell_phone.gsub(/^0/, '')}"
       end
 
       ##

--- a/test/test_en_au_locale.rb
+++ b/test/test_en_au_locale.rb
@@ -35,4 +35,11 @@ class TestEnAuLocale < Test::Unit::TestCase
     assert_equal '0', mobile[0]
     assert_equal '4', mobile[1]
   end
+
+  def test_aussie_cell_phone_in_e164
+    mobile = Faker::PhoneNumber.cell_phone_in_e164
+
+    assert_equal '+61', mobile[0..2]
+    assert_not_equal '0', mobile[3]
+  end
 end

--- a/test/test_en_nz_locale.rb
+++ b/test/test_en_nz_locale.rb
@@ -41,6 +41,13 @@ class TestEnNzLocale < Test::Unit::TestCase
     assert_equal '2', cellphone[1]
   end
 
+  def test_en_nz_cell_phone_in_e164
+    mobile = Faker::PhoneNumber.cell_phone_in_e164
+
+    assert_equal '+64', mobile[0..2]
+    assert_not_equal '0', mobile[3]
+  end
+
   def test_en_nz_team_methods
     assert Faker::Team.sport.is_a? String
     assert Faker::Team.name.is_a? String


### PR DESCRIPTION
### Summary

Fixes Issue #2686 

When combining a country code and a cell phone number, the leading zero of the cell phone number should be removed for the E.164 formatting.

This PR changes the `cell_phone_with_country_code` to remove the leading zero after the country code.
This is under the assumption that no countries use a leading zero when combining a country code and a cell phone number (which is true for at least Aussie, NZ and Sweden).

### Other Information

[E164 Formatting reference](https://support.twilio.com/hc/en-us/articles/223183008-Formatting-International-Phone-Numbers)