### PR TITLE
Remove the duplicate method Faker::Commerce.material description

### DIFF
--- a/doc/default/commerce.md
+++ b/doc/default/commerce.md
@@ -22,8 +22,6 @@ Faker::Commerce.price(range: 0..10.0, as_string: true) #=> "2.18"
 Faker::Commerce.promotion_code #=> "AmazingDeal829102"
 Faker::Commerce.promotion_code(digits: 2) #=> "AmazingPrice57"
 
-Faker::Commerce.material #=> "Plastic"
-
 # Generate a random brand
 Faker::Commerce.brand #=> "Apple"
 


### PR DESCRIPTION
This Pull Request has been created because we have duplication of  the Faker::Commerce.material method which is redundant in documentation.

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [x] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [x] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
