### PR TITLE
Update `Internet#username` separator param to match with the example  

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -60,7 +60,7 @@ module Faker
       #   Faker::Internet.username(specifier: 10)                     #=> "lulu.goodwin"
       #   Faker::Internet.username(specifier: 5..10)                  #=> "morris"
       #   Faker::Internet.username(specifier: 5..10)                  #=> "berryberry"
-      #   Faker::Internet.username(specifier: 20, separators: ['-'])  #=> "nikki_sawaynnikki_saway"
+      #   Faker::Internet.username(specifier: 20, separators: ['_'])  #=> "nikki_sawaynnikki_saway"
       def username(specifier: nil, separators: %w[. _])
         with_locale(:en) do
           return shuffle(specifier.scan(/[[:word:]]+/)).join(sample(separators)).downcase if specifier.respond_to?(:scan)


### PR DESCRIPTION
### Motivation / Background
This PR is a minor documentation fix. Using this param `separators: ['-']` on `Faker::Internet.username` method will return a username with `-` and not `_` as the example. I have updated the param to match with the current example.

Example:
```
irb(main):006:0> Faker::Internet.username(specifier: 20, separators: ['-'])
=> "lauren-connlauren-conn"
irb(main):007:0> Faker::Internet.username(specifier: 20, separators: ['_'])
=> "toccara_nikolaustoccara_nikolaus"
```

### Additional information

This change is small and simple but would help to maintain the integrity of the doc.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] No tests required as this is a doc update.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
