### PR TITLE
Generate safe `email` and `domain_name` by default (RFC 2606)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,3 +109,7 @@ Security/Eval:
   Description: The use of eval represents a serious security risk.
   Exclude:
     - 'lib/faker/default/json.rb'
+
+Style/IfUnlessModifier:
+  Description: Checks for `if` and `unless` statements that would fit on one line if written as modifier `if`/`unless`. The cop also checks for modifier `if`/`unless` lines that exceed the maximum line length.
+  Enabled: false

--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -1,15 +1,29 @@
 # Faker::Internet
 
+### About faker-ruby transition to be RFC 2606 compliant
+
+faker-ruby is transitioning to no longer generating real email and url addresses.
+
+The migration plan is:
+- First step:
+  - change `email` and `domain_name` to be RFC 2606 compliant. Both now generate safe values by default using the Reserved Top Level DNS Names: `example` and `test`. To maintain backwards compatibility and give users the option to use non-safe domains at their own risk, custom domains are allowed.
+  - add deprecation message for `free_email` and `safe_email` users to switch to `email` instead.
+- Second step (after October 2023):
+  - remove deprecated generators and locales.
+
+To give users time, once the first step is released, users will have until October 2023 to make the necessary changes.
+
 ```ruby
 # Keyword arguments: name, username, email, password, domain_name, user_agent, uuid etc...
-Faker::Internet.user #=> { username: 'alexie', email: 'alexie@example.net' }
-Faker::Internet.user('username', 'email', 'password') #=> { username: 'alexie', email: 'alexie@example.net', password: 'DtEf9P8wS31iMyC' }
+Faker::Internet.user #=> { username: 'alexie', email: 'trudie@grant.test' }
+Faker::Internet.user('username', 'email', 'password') #=> { username: 'alexie', email: 'gayle@kohler.test', password: 'DtEf9P8wS31iMyC' }
 
-# Keyword arguments: name, separators
-Faker::Internet.email #=> "eliza@mann.net"
-Faker::Internet.email(name: 'Nancy') #=> "nancy@terry.biz"
-Faker::Internet.email(name: 'Janelle Santiago', separators: '+') #=> "janelle+santiago@becker.com"
-Faker::Internet.email(domain: 'example') #=> "alice@example.name"
+# Keyword arguments: name, separators, domain
+Faker::Internet.email #=> "eliza@mann.test"
+Faker::Internet.email(name: 'Nancy') #=> "nancy@terry.test"
+Faker::Internet.email(name: 'Janelle Santiago', separators: ['+']) #=> "janelle+santiago@becker.example"
+Faker::Internet.email(domain: 'gmail.com')  #=> "foo@gmail.com"
+Faker::Internet.email(name: 'sam smith', separators: ['-'], domain: 'test') #=> "sam-smith@test.test"
 
 # Keyword arguments: name
 Faker::Internet.free_email #=> "freddy@gmail.com"
@@ -44,13 +58,18 @@ Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true) #=> "3k
 Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true, special_characters: true) #=> "*%NkOnJsH4"
 
 # Keyword arguments: subdomain, domain
-Faker::Internet.domain_name #=> "effertz.info"
-Faker::Internet.domain_name(domain: "example") #=> "example.net"
-Faker::Internet.domain_name(subdomain: true, domain: "example") #=> "horse.example.org"
+Faker::Internet.domain_name #=> "herzog.example"
+Faker::Internet.domain_name(subdomain: true) #=> "tillman.kohler.test"
+Faker::Internet.domain_name(subdomain: true, domain: 'faker') #=> "ebert.faker.example"
+Faker::Internet.domain_name(domain: 'faker-ruby.org')  #=> "faker-ruby.org"
+Faker::Internet.domain_name(subdomain: true, domain: 'faker-ruby.org') #=> "foo.faker-ruby.org"
+Faker::Internet.domain_name(subdomain: true, domain: 'faker.faker-ruby.org')  #=> "faker.faker-ruby.org"
 
 Faker::Internet.domain_word #=> "haleyziemann"
 
+# Keyword arguments: safe ('example' and 'test' suffixes)
 Faker::Internet.domain_suffix #=> "info"
+Faker::Internet.domain_suffix(safe: true) #=> "example"
 
 Faker::Internet.ip_v4_address #=> "24.29.18.175"
 
@@ -71,7 +90,9 @@ Faker::Internet.mac_address #=> "e6:0d:00:11:ed:4f"
 Faker::Internet.mac_address(prefix: '55:44:33') #=> "55:44:33:02:1d:9b"
 
 # Keyword arguments: host, path, scheme
-Faker::Internet.url #=> "http://thiel.com/chauncey_simonis"
+Faker::Internet.url #=> "http://treutel.test/demarcus"
+Faker::Internet.url #=> "http://ullrich.example/fritz_braun"
+Faker::Internet.url(host: 'faker') #=> "http://faker/nakita"
 Faker::Internet.url(host: 'example.com') #=> "http://example.com/clotilde.swift"
 Faker::Internet.url(host: 'example.com', path: '/foobar.html') #=> "http://example.com/foobar.html"
 

--- a/doc/default/stripe.md
+++ b/doc/default/stripe.md
@@ -31,5 +31,5 @@ Use some of the other handy Faker classes for Stripe charge amounts and email.
 # Keyword arguments: from, to
 Faker::Number.between(from: 3, to: 10) #=> 100
 
-Faker::Internet.free_email #=> "freddy@gmail.com"
+Faker::Internet.email #=> "niesha@swaniawski-lynch.test"
 ```

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Faker
-  # rubocop:disable Style/IfUnlessModifier
   class Internet < Base
     # Private, Host, and Link-Local network address blocks as defined in https://en.wikipedia.org/wiki/IPv4#Special-use_addresses
     PRIVATE_IPV4_ADDRESS_RANGES = [
@@ -607,4 +606,3 @@ module Faker
     end
   end
 end
-# rubocop:enable Style/IfUnlessModifier

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Faker
+  # rubocop:disable Style/IfUnlessModifier
   class Internet < Base
     # Private, Host, and Link-Local network address blocks as defined in https://en.wikipedia.org/wiki/IPv4#Special-use_addresses
     PRIVATE_IPV4_ADDRESS_RANGES = [
@@ -15,6 +16,8 @@ module Faker
     ].each(&:freeze).freeze
 
     class << self
+      extend Gem::Deprecate
+
       ##
       # Returns the email address
       #
@@ -25,10 +28,11 @@ module Faker
       # @param domain [String]
       #
       # @example
-      #   Faker::Internet.email                                                           #=> "samsmith@faker.com"
-      #   Faker::Internet.email(name: 'smith')                                            #=> "smith@faker.com"
-      #   Faker::Internet.email(name: 'sam smith', separators: ['-'])                     #=> "sam-smith@faker.com"
-      #   Faker::Internet.email(name: 'sam smith', separators: ['-'], domain: 'gmail')    #=> "sam-smith@gmail.com"
+      #   Faker::Internet.email                                                           #=> "renee@zieme.test"
+      #   Faker::Internet.email(name: 'smith')                                            #=> "smith@bergnaum.test"
+      #   Faker::Internet.email(name: 'sam smith', separators: ['-'])                     #=> "smith-sam@tromp.example"
+      #   Faker::Internet.email(name: 'sam smith', separators: ['-'], domain: 'test')     #=> "sam-smith@test.example"
+      #   Faker::Internet.email(domain: 'gmail.com')                                      #=> "foo@gmail.com"
       def email(name: nil, separators: nil, domain: nil)
         local_part = if separators
                        username(specifier: name, separators: separators)
@@ -37,7 +41,14 @@ module Faker
                      end
 
         sanitized_local_part = sanitize_email_local_part(local_part)
-        construct_email(sanitized_local_part, domain_name(domain: domain))
+
+        generate_domain = if domain.nil?
+                            domain_name
+                          else
+                            domain_name(domain: domain)
+                          end
+
+        construct_email(sanitized_local_part, generate_domain)
       end
 
       ##
@@ -56,6 +67,7 @@ module Faker
           fetch('internet.free_email')
         )
       end
