### PR TITLE
Delete doc/default/michael_scott.md

### DIFF
--- a/doc/default/michael_scott.md
+++ b/doc/default/michael_scott.md
@@ -1,7 +1,0 @@
-# Faker::MichaelScott
-
-Available since version 1.9.0.
-
-```ruby
-Faker::MichaelScott.quote #=> "I am Beyoncé, always."
-```


### PR DESCRIPTION
This file is obsolete and has been superseded by https://github.com/faker-ruby/faker/blob/main/doc/tv_shows/michael_scott.md