### PR TITLE
Generate a mock Omniauth response for Azure Active Directory v2

### DIFF
--- a/doc/default/omniauth.md
+++ b/doc/default/omniauth.md
@@ -321,4 +321,23 @@ Faker::Omniauth.auth0 #=>
     }
   }
 }
+
+Faker::Omniauth.azure_activedirectory_v2 #=>
+{
+  provider: "azure_activedirectory_v2",
+  uid: "9e78c371-2ffc-4ca3-8589-6576182b79e2",
+  info: {
+    name: "John Doe",
+    first_name: "John",
+    last_name: "Doe",
+    email: "doe.john@example.com",
+    id: "9e78c371-2ffc-4ca3-8589-6576182b79e2"
+  },
+  credentials: {
+    token: "token",
+    expires_at: 1710138804,
+    expires: true
+  },
+  extra: {}
+}
 ```

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -441,6 +441,38 @@ module Faker
         }
       end
 
+      ##
+      # Generate a mock Omniauth response for Azure Active Directory v2.
+      #
+      # @param name [String, nil] A specific name to return in the response;
+      # @param email [String, nil] A specific email to return in the response;
+      # @param uid [String, nil] A specific UID to return in the response;
+      #
+      # @return [Hash] An auth hash in the format provided by omniauth-azure-activedirectory-v2.
+      #
+      # @faker.version next
+      def azure_activedirectory_v2(name: nil, email: nil, uid: nil)
+        auth = Omniauth.new(name: name, email: email)
+        uid ||= Config.random.uuid
+        {
+          provider: 'azure_activedirectory_v2',
+          uid: uid,
+          info: {
+            name: auth.name,
+            first_name: auth.first_name,
+            last_name: auth.last_name,
+            email: auth.email,
+            id: uid
+          },
+          credentials: {
+            token: Crypto.md5,
+            expires_at: Time.forward(days: 365).to_i,
+            expires: true
+          },
+          extra: {}
+        }
+      end
+
       private
 
       def gender

--- a/test/faker/default/test_faker_omniauth.rb
+++ b/test/faker/default/test_faker_omniauth.rb
@@ -534,6 +534,27 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert raw_info[:email_verified]
   end
 
+  def test_omniauth_azure_activedirectory_v2
+    auth            = @tester.azure_activedirectory_v2
+    provider        = auth[:provider]
+    uid             = auth[:uid]
+    info            = auth[:info]
+    credentials     = auth[:credentials]
+    extra           = auth[:extra]
+
+    assert_equal 'azure_activedirectory_v2', provider
+    assert_instance_of String, auth[:uid]
+    assert_instance_of String, info[:name]
+    assert_instance_of String, info[:first_name]
+    assert_instance_of String, info[:last_name]
+    assert_match email_regex(info[:first_name], info[:last_name]), info[:email]
+    assert_equal uid, info[:id]
+    assert_instance_of String, credentials[:token]
+    assert credentials[:expires]
+    assert_not_nil credentials[:expires_at]
+    assert_empty(extra)
+  end
+
   def word_count(string)
     string.split.length
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to be able to generate a mock Omniauth response for Azure Active Directory v2.

### Additional information

The corresponding omniauth strategy is [here](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [X] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [X] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [X] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