+      deprecate :free_email, :email, 2023, 10
 
       ##
       # Returns the email address with fixed domain name as 'example'
@@ -73,6 +85,7 @@ module Faker
           "example.#{sample(%w[org com net])}"
         )
       end
+      deprecate :safe_email, :email, 2023, 10
 
       ##
       # Returns the username
@@ -200,10 +213,12 @@ module Faker
       # @param domain [String]
       #
       # @example
-      #   Faker::Internet.domain_name                                       #=> "test.net"
-      #   Faker::Internet.domain_name(subdomain: true)                      #=> "test.faker.io"
-      #   Faker::Internet.domain_name(subdomain: true, domain: 'example')   #=> "faker.example.com"
-      #   Faker::Internet.domain_name(domain: 'faker')                      #=> "faker.org"
+      #   Faker::Internet.domain_name                                                   #=> "altenwerth-gerhold.example"
+      #   Faker::Internet.domain_name(subdomain: true)                                  #=> "metz.mclaughlin-brekke.test"
+      #   Faker::Internet.domain_name(subdomain: true, domain: 'faker')                 #=> "foo.faker.test"
+      #   Faker::Internet.domain_name(domain: 'faker-ruby.org')                         #=> "faker-ruby.org"
+      #   Faker::Internet.domain_name(subdomain: true, domain: 'faker-ruby.org')        #=> "foo.faker-ruby.org"
+      #   Faker::Internet.domain_name(subdomain: true, domain: 'faker.faker-ruby.org')  #=> "faker.faker-ruby.org"
       def domain_name(subdomain: false, domain: nil)
         with_locale(:en) do
           if domain
