### PR TITLE
Add `max_rut` option to `Faker::ChileRut.rut`

### DIFF
--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -8,18 +8,19 @@ module Faker
       ##
       # Produces a random Chilean RUT (Rol Unico Tributario, ID with 8 digits).
       #
-      # @param min_rut [Integer] Specifies the minimum value of the rut.
-      # @param fixed [Boolean] Determines if the rut is fixed (returns the min_rut value).
+      # @param min_rut [Integer] Specifies the minimum value of the RUT.
+      # @param max_rut [Integer] Specifies the maximum value of the RUT.
+      # @param fixed [Boolean] Determines if the RUT is fixed (returns the min_rut value).
       # @return [Number]
       #
       # @example
       #   Faker::ChileRut.rut #=> 11235813
-      #   Faker::ChileRut.rut(min_rut: 20890156) #=> 31853211
-      #   Faker::ChileRut.rut(min_rut: 20890156, fixed: true) #=> 20890156
+      #   Faker::ChileRut.rut(min_rut: 10_000_000, max_rut: 30_000_000) #=> 21853211
+      #   Faker::ChileRut.rut(min_rut: 20_890_156, fixed: true) #=> 20890156
       #
-      # @faker.version 1.9.2
-      def rut(min_rut: 1, fixed: false)
-        @last_rut = fixed ? min_rut : rand_in_range(min_rut, 99_999_999)
+      # @faker.version next
+      def rut(min_rut: 1, max_rut: 99_999_999, fixed: false)
+        @last_rut = fixed ? min_rut : rand_in_range(min_rut, max_rut)
       end
 
       ##
@@ -68,22 +69,21 @@ module Faker
       ##
       # Produces a random Chilean RUT (Rol Unico Tributario, ID with 8 digits) with a dv (digito verificador, check-digit).
       #
-      # @param min_rut [Integer] Specifies the minimum value of the rut.
-      # @param fixed [Boolean] Determines if the rut is fixed (returns the min_rut value).
+      # @param min_rut [Integer] Specifies the minimum value of the RUT.
+      # @param max_rut [Integer] Specifies the maximum value of the RUT.
+      # @param fixed [Boolean] Determines if the RUT is fixed (returns the min_rut value).
       # @return [String]
       #
       # @example
       #   Faker::ChileRut.full_rut #=> "30686957-4"
-      #   Faker::ChileRut.full_rut(min_rut: 20890156) #=> "30686957-4"
-      #   Faker::ChileRut.full_rut(min_rut: 30686957, fixed: true) #=> "30686957-4"
+      #   Faker::ChileRut.full_rut(min_rut: 10_000_000, max_rut: 30_000_000) #=> "20686957-4"
+      #   Faker::ChileRut.full_rut(min_rut: 30_686_957, fixed: true) #=> "30686957-4"
       #
       # @faker.version next
-      def full_rut(min_rut: 0, fixed: false, formatted: false)
-        if formatted
-          "#{rut(min_rut: min_rut, fixed: fixed).to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse}-#{dv}"
-        else
-          "#{rut(min_rut: min_rut, fixed: fixed)}-#{dv}"
-        end
+      def full_rut(min_rut: 1, max_rut: 99_999_999, fixed: false, formatted: false)
+        this_rut = rut(min_rut: min_rut, max_rut: max_rut, fixed: fixed)
+        this_rut = this_rut.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse if formatted
+        "#{this_rut}-#{dv}"
       end
 
       attr_reader :last_rut

--- a/lib/faker/default/chile_rut.rb
+++ b/lib/faker/default/chile_rut.rb
@@ -82,11 +82,17 @@ module Faker
       # @faker.version next
       def full_rut(min_rut: 1, max_rut: 99_999_999, fixed: false, formatted: false)
         this_rut = rut(min_rut: min_rut, max_rut: max_rut, fixed: fixed)
-        this_rut = this_rut.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse if formatted
+        this_rut = format_rut(this_rut) if formatted
         "#{this_rut}-#{dv}"
       end
 
       attr_reader :last_rut
+
+      private
+
+      def format_rut(rut)
+        rut.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1.').reverse
+      end
     end
   end
 end

--- a/test/faker/default/test_faker_chile_rut.rb
+++ b/test/faker/default/test_faker_chile_rut.rb
@@ -9,12 +9,17 @@ class TestChileRut < Test::Unit::TestCase
 
   def test_full_rut
     assert_equal('6-k', @tester.full_rut(min_rut: 6, fixed: true))
+    assert_equal('8', @tester.full_rut(min_rut: 8, max_rut: 8)[0])
     assert_equal('30686957-4', @tester.full_rut(min_rut: 30_686_957, fixed: true))
   end
 
   def test_rut_length
     refute_empty @tester.rut.to_s
     assert @tester.rut.to_s.length <= 8
+  end
+
+  def test_rut_min_max
+    assert_equal(7, @tester.rut(min_rut: 7, max_rut: 7))
   end
 
   # We need to set specific rut before testing the check digit

--- a/test/faker/default/test_faker_chile_rut.rb
+++ b/test/faker/default/test_faker_chile_rut.rb
@@ -9,7 +9,8 @@ class TestChileRut < Test::Unit::TestCase
 
   def test_full_rut
     assert_equal('6-k', @tester.full_rut(min_rut: 6, fixed: true))
-    assert_equal('8', @tester.full_rut(min_rut: 8, max_rut: 8)[0])
+    assert_equal('8-6', @tester.full_rut(min_rut: 8, max_rut: 8))
+    assert_equal('11.111.111-1', @tester.full_rut(min_rut: 11_111_111, max_rut: 11_111_111, formatted: true))
     assert_equal('30686957-4', @tester.full_rut(min_rut: 30_686_957, fixed: true))
   end
 


### PR DESCRIPTION
### Motivation / Background

Allows to set a maximum RUT number for ChileRut. I needed this because juridical person RUTs start at a higher number than natural person RUTs. I needed to create human RUTs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
(test_brazilian_id is failing, but that's not related to my code)