### PR TITLE
Improve `#deterministically_verify` helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,12 +31,10 @@ require File.expand_path("#{File.dirname(__FILE__)}/../lib/faker")
 #     assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
 #   end
 #
-def deterministically_verify(subject_proc, depth: 2, random: nil, &block)
-  raise 'need block' unless block_given?
-
+def deterministically_verify(subject_proc, depth: 2, random: nil)
   results = depth.times.map do
     Faker::Config.stub :random, random.clone || Random.new(42) do
-      subject_proc.call.freeze.tap(&block)
+      yield subject_proc.call.freeze
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,9 +34,9 @@ require File.expand_path("#{File.dirname(__FILE__)}/../lib/faker")
 def deterministically_verify(subject_proc, depth: 2, random: nil, &block)
   raise 'need block' unless block_given?
 
-  results = depth.times.inject([]) do |r, _index|
+  results = depth.times.map do
     Faker::Config.stub :random, random.clone || Random.new(42) do
-      r << subject_proc.call.freeze.tap(&block)
+      subject_proc.call.freeze.tap(&block)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,9 +31,9 @@ require File.expand_path("#{File.dirname(__FILE__)}/../lib/faker")
 #     assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
 #   end
 #
-def deterministically_verify(subject_proc, depth: 2, random: nil)
+def deterministically_verify(subject_proc, depth: 2, random: Random.new(42))
   results = depth.times.map do
-    Faker::Config.stub :random, random.clone || Random.new(42) do
+    Faker::Config.stub :random, random.clone do
       yield subject_proc.call.freeze
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,6 @@ def deterministically_verify(subject_proc, depth: 2, random: nil, &block)
     Faker::Config.stub :random, random.clone || Random.new(42) do
       results << subject_proc.call.freeze.tap(&block)
     end
-  end.repeated_combination(2) { |(first, second)| assert_equal first, second }
+  end.combination(2) { |(first, second)| assert_equal first, second }
   # rubocop:enable Style/MultilineBlockChain
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,7 @@ def deterministically_verify(subject_proc, depth: 2, random: nil, &block)
 
   # rubocop:disable Style/MultilineBlockChain
   depth.times.inject([]) do |results, _index|
-    Faker::Config.random = random || Random.new(42)
+    Faker::Config.random = random.clone || Random.new(42)
     results << subject_proc.call.freeze.tap(&block)
   end.repeated_combination(2) { |(first, second)| assert_equal first, second }
   # rubocop:enable Style/MultilineBlockChain

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,8 +23,8 @@ require File.expand_path("#{File.dirname(__FILE__)}/../lib/faker")
 #   times with the same deterministic_random seed.
 # @param subject_proc [Proc] a proc object that returns the subject under test
 #   when called.
-# @param depth [Integer] the depth of deterministic comparisons to run.
-# @param random [Integer] A random number seed; Used to override the default.
+# @param depth [Integer] the depth of deterministic comparisons to run; the default value is 2.
+# @param seed [Integer] A random number seed; Used to override the default value which is 42.
 #
 # @example
 #   deterministically_verify ->{ @tester.username('bo peep') } do |subject|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,9 +31,9 @@ require File.expand_path("#{File.dirname(__FILE__)}/../lib/faker")
 #     assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
 #   end
 #
-def deterministically_verify(subject_proc, depth: 2, random: Random.new(42))
+def deterministically_verify(subject_proc, depth: 2, seed: 42)
   results = depth.times.map do
-    Faker::Config.stub :random, random.clone do
+    Faker::Config.stub :random, Random.new(seed) do
       yield subject_proc.call.freeze
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,11 +34,11 @@ require File.expand_path("#{File.dirname(__FILE__)}/../lib/faker")
 def deterministically_verify(subject_proc, depth: 2, random: nil, &block)
   raise 'need block' unless block_given?
 
-  # rubocop:disable Style/MultilineBlockChain
-  depth.times.inject([]) do |results, _index|
+  results = depth.times.inject([]) do |r, _index|
     Faker::Config.stub :random, random.clone || Random.new(42) do
