### PR TITLE
Fix locale setting

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -12,6 +12,8 @@ I18n.reload! if I18n.backend.initialized?
 
 module Faker
   module Config
+    @locale = nil
+
     class << self
       def locale=(new_locale)
         Thread.current[:faker_config_locale] = new_locale
@@ -19,7 +21,7 @@ module Faker
 
       def locale
         # Because I18n.locale defaults to :en, if we don't have :en in our available_locales, errors will happen
-        Thread.current[:faker_config_locale] || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
+        Thread.current[:faker_config_locale] || @locale || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
       end
 
       def own_locale

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -15,6 +15,10 @@ module Faker
     @locale = nil
 
     class << self
+      def locale!(new_locale)
+        @locale = new_locale
+      end
+      
       def locale=(new_locale)
         Thread.current[:faker_config_locale] = new_locale
       end

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -15,10 +15,8 @@ module Faker
     @default_locale = nil
 
     class << self
-      def locale!(new_locale)
-        @locale = new_locale
-      end
-      
+      attr_writer :default_locale
+
       def locale=(new_locale)
         Thread.current[:faker_config_locale] = new_locale
       end

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -12,7 +12,7 @@ I18n.reload! if I18n.backend.initialized?
 
 module Faker
   module Config
-    @locale = nil
+    @default_locale = nil
 
     class << self
       def locale!(new_locale)

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -23,7 +23,7 @@ module Faker
 
       def locale
         # Because I18n.locale defaults to :en, if we don't have :en in our available_locales, errors will happen
-        Thread.current[:faker_config_locale] || @locale || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
+        Thread.current[:faker_config_locale] || @default_locale || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
       end
 
       def own_locale


### PR DESCRIPTION
### Summary

Better late than never.

This PR aims to make the locale setting work in threaded server environments.

It adds back the `@locale` class variable to `Faker::Config` and adds a new thread unsafe method that sets that variable. That way we can still set the locale on a per thread basis with `Faker::Config.locale` or we can set it in a global manner using `Faker::Config.locale!`

As a final remark, not really sure this does what we want it to do, but tests still pass.

Also would like to give a shout out to @nateberkopec, @hlascelles, @stefannibrasil and @thdaraujo for all the help and patience.

P.S.: I might need some help with writing tests. I kind of know how to write the tests, just not sure in what file to add it.

Fixes Issue #2563