@@ -211,12 +226,18 @@ module Faker
               .split('.')
               .map { |domain_part| Char.prepare(domain_part) }
               .tap do |domain_elements|
-                domain_elements << domain_suffix if domain_elements.length < 2
-                domain_elements.unshift(Char.prepare(domain_word)) if subdomain && domain_elements.length < 3
+                if domain_elements.length < 2
+                  domain_elements << domain_suffix(safe: true)
+                end
+                if subdomain && domain_elements.length < 3
+                  domain_elements.unshift(Char.prepare(domain_word))
+                end
               end.join('.')
           else
-            [domain_word, domain_suffix].tap do |domain_elements|
-              domain_elements.unshift(Char.prepare(domain_word)) if subdomain
+            [domain_word, domain_suffix(safe: true)].tap do |domain_elements|
+              if subdomain
+                domain_elements.unshift(Char.prepare(domain_word))
+              end
             end.join('.')
           end
         end
@@ -253,10 +274,16 @@ module Faker
       # @return [String]
       #
       # @example
-      #   Faker::Internet.domain_suffix   #=> "com"
-      #   Faker::Internet.domain_suffix   #=> "biz"
-      def domain_suffix
-        fetch('internet.domain_suffix')
+      #   Faker::Internet.domain_suffix              #=> "com"
+      #   Faker::Internet.domain_suffix              #=> "biz"
+      #   Faker::Internet.domain_suffix(safe: true)  #=> "example"
+      #   Faker::Internet.domain_suffix(safe: true)  #=> "test"
+      def domain_suffix(safe: nil)
+        if safe
+          fetch('internet.safe_domain_suffix')
+        else
+          fetch('internet.domain_suffix')
+        end
       end
 
       ##
@@ -421,10 +448,10 @@ module Faker
       # @param scheme [String]
       #
       # @example
-      #   Faker::Internet.url                                                           #=> "http://sipes-okon.com/hung.macejkovic"
+      #   Faker::Internet.url                                                           #=> "http://treutel.test/demarcus"
       #   Faker::Internet.url(host: 'faker')                                            #=> "http://faker/shad"
-      #   Faker::Internet.url(host: 'faker', path: '/fake_test_path')                   #=> "http://faker/fake_test_path"
-      #   Faker::Internet.url(host: 'faker', path: '/fake_test_path', scheme: 'https')  #=> "https://faker/fake_test_path"
+      #   Faker::Internet.url(host: 'faker', path: '/docs')                             #=> "http://faker/docs"
+      #   Faker::Internet.url(host: 'faker', path: '/docs', scheme: 'https')            #=> "https://faker/docs"
       def url(host: domain_name, path: "/#{username}", scheme: 'http')
         "#{scheme}://#{host}#{path}"
       end
@@ -542,10 +569,10 @@ module Faker
       ##
       # Produces a randomized hash of internet user details
       # @example
-      #   Faker::Internet.user #=> { username: 'alexie', email: 'alexie@example.net' }
+      #   Faker::Internet.user #=> { username: 'alexie', email: 'trudie@grant.test' }
       #
       # @example
-      #   Faker::Internet.user('username', 'email', 'password') #=> { username: 'alexie', email: 'alexie@example.net', password: 'DtEf9P8wS31iMyC' }
+      #   Faker::Internet.user('username', 'email', 'password') #=> { username: 'alexie', email: 'gayle@kohler.test', password: 'DtEf9P8wS31iMyC' }
       #
       # @return [hash]
       #
@@ -580,3 +607,4 @@ module Faker
     end
   end
 end
+# rubocop:enable Style/IfUnlessModifier

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -12,7 +12,7 @@ module Faker
       super()
 
       @name = name || "#{Name.first_name} #{Name.last_name}"
