### PR TITLE
Speed up Internet::Password generation using constants

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -183,27 +183,27 @@ module Faker
         character_bag = []
 
         # use lower_chars by default and add upper_chars if mix_case
-        lower_chars = ('a'..'z').to_a
-        password << lower_chars[rand(lower_chars.count - 1)]
+        lower_chars = self::LLetters
+        password << sample(lower_chars)
         character_bag += lower_chars
 
         digits = ('0'..'9').to_a
-        password << digits[rand(digits.count - 1)]
+        password << sample(digits)
         character_bag += digits
 
-        if character_types.include?(:mix_case)
-          upper_chars = ('A'..'Z').to_a
-          password << upper_chars[rand(upper_chars.count - 1)]
+        if mix_case
+          upper_chars = self::ULetters
+          password << sample(upper_chars)
           character_bag += upper_chars
         end
 
-        if character_types.include?(:special_characters)
+        if special_characters
           special_chars = %w[! @ # $ % ^ & *]
-          password << special_chars[rand(special_chars.count - 1)]
+          password << sample(special_chars)
           character_bag += special_chars
         end
 
-        password << character_bag[rand(character_bag.count - 1)] while password.length < target_length
+        password << sample(character_bag) while password.length < target_length
 
         shuffle(password).join
       end


### PR DESCRIPTION
### Summary

When reviewing https://github.com/faker-ruby/faker/pull/2705, I found out that there is a way to speed up password generation for Faker::Internet by more than 30% (benchmarks below). Instead of creating a new array with desired characters every time, we can use constants already defined in Faker::Base.

Also, to improve readability, I've changed [rand(special_chars.count - 1)] with a predefined sample() method and shortened if statements to base on parameters.

I changed a minimal required password length to the first password test since the default min. length is 8 (not 3)

### Other Information

Benchmark I've run:
```
require 'benchmark'
puts Benchmark.measure { 500_000.times { Faker::Internet.password } }
```
Before the change I've got:
`3.272090   0.010629   3.282719 (  3.282693)`

After the change I've got:
`2.179874   0.005755   2.185629 (  2.185604)`

That is my first PR. I followed the guide, however, if I missed something, I am sorry!