### PR TITLE
performance: remove unnecessary i18n locale reload

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -8,7 +8,6 @@ require 'i18n'
 Dir.glob(File.join(mydir, 'helpers', '*.rb')).sort.each { |file| require file }
 
 I18n.load_path += Dir[File.join(mydir, 'locales', '**/*.yml')]
-I18n.reload! if I18n.backend.initialized?
 
 module Faker
   module Config

--- a/test/test_i18n_reload.rb
+++ b/test/test_i18n_reload.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'open3'
+
+class TestI18nLoad < Test::Unit::TestCase
+  def test_faker_i18n
+    # run this code in a subshell to test require faker
+    # and proper initialization of i18n.
+    code = <<-RUBY
+      require 'bundler/inline'
+
+      gemfile do
+        source 'https://rubygems.org'
+        gem 'minitest'
+        gem 'i18n'
+      end
+
+      require 'minitest/autorun'
+      require 'i18n'
+
+      class TestI18nLoad < Minitest::Test
+        def test_faker_i18n
+          I18n.available_locales = [:en]
+          refute_predicate I18n.backend, :initialized?
+          I18n.translate('doesnt matter just triggering a lookup')
+
+          assert_predicate I18n.backend, :initialized?
+
+          assert require File.expand_path('#{File.dirname(__FILE__)}/../lib/faker')
+
+          assert Faker::Name.name
+        end
+      end
+    RUBY
+
+    cmd = %( ruby -e "#{code}" )
+    output, status = Open3.capture2e(cmd)
+
+    assert_equal 0, status, output
+  end
+end


### PR DESCRIPTION
### Summary

I18n is reloaded whenever load_path is set, so an additional reload is not needed and only increases load time (because all locale files are reloaded twice :disappointed:).

See https://github.com/ruby-i18n/i18n/blob/b4cd00d73234e369d713eb2607c729765bb3ec06/lib/i18n/config.rb#L135

### Other Information

The steps described in the [original issue](https://github.com/faker-ruby/faker/pull/811) that introduced the reload now work as expected, even without the reload.
