### PR TITLE
Fix bug on phone number generator for `en-US` locale caused by incorrect `.yml` file structure

### DIFF
--- a/lib/locales/en-US.yml
+++ b/lib/locales/en-US.yml
@@ -6949,16 +6949,16 @@ en-US:
         - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
         - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
         - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
-      cell_phone:
-        formats:
-          - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
-          - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
-          - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
-          - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number}"
-          - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
-          - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
-          - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
-          - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number}"
+    cell_phone:
+      formats:
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number}"
     id_number:
       valid: "#{IdNumber.ssn_valid}"
       invalid:


### PR DESCRIPTION
### Motivation / Background

`PhoneNumber.cell_phone` expects an i18n key of `cell_phone.formats`, but the en-US.yml file currently has `faker.phone_number.cell_phone` instead of `faker.cell_phone`.

The result of that mismatch is that `cell_phone` will ignore the defined formats, and potentially generate invalid US numbers (e.g. those with an area code beginning with 1) when the locale is en-US.

31d99d14c1e7d976e89f83c9496c0d97baa6aa3e reworked YAML structure and appears to have inadvertently moved the key.

You can see the change in US number behavior in a console:

```ruby
Faker::Config.locale = "en-US"
Faker::PhoneNumber.translate("faker.cell_phone.formats")
```

On 3.3.0 this returns

```ruby
["###-###-####", "(###) ###-####", "###.###.####", "### ### ####"]
```

because it's the fallback value within the `en` (not `en-US`) locale file. The correct value should be the formats outdented in this commit.

Fixes #2922 (although it's currently closed).

### Additional information

See https://github.com/faker-ruby/faker/issues/2922#issuecomment-2023396304.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