-      results << subject_proc.call.freeze.tap(&block)
+      r << subject_proc.call.freeze.tap(&block)
     end
-  end.combination(2) { |(first, second)| assert_equal first, second }
-  # rubocop:enable Style/MultilineBlockChain
+  end
+
+  results.combination(2) { |(first, second)| assert_equal first, second }
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,8 +36,9 @@ def deterministically_verify(subject_proc, depth: 2, random: nil, &block)
 
   # rubocop:disable Style/MultilineBlockChain
   depth.times.inject([]) do |results, _index|
-    Faker::Config.random = random.clone || Random.new(42)
-    results << subject_proc.call.freeze.tap(&block)
+    Faker::Config.stub :random, random.clone || Random.new(42) do
+      results << subject_proc.call.freeze.tap(&block)
+    end
   end.repeated_combination(2) { |(first, second)| assert_equal first, second }
   # rubocop:enable Style/MultilineBlockChain
 end


### PR DESCRIPTION
<!--
Thanks for contributing to faker-ruby!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the faker-ruby repo.

Create a pull request when it is ready for review and feedback
from the faker-ruby team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.

If you're proposing a new generator, please follow the [Documentation guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).
-->

This Pull Request has been created because I was trying to fix a test using the `#deterministic_verify` helper with the `random` parameter set and saw that my test was failing with the default `depth` value (2).

I then realized a few issues with the current implementation:

1. The documentation does not reflect the implementation. It documents expecting an `Integer` value for `random` while it expects a `Random` instance internally. 
2. It does not guarantee the same `Random#rand` iteration across `depth` iterations if a custom `random` value is set.
   1. This makes any runs with `depth > 1` fail the internal assertion due to different values being generated across `depth` iterations.
   2. It's easy to verify this, just set `random` to a custom value on any existing `deterministic_verify` block on the codebase.
3. It does not protect the existing `Faker::Config.random` state from being mutated across `#deterministic_verify` runs.
   1. It's also easy to verify this, just place a debugger call before and after each `#deterministic_verify` block and inspect the value of `Faker::Config.random` around it.

I've addressed those issues above by:

1. Updated the implementation to receive an `Integer` through a `seed` parameter instead of a `Random` instance through `random`.
   1. The documentation was updated accordingly and also to reflect the default values.
   2. The implementation was also simplified to define both default values on the method signature instead resolving internally to a default instance.
2. Ensuring that if `seed` is set then it will always use a new `Random` instance before calling `subject_proc`.
   1. This ensures the same `random#rand` iteration for each internal `depth` iteration.
   2. This is the same guarantee provided when `random` (before) / `seed` (now) is not set, thus making those iterations generate the same values (as expected).
3. Relying on `MiniTest`'s [`Object#stub`](https://www.rubydoc.info/gems/minitest/5.20.0/Object:stub) to prevent mutating the `Faker::Config.random` state inside `depth` iterations.

I've also included a few other minor improvements:
1. The internal assertions won't run against values generated on the same `depth` iteration anymore (this was a waste of cycles).
   1. The assertions were comparing the generated instances against themselves for equality before this change, now they will only be compared against other instances.
   2. This might help partially address #2720 also.
2. Removed the multi-line block chain from the implementation for clarity and to comply with linter rules instead of silencing it.
3. Replaced `inject` with `map` since there was (apparently) no benefit in using the earlier after the changes above.
4. Use `yield` instead of manually calling `&block`. The reason is that we get an automatic `LocalJumpError` if no block is provided, so it was possible to remove the manual `raise` from the implementation.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
  * _I consider it multiple changes, but with a similar scope, so I've decided to put all in one PR. Please let me know if multiple PRs are preferred._
  * _I do believe it's better to deliver it all in one go in this particular case._
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug, refactor something, or add a feature.
  * _I'm not sure if this requires a test or not; there were no tests currently - the existing test suite will rely on/exercise this code, though._
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator:

* [ ] Open an issue first for discussion before you write any code.
* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Documentation guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).
