### PR TITLE
docs: add absolute links to CONTRIBUTING from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,9 +486,9 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'main
 
 ## Contributing
 
-**Note**: We are not accepting proposals for new generators and locales. The [Contributing](CONTRIBUTING.md) guide has a few notes about this decision.
+**Note**: We are not accepting proposals for new generators and locales. The [Contributing](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md) guide has a few notes about this decision.
 
-Take a look at the [Contributing](CONTRIBUTING.md) document for
+Take a look at the [Contributing](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md) document for
 instructions on setting up the repo on your machine, opening bug reports, understanding the codebase,
 and creating a good pull request.
 


### PR DESCRIPTION
### Motivation / Background

On https://www.rubydoc.info/gems/faker/ the links to the CONTRIBUTING document are 404s because it tries to follow a relative link.

### Additional information

Make them absolute links to the main branch on github