-      @email = email || Internet.safe_email(name: self.name)
+      @email = email || Internet.email(name: self.name)
       @first_name, @last_name = self.name.split
     end
 

--- a/lib/faker/default/twitter.rb
+++ b/lib/faker/default/twitter.rb
@@ -63,7 +63,7 @@ module Faker
           verified: Faker::Boolean.boolean(true_ratio: 0.1)
         }
         user[:status] = Faker::Twitter.status(include_user: false) if include_status
-        user[:email] = Faker::Internet.safe_email if include_email
+        user[:email] = Faker::Internet.email if include_email
         user
       end
 

--- a/lib/locales/en/internet.yml
+++ b/lib/locales/en/internet.yml
@@ -10,6 +10,9 @@ en:
         - org
         - io
         - co
+      safe_domain_suffix:
+        - example
+        - test
       free_email:
         - gmail.com
         - yahoo.com

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../test_helper'
+require 'uri'
 
 class TestFakerInternet < Test::Unit::TestCase
   def setup
@@ -12,40 +13,93 @@ class TestFakerInternet < Test::Unit::TestCase
     Faker::Config.locale = @default_locale
   end
 
-  def test_email
-    assert_match(/.+@.+\.\w+/, @tester.email)
+  def test_email_with_no_arguments
+    deterministically_verify -> { @tester.email } do |result|
+      name, domain = result.split('@')
+
+      domain_name, domain_suffix = domain.split('.')
+
+      assert name.is_a? String
+      assert domain_name.is_a? String
+      assert_includes(%w[example test], domain_suffix)
+    end
   end
 
