### PR TITLE
Generate UUIDs based on a pattern

### DIFF
--- a/doc/default/internet.md
+++ b/doc/default/internet.md
@@ -109,5 +109,7 @@ Faker::Internet.user_agent(vendor: :firefox) #=> "Mozilla/5.0 (Windows NT x.y; W
 Faker::Internet.bot_user_agent #=> "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 Faker::Internet.bot_user_agent(vendor: :duckduckbot) #=> "Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)"
 
+# Keyword arguments: pattern
 Faker::Internet.uuid #=> "929ef6ef-b11f-38c9-111b-accd67a258b2"
+Faker::Internet.uuid(pattern: '123')  #=> "12312312-3123-1231-2312-312312312312"
 ```

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -530,8 +530,12 @@ module Faker
       #
       # @return [String]
       #
+      # @param pattern [String] A pattern that will be repeated to produce 32 characters.
+      #
       # @example
-      #   Faker::Internet.uuid  #=> "8a6cdd40-6d78-4fdb-912b-190e3057197f"
+      #   Faker::Internet.uuid                  #=> "8a6cdd40-6d78-4fdb-912b-190e3057197f"
+      #
+      #   Faker::Internet.uuid(pattern: '123')  #=> "12312312-3123-1231-2312-312312312312"
       def uuid(pattern: false)
         if pattern
           chars = pattern * ((32 / pattern.size).ceil + 1)

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -538,6 +538,9 @@ module Faker
       #   Faker::Internet.uuid(pattern: '123')  #=> "12312312-3123-1231-2312-312312312312"
       def uuid(pattern: false)
         if pattern
+          pattern = pattern.downcase
+          raise ArgumentError, "The pattern #{pattern.inspect} contains non-hexadecimal digits" unless pattern =~ /\A[0-9a-f]+\z/
+
           chars = pattern * ((32 / pattern.size).ceil + 1)
           blocks = chars.scan(/^(.{8})(.{4})(.{4})(.{4})(.{12})/)
           blocks.join('-')

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -532,12 +532,18 @@ module Faker
       #
       # @example
       #   Faker::Internet.uuid  #=> "8a6cdd40-6d78-4fdb-912b-190e3057197f"
-      def uuid
-        # borrowed from: https://github.com/ruby/ruby/blob/d48783bb0236db505fe1205d1d9822309de53a36/lib/securerandom.rb#L250
-        ary = Faker::Config.random.bytes(16).unpack('NnnnnN')
-        ary[2] = (ary[2] & 0x0fff) | 0x4000
-        ary[3] = (ary[3] & 0x3fff) | 0x8000
-        '%08x-%04x-%04x-%04x-%04x%08x' % ary # rubocop:disable Style/FormatString
+      def uuid(pattern: false)
+        if pattern
+          chars = pattern * ((32 / pattern.size).ceil + 1)
+          blocks = chars.scan(/^(.{8})(.{4})(.{4})(.{4})(.{12})/)
+          blocks.join('-')
+        else
+          # borrowed from: https://github.com/ruby/ruby/blob/d48783bb0236db505fe1205d1d9822309de53a36/lib/securerandom.rb#L250
+          ary = Faker::Config.random.bytes(16).unpack('NnnnnN')
+          ary[2] = (ary[2] & 0x0fff) | 0x4000
+          ary[3] = (ary[3] & 0x3fff) | 0x8000
+          '%08x-%04x-%04x-%04x-%04x%08x' % ary # rubocop:disable Style/FormatString
+        end
       end
 
       ##

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -562,6 +562,16 @@ class TestFakerInternet < Test::Unit::TestCase
     assert_match('45645645-6456-4564-5645-645645645645', uuid456)
   end
 
+  def test_uuid_with_invalid_pattern_argument
+    assert_raises ArgumentError do
+      @tester.uuid(pattern: 'z')
+    end
+
+    assert_raises ArgumentError do
+      @tester.uuid(pattern: "0\n1")
+    end
+  end
+
   def test_base64
     assert_match(/[[[:alnum:]]\-_]{16}/, @tester.base64)
     assert_match(/[[[:alnum:]]\-_]{4}/, @tester.base64(length: 4))

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -552,6 +552,16 @@ class TestFakerInternet < Test::Unit::TestCase
     assert_match(/\A\h{8}-\h{4}-4\h{3}-\h{4}-\h{12}\z/, uuid)
   end
 
+  def test_uuid_with_pattern_argument
+    uuid1 = @tester.uuid(pattern: '1')
+    uuid23 = @tester.uuid(pattern: '23')
+    uuid456 = @tester.uuid(pattern: '456')
+
+    assert_equal('11111111-1111-1111-1111-111111111111', uuid1)
+    assert_match('23232323-2323-2323-2323-232323232323', uuid23)
+    assert_match('45645645-6456-4564-5645-645645645645', uuid456)
+  end
+
   def test_base64
     assert_match(/[[[:alnum:]]\-_]{16}/, @tester.base64)
     assert_match(/[[[:alnum:]]\-_]{4}/, @tester.base64(length: 4))


### PR DESCRIPTION
### Summary

Generate UUIDs based on repetitive patterns, such as `11111111-1111-1111-1111-111111111111`, `23232323-2323-2323-2323-232323232323`, etc.

### How is this useful?

Lately I have found myself in situations where I could use predictable and quickly differentiable UUIDs. So for example if I have three instances that look like `11111`, `22222`, `33333`, these are easier to identify and tell apart than actual random UUIDs where I have to squint and think "ok, this one starts with `bf3`, the other one starts with `b35`".

### Notes

This implementation is a bit crude and more of a proof of concept, although I admit that I wouldn't be sure how to improve it :flushed: Any ideas?

This does not generate the version/variant bits. On the other hand, these UUIDs are none of the standard ones, so perhaps it doesn't matter?