### PR TITLE
Fix Typo in README Link: Update sports.md to sport.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main
 <details>
   <summary>Sports</summary>
 
-  - [Faker::Sports](doc/sports/sports.md)
+  - [Faker::Sport](doc/sports/sport.md)
   - [Faker::Sports::Basketball](doc/sports/basketball.md)
   - [Faker::Sports::Chess](doc/sports/chess.md)
   - [Faker::Sports::Football](doc/sports/football.md)


### PR DESCRIPTION
### Motivation / Background

This Pull Request is a minor documentation fix. The link to the sports documentation was incorrectly referenced as `doc/sports/sports.md`, which leads to a dead link. I have updated it to the correct file name, `doc/sports/sport.md`, to ensure users can access the intended documentation without any issues.

### Additional information

This change is straightforward and doesn't involve any code alterations or new features. It's a simple yet important fix to maintain the integrity of the documentation.

### Checklist

Before submitting the PR, I confirm the following:

* [x] This Pull Request is related to one change - correcting a documentation link.
* [x] Commit message is clear and describes the change made.
* [x] No tests are required as this is a documentation update.
* [x] Tests and Rubocop are not applicable to this documentation correction.