-  def test_email_with_non_permitted_characters
-    assert_match(/mart#n@.+\.\w+/, @tester.email(name: 'martín'))
+  def test_email_name_with_non_permitted_characters
+    deterministically_verify -> { @tester.email(name: 'martín') } do |result|
+      name, domain = result.split('@')
+      domain_name, domain_suffix = domain.split('.')
+
+      assert_equal('mart#n', name)
+      assert domain_name.is_a? String
+      assert_includes(%w[example test], domain_suffix)
+    end
   end
 
   def test_email_with_separators
-    assert_match(/.+\+.+@.+\.\w+/, @tester.email(name: 'jane doe', separators: '+'))
+    deterministically_verify -> { @tester.email(name: 'jane doe', separators: '+') } do |result|
+      name, domain = result.split('@')
+      domain_name, domain_suffix = domain.split('.')
+
+      assert_match(/(jane\+doe|doe\+jane)/, name)
+      assert domain_name.is_a? String
+      assert_includes(%w[example test], domain_suffix)
+    end
   end
 
-  def test_email_with_domain_option_given
-    assert_match(/.+@customdomain\.\w+/, @tester.email(name: 'jane doe', domain: 'customdomain'))
+  def test_email_with_domain_name_option_given
+    result = @tester.email(domain: 'customdomain')
+
+    name, domain = result.split('@')
+    domain_name, domain_suffix = domain.split('.')
+
+    assert name.is_a? String
+    assert_equal('customdomain', domain_name)
+    assert_includes(%w[example test], domain_suffix)
   end
 
-  def test_email_with_domain_option_given_with_domain_suffix
-    assert_match(/.+@customdomain\.customdomainsuffix/, @tester.email(name: 'jane doe', domain: 'customdomain.customdomainsuffix'))
+  def test_email_with_full_domain_option_given
+    deterministically_verify -> { @tester.email(domain: 'customdomain.org') } do |result|
+      name, domain = result.split('@')
+
+      assert name.is_a? String
+      assert_equal('customdomain.org', domain)
+    end
+  end
+
+  def test_email_with_name_seperators_domain
+    deterministically_verify -> { @tester.email(name: 'faker ruby', separators: '-', domain: 'test') } do |result|
+      name, domain = result.split('@')
+      domain_name, domain_suffix = domain.split('.')
+
+      assert_match(/(ruby-faker|faker-ruby)/, name)
+      assert_equal('test', domain_name)
+      assert_includes(%w[example test], domain_suffix)
+    end
   end
 
   def test_free_email
-    assert_match(/.+@(gmail|hotmail|yahoo)\.com/, @tester.free_email)
+    Gem::Deprecate.skip_during do
+      assert_match(/.+@(gmail|hotmail|yahoo)\.com/, @tester.free_email)
+    end
   end
 
   def test_free_email_with_non_permitted_characters
-    assert_match(/mart#n@.+\.\w+/, @tester.free_email(name: 'martín'))
+    Gem::Deprecate.skip_during do
+      assert_match(/mart#n@.+\.\w+/, @tester.free_email(name: 'martín'))
+    end
   end
 
   def test_safe_email
-    assert_match(/.+@example.(com|net|org)/, @tester.safe_email)
+    Gem::Deprecate.skip_during do
+      assert_match(/.+@example.(com|net|org)/, @tester.safe_email)
+    end
   end
 
   def test_safe_email_with_non_permitted_characters
-    assert_match(/mart#n@.+\.\w+/, @tester.safe_email(name: 'martín'))
+    Gem::Deprecate.skip_during do
+      assert_match(/mart#n@.+\.\w+/, @tester.safe_email(name: 'martín'))
+    end
   end
 
   def test_username
@@ -243,27 +297,73 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_domain_name_without_subdomain
-    assert_match(/[\w-]+\.\w+/, @tester.domain_name)
+    domain_name, domain_suffix = @tester.domain_name.split('.')
+
+    assert domain_name.is_a? String
+    assert_includes(%w[example test], domain_suffix)
   end
 
   def test_domain_name_with_subdomain
-    assert_match(/[\w-]+\.[\w-]+\.\w+/, @tester.domain_name(subdomain: true))
+    subdomain, domain_name, domain_suffix = @tester.domain_name(
+      subdomain: true
+    ).split('.')
+
+    assert domain_name.is_a? String
+    assert subdomain.is_a? String
+    assert_includes(%w[example test], domain_suffix)
   end
 
-  def test_domain_name_with_subdomain_and_with_domain_option_given
-    assert_match(/customdomain\.\w+/, @tester.domain_name(subdomain: true, domain: 'customdomain'))
+  def test_domain_name_with_subdomain_and_with_domain_name_option_given
+    subdomain, domain_name, domain_suffix = @tester.domain_name(
+      subdomain: true,
+      domain: 'customdomain'
+    ).split('.')
+
+    assert subdomain.is_a? String
+    assert_equal 'customdomain', domain_name
+    assert_includes(%w[example test], domain_suffix)
+  end
+
+  def test_domain_name_with_subdomain_and_with_full_domain_option_given
+    subdomain, domain_name, domain_suffix = @tester.domain_name(
+      subdomain: true,
+      domain: 'faker-ruby.org'
+    ).split('.')
+
+    assert subdomain.is_a? String
+    assert_equal 'faker-ruby', domain_name
+    assert_equal 'org', domain_suffix
   end
 
   def test_domain_name_with_subdomain_and_with_domain_option_given_with_domain_suffix
-    assert_match(/customdomain\.customdomainsuffix/, @tester.domain_name(subdomain: true, domain: 'customdomain.customdomainsuffix'))
+    subdomain, domain_name, domain_suffix = @tester.domain_name(
+      subdomain: true,
+      domain: 'faker.faker-ruby.org'
+    ).split('.')
+
+    assert_equal 'faker', subdomain
+    assert_equal 'faker-ruby', domain_name
+    assert_equal 'org', domain_suffix
   end
 
   def test_domain_word
     assert_match(/^[\w-]+$/, @tester.domain_word)
   end
 
-  def test_domain_suffix
-    assert_match(/^\w+(\.\w+)?/, @tester.domain_suffix)
+  def test_domain_suffix_with_no_arguments
+    result = @tester.domain_suffix
+
+    domain_suffixes_options = %w[com biz info name net org org io co]
+
+    assert_includes(domain_suffixes_options, result)
+  end
+
+  def test_domain_suffix_with_arguments
+    result = @tester.domain_suffix(safe: true)
+
+    safe_domain_suffixes_options = %w[example test]
+
+    assert_includes(safe_domain_suffixes_options, result)
   end
 
   def test_ip_v4_address
@@ -383,8 +483,27 @@ class TestFakerInternet < Test::Unit::TestCase
     assert_match(/^foo(_|\.|-)bar(_|\.|-)baz$/, @tester.slug(words: 'Foo.. bAr., baZ,,'))
   end
 
-  def test_url
-    assert_match %r{^https://domain\.com/username$}, @tester.url(host: 'domain.com', path: '/username', scheme: 'https')
+  def test_url_with_arguments
+    deterministically_verify -> { @tester.url(host: 'domain.com', path: '/username', scheme: 'https') } do |result|
+      uri = URI.parse(result)
+
+      assert_equal 'https', uri.scheme
+      assert_includes('domain.com', uri.host)
+      assert_equal '/username', uri.path
+    end
+  end
+
+  def test_url_with_no_arguments
+    deterministically_verify -> { @tester.url } do |result|
+      uri = URI.parse(result)
+
+      # example: http://zieme-bosco.example/porsche
+      # we just care about the last part here
+      suffix = uri.host.split('.').last
+
+      assert_equal 'http', uri.scheme
+      assert_includes(%w[example test], suffix)
+    end
   end
 
   def test_device_token

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -20,7 +20,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'google_oauth2', provider
     assert_equal 9, auth[:uid].length
     assert_equal 2, word_count(info[:name])
-    assert_match safe_email_regex(info[:first_name], info[:last_name]), info[:email]
+    assert_match email_regex(info[:first_name], info[:last_name]), info[:email]
     assert_equal info[:name].split.first, info[:first_name]
     assert_equal info[:name].split.last, info[:last_name]
     assert_instance_of String, info[:image]
@@ -62,7 +62,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, info[:name]
     assert_equal 2, word_count(info[:name])
     assert_equal custom_name, info[:name]
-    assert_match safe_email_regex(first_name, last_name), info[:email]
+    assert_match email_regex(first_name, last_name), info[:email]
     assert_equal first_name, info[:first_name]
     assert_equal last_name, info[:last_name]
     assert_equal custom_name, extra_raw_info[:name]
@@ -108,7 +108,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
 
     assert_equal 'facebook', provider
     assert_equal 7, uid.length
-    assert_match safe_email_regex(info[:first_name], info[:last_name]), info[:email]
+    assert_match email_regex(info[:first_name], info[:last_name]), info[:email]
     assert_equal 2, word_count(info[:name])
     assert_instance_of String, info[:first_name]
     assert_instance_of String, info[:last_name]
@@ -154,7 +154,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal last_name, info[:last_name]
     assert_equal last_name, extra_raw_info[:last_name]
 
-    assert_match safe_email_regex(first_name, last_name), info[:email]
+    assert_match email_regex(first_name, last_name), info[:email]
 
     assert_equal url, extra_raw_info[:link]
     assert_equal username, extra_raw_info[:username]
@@ -308,7 +308,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'linkedin', auth[:provider]
     assert_equal 6, auth[:uid].length
     assert_equal 2, word_count(info[:name])
-    assert_match safe_email_regex(first_name, last_name), info[:email]
+    assert_match email_regex(first_name, last_name), info[:email]
     assert_equal info[:name], info[:nickname]
     assert_instance_of String, info[:first_name]
     assert_instance_of String, info[:last_name]
@@ -349,7 +349,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 2, word_count(info[:name])
     assert_instance_of String, info[:name]
     assert_equal custom_name, info[:name]
-    assert_match safe_email_regex(first_name, last_name), info[:email]
+    assert_match email_regex(first_name, last_name), info[:email]
     assert_equal custom_name, info[:nickname]
     assert_equal first_name, info[:first_name]
     assert_equal last_name, info[:last_name]
@@ -388,7 +388,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'github', provider
     assert_equal 8, uid.length
     assert_equal uid, extra_raw_info[:id]
-    assert_match safe_email_regex(info[:first_name], info[:last_name]), info[:email]
+    assert_match email_regex(info[:first_name], info[:last_name]), info[:email]
     assert_equal info[:email], extra_raw_info[:email]
     assert_equal 2, word_count(name)
     assert_instance_of String, name
@@ -438,14 +438,14 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     auth            = @tester.github(name: custom_name)
     info            = auth[:info]
     extra_raw_info  = auth[:extra][:raw_info]
-    safe_email_re   = safe_email_regex(info[:first_name], info[:last_name])
+    expected_email_regex = email_regex(info[:first_name], info[:last_name])
 
     assert_equal custom_name, info[:name]
     assert_equal 2, word_count(info[:name])
     assert_instance_of String, info[:name]
     assert_equal custom_name, extra_raw_info[:name]
-    assert_match safe_email_re, info[:email]
-    assert_match safe_email_re, extra_raw_info[:email]
+    assert_match expected_email_regex, info[:email]
+    assert_match expected_email_regex, extra_raw_info[:email]
     assert_equal login, info[:nickname]
   end
 
@@ -482,7 +482,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'apple', auth[:provider]
     assert_instance_of String, auth[:uid]
     assert_equal 44, auth[:uid].length
-    assert_match safe_email_regex(first_name, last_name), info[:email]
+    assert_match email_regex(first_name, last_name), info[:email]
     assert_equal auth[:uid], info[:sub]
     assert_instance_of String, info[:first_name]
     assert_instance_of String, info[:last_name]
@@ -513,7 +513,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal 'auth0', auth[:provider]
     assert_instance_of String, auth[:uid]
     assert_equal 30, auth[:uid].length
-    assert_match safe_email_regex(first_name, last_name), info[:email]
+    assert_match email_regex(first_name, last_name), info[:email]
     assert_equal auth[:uid], info[:name]
     assert_instance_of String, info[:image]
     assert_instance_of String, info[:nickname]
@@ -546,7 +546,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     %w[female male].include?(test)
   end
 
-  def safe_email_regex(f_name, l_name)
-    /(#{f_name}(.|_)#{l_name}|#{l_name}(.|_)#{f_name})@example.(com|net|org)/i
+  def email_regex(first_name, last_name)
+    /(#{first_name}(.|_)#{last_name}|#{last_name}(.|_)#{first_name})@(.*).(example|test)/i
   end
 end

--- a/test/test_bg_locale.rb
+++ b/test/test_bg_locale.rb
@@ -25,7 +25,7 @@ class TestBgLocale < Test::Unit::TestCase
   end
 
   def test_bg_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_de_at_locale.rb
+++ b/test/test_de_at_locale.rb
@@ -34,7 +34,7 @@ class TestDeAtLocale < Test::Unit::TestCase
   end
 
   def test_de_at_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_de_locale.rb
+++ b/test/test_de_locale.rb
@@ -80,7 +80,7 @@ class TestDeLocale < Test::Unit::TestCase
   end
 
   def test_de_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -11,18 +11,16 @@ class TestDeterminism < Test::Unit::TestCase
   def test_determinism
     Faker::Config.random = Random.new(42)
 
-    Gem::Deprecate.skip_during do
-      @all_methods.each_index do |index|
-        store_result @all_methods[index]
-      end
+    @all_methods.each_index do |index|
+      store_result @all_methods[index]
+    end
 
-      @first_run.freeze
+    @first_run.freeze
 
-      Faker::Config.random = Random.new(42)
+    Faker::Config.random = Random.new(42)
 
-      @all_methods.each_index do |index|
-        assert deterministic_random? @first_run[index], @all_methods[index]
-      end
+    @all_methods.each_index do |index|
+      assert deterministic_random? @first_run[index], @all_methods[index]
     end
   end
 

--- a/test/test_ee_locale.rb
+++ b/test/test_ee_locale.rb
@@ -35,7 +35,7 @@ class TestEeLocale < Test::Unit::TestCase
   end
 
   def test_ee_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_en_ca_locale.rb
+++ b/test/test_en_ca_locale.rb
@@ -25,7 +25,7 @@ class TestEnCaLocale < Test::Unit::TestCase
   end
 
   def test_en_ca_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_en_ind_locale.rb
+++ b/test/test_en_ind_locale.rb
@@ -25,7 +25,7 @@ class TestEnIndLocale < Test::Unit::TestCase
   end
 
   def test_en_ind_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_en_nep_locale.rb
+++ b/test/test_en_nep_locale.rb
@@ -35,7 +35,7 @@ class TestEnNepLocale < Test::Unit::TestCase
   end
 
   def test_en_nep_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 end

--- a/test/test_en_pak_locale.rb
+++ b/test/test_en_pak_locale.rb
@@ -24,7 +24,7 @@ class TestEnPakLocale < Test::Unit::TestCase
   end
 
   def test_en_pak_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_es_locale.rb
+++ b/test/test_es_locale.rb
@@ -73,7 +73,7 @@ class TestEsLocale < Test::Unit::TestCase
   end
 
   def test_es_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_es_mx_locale.rb
+++ b/test/test_es_mx_locale.rb
@@ -33,7 +33,7 @@ class TestEsMxLocale < Test::Unit::TestCase
   end
 
   def test_es_mx_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_fr_ca_locale.rb
+++ b/test/test_fr_ca_locale.rb
@@ -48,7 +48,7 @@ class TestFrCaLocale < Test::Unit::TestCase
   end
 
   def test_fr_ca_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_fr_ch_locale.rb
+++ b/test/test_fr_ch_locale.rb
@@ -45,7 +45,7 @@ class TestFrChLocale < Test::Unit::TestCase
   end
 
   def test_fr_ch_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_fr_locale.rb
+++ b/test/test_fr_locale.rb
@@ -90,7 +90,7 @@ class TestFrLocale < Test::Unit::TestCase
   end
 
   def test_fr_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_hy_locale.rb
+++ b/test/test_hy_locale.rb
@@ -104,8 +104,7 @@ class TestHyLocale < Test::Unit::TestCase
 
   def test_hy_internet_methods
     assert_kind_of String, Faker::Internet.email
-    assert_kind_of String, Faker::Internet.free_email
-    assert_kind_of String, Faker::Internet.safe_email
+    assert_kind_of String, Faker::Internet.email
     assert_kind_of String, Faker::Internet.domain_name
     assert_kind_of String, Faker::Internet.domain_suffix
     assert_kind_of String, Faker::Internet.domain_word

--- a/test/test_it_locale.rb
+++ b/test/test_it_locale.rb
@@ -35,7 +35,7 @@ class TestItLocale < Test::Unit::TestCase
   end
 
   def test_it_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_ko_locale.rb
+++ b/test/test_ko_locale.rb
@@ -49,7 +49,7 @@ class TestKoLocale < Test::Unit::TestCase
   end
 
   def test_ko_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_lv_locale.rb
+++ b/test/test_lv_locale.rb
@@ -46,7 +46,7 @@ class TestLvLocale < Test::Unit::TestCase
   end
 
   def test_lv_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_nl_locale.rb
+++ b/test/test_nl_locale.rb
@@ -42,7 +42,7 @@ class TestNlLocale < Test::Unit::TestCase
   end
 
   def test_nl_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_pl_locale.rb
+++ b/test/test_pl_locale.rb
@@ -61,7 +61,7 @@ class TestPlLocale < Test::Unit::TestCase
   end
 
   def test_pl_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_pt_br_locale.rb
+++ b/test/test_pt_br_locale.rb
@@ -89,10 +89,15 @@ class TestPtBrLocale < Test::Unit::TestCase
   end
 
   def test_pt_br_internet_methods
-    assert Faker::Internet.free_email.is_a? String
-    assert_match(/^[a-z0-9._-]+@[a-z0-9]+.[a-z]+.([a-z]+)?$/i, Faker::Internet.free_email)
+    deterministically_verify -> { Faker::Internet.email } do |result|
+      name, domain = result.split('@')
+      domain_name, domain_suffix = domain.split('.')
 
-    assert Faker::Internet.domain_suffix.is_a? String
+      assert name.is_a? String
+      assert domain_name.is_a? String
+      assert_includes(%w[example test], domain_suffix)
+      assert_match(/^[a-z0-9._-]+@[a-z0-9]+.[a-z]+.([a-z]+)?$/i, result)
+    end
   end
 
   def test_pt_br_job_methods

--- a/test/test_pt_locale.rb
+++ b/test/test_pt_locale.rb
@@ -26,7 +26,7 @@ class TestPtLocale < Test::Unit::TestCase
   end
 
   def test_pt_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_ru_locale.rb
+++ b/test/test_ru_locale.rb
@@ -44,7 +44,7 @@ class TestRuLocale < Test::Unit::TestCase
   end
 
   def test_ru_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_sk_locale.rb
+++ b/test/test_sk_locale.rb
@@ -37,7 +37,7 @@ class TestSKLocale < Test::Unit::TestCase
   end
 
   def test_sk_internet_methods
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
   end
 

--- a/test/test_tr_locale.rb
+++ b/test/test_tr_locale.rb
@@ -26,9 +26,9 @@ class TestTRLocale < Test::Unit::TestCase
   end
 
   def test_tr_internet_fields
-    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.email.is_a? String
     assert Faker::Internet.domain_suffix.is_a? String
-    assert Faker::Internet.safe_email.is_a? String
+    assert Faker::Internet.email.is_a? String
   end
 
   def test_tr_names


### PR DESCRIPTION
### Summary

Fixes #2431

faker-ruby is transitioning to no longer generating potentially real email and url addresses.

The migration plan is:

First step:
  - change `email` and `domain_name` to be [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) compliant. Both now generate safe values by default using the Reserved Top Level DNS Names: `example` and `test`. To maintain backwards compatibility and give users the option to use non-safe domains at their own risk, custom domains are allowed. 
  - add deprecation message for `free_email` and `safe_email` to use `email` instead.

Second step (after October 2023):
  - remove deprecated generators and locales.

To give users time, once the first step is released, users will have until October 2023 to make the necessary changes.

## Other Information

- Disabling `# rubocop:disable Style/IfUnlessModifier` because inline conditionals are hard to read and therefore to refactor. With the explicit conditionals, it's easier to extract them to a method, etc.
- Unfortunately, the locale tests are only asserting that the results are strings. There is an opportunity to improve them. Help is welcomed!