### PR TITLE
add numbers in #internet::password method

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -169,10 +169,12 @@ module Faker
         password = []
         character_bag = []
 
-        # use lower_chars by default and add upper_chars if mix_case
+        # use lower_chars and numbers by default and add upper_chars if mix_case
         lower_chars = ('a'..'z').to_a
+        numbers = (0..9).to_a
         password << lower_chars[rand(lower_chars.count - 1)]
-        character_bag += lower_chars
+        password << numbers[rand(numbers.count - 1)]
+        character_bag += lower_chars+numbers
 
         if character_types.include?(:mix_case)
           upper_chars = ('A'..'Z').to_a

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -145,6 +145,11 @@ class TestFakerInternet < Test::Unit::TestCase
     assert passwords.select { |item| item.length == 16 }.size >= 1
   end
 
+  def test_password_contains_numbers
+    password = @tester.password
+    assert_match(/\d+/, password)
+  end
+
   def test_password_with_mixed_case
     password = @tester.password
     upcase_count = 0


### PR DESCRIPTION
### Summary

Fixes issue #2704 

<!-- Provide a general description of the code changes in your pull request.

have added numbers to the password

Were there any bugs you had fixed? If so, mention them: Fixes Issue #add-issue-number -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.

If you are creating a new generator, share how you are going to use it. Use cases are important to make sure that our faker generators are useful. Also, add `@faker.version next` to help users know when a generator was added. See [this example](https://github.com/faker-ruby/faker/blob/aa31845ed54c25eb2638d716bfddf59771b502aa/lib/faker/music/opera.rb#L68).

Finally, if your pull request affects documentation, please follow the [Guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

Thanks for contributing to Faker! -->