### PR TITLE
Remove broken chars from minecraft.yml

### DIFF
--- a/lib/locales/en/minecraft.yml
+++ b/lib/locales/en/minecraft.yml
@@ -629,14 +629,14 @@ en:
           - Piglin
         status_effect:
           - Absorption
-          - Bad Luck ‌
+          - Bad Luck
           - Bad Omen
           - Blindness
           - Conduit Power
-          - Dolphin's Grace‌
-          - Fatal Poison‌
+          - Dolphin's Grace
+          - Fatal Poison
           - Fire Resistance
-          - Glowing‌
+          - Glowing
           - Haste
           - Health Boost
           - Hero of the Village


### PR DESCRIPTION
### Motivation / Background

I found that when I use `Faker::Games::Minecraft.status_effect` the strings given from it sometimes had something weird at the end.

Found that the yml had a unicode character [<200c>](https://unicode-explorer.com/c/200C) and space(s) at the end:
![Screenshot_2023-05-25_16-00-33](https://github.com/faker-ruby/faker/assets/11504/b286428e-ddeb-4aab-8866-6b99da54cfca)

This Pull Request has been created because these need to be truncated.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [N/A] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [ ] Tests and Rubocop are passing before submitting your proposed changes.

