### PR TITLE
Fix formatting in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ and it was the original impetus for the creation of this gem).
     - [Customization](#customization)
     - [Minitest and Faker \>= 2.22](#minitest-and-faker--222)
   - [Generators](#generators)
-    - [Travel](#travel)
   - [Contributing](#contributing)
   - [Versioning](#versioning)
   - [License](#license)
@@ -323,10 +322,13 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main
 </details>
 
 <details>
-  <summary>Creature</summary>
+  <summary>Travel</summary>
 
-### Travel
   - [Faker:Travel::Airport](doc/travel/airport.md)
+</details>
+
+<details>
+  <summary>Creature</summary>
 
   - [Faker::Creature::Animal](doc/creature/animal.md)
   - [Faker::Creature::Bird](doc/creature/bird.md)


### PR DESCRIPTION
Very small PR that fixes a formatting bug in README.md.  
1. The Travel link on line 41 didn't worked, because the Travel title was collapsed inside the Creature section.
2. Without knowing I wouldn't expect that the Travel section would be inside of Creature.

Before:    
<img width="314" alt="image" src="https://user-images.githubusercontent.com/17851143/222076722-3f7b59c3-621b-474a-bbb4-e52ce5637bc8.png">

---

After:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/17851143/222076895-469e6a8e-64bc-497b-af7c-5133ff3ccd4b.png">
