### PR TITLE
Performance: Reduce the time complexity of all Faker::Crypto methods

### DIFF
--- a/lib/faker/default/crypto.rb
+++ b/lib/faker/default/crypto.rb
@@ -15,7 +15,14 @@ module Faker
       #
       # @faker.version 1.6.4
       def md5
-        OpenSSL::Digest::MD5.hexdigest(Lorem.characters)
+        # The MD5 algorithm will experience a collision much sooner
+        # than Lorem.characters(number: 5) will. Setting the lorem
+        # character number lower than the default of 255 reduces the
+        # time complexity of this method while still returning
+        # deterministically unique values. Mathematical proof:
+        # 4^36 < 32^16 by -1204203453131759529492480
+        # 5^36 > 32^16 by 13342989408752222631934449
+        OpenSSL::Digest::MD5.hexdigest(Lorem.characters(number: 5))
       end
 
       ##
@@ -28,7 +35,9 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha1
-        OpenSSL::Digest::SHA1.hexdigest(Lorem.characters)
+        # 5^36 < 40^16 by   -28397757731633148193359375
+        # 6^36 > 40^16 by 10271475125530535546171949056
+        OpenSSL::Digest::SHA1.hexdigest(Lorem.characters(number: 6))
       end
 
       ##
@@ -41,7 +50,9 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha256
-        OpenSSL::Digest::SHA256.hexdigest(Lorem.characters)
+        # 6^36 < 64^16 by  -68913737715773802047372001280
+        # 7^36 > 64^16 by 2572502683345389134185479431265
+        OpenSSL::Digest::SHA256.hexdigest(Lorem.characters(number: 7))
       end
 
       ##
@@ -54,7 +65,9 @@ module Faker
       #
       # @faker.version next
       def sha512
-        OpenSSL::Digest::SHA512.hexdigest(Lorem.characters)
+        # 8^36 < 128^16 by -4867778304876400901747340308643840
+        # 9^36 > 128^16 by 17336102686404346783309651545552545
+        OpenSSL::Digest::SHA512.hexdigest(Lorem.characters(number: 9))
       end
     end
   end

--- a/lib/faker/default/crypto.rb
+++ b/lib/faker/default/crypto.rb
@@ -22,7 +22,7 @@ module Faker
         # deterministically unique values. Mathematical proof:
         # 4^36 < 32^16 by -1204203453131759529492480
         # 5^36 > 32^16 by 13342989408752222631934449
-        OpenSSL::Digest::MD5.hexdigest(Lorem.characters(number: 5))
+        OpenSSL::Digest::MD5.hexdigest(Lorem.characters(number: 25))
       end
 
       ##
@@ -37,7 +37,7 @@ module Faker
       def sha1
         # 5^36 < 40^16 by   -28397757731633148193359375
         # 6^36 > 40^16 by 10271475125530535546171949056
-        OpenSSL::Digest::SHA1.hexdigest(Lorem.characters(number: 6))
+        OpenSSL::Digest::SHA1.hexdigest(Lorem.characters(number: 31))
       end
 
       ##
@@ -52,7 +52,7 @@ module Faker
       def sha256
         # 6^36 < 64^16 by  -68913737715773802047372001280
         # 7^36 > 64^16 by 2572502683345389134185479431265
-        OpenSSL::Digest::SHA256.hexdigest(Lorem.characters(number: 7))
+        OpenSSL::Digest::SHA256.hexdigest(Lorem.characters(number: 50))
       end
 
       ##
@@ -67,7 +67,7 @@ module Faker
       def sha512
         # 8^36 < 128^16 by -4867778304876400901747340308643840
         # 9^36 > 128^16 by 17336102686404346783309651545552545
-        OpenSSL::Digest::SHA512.hexdigest(Lorem.characters(number: 9))
+        OpenSSL::Digest::SHA512.hexdigest(Lorem.characters(number: 100))
       end
     end
   end


### PR DESCRIPTION
<!--
Thanks for contributing to faker-ruby!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the faker-ruby repo.

Create a pull request when it is ready for review and feedback
from the faker-ruby team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.

If you're proposing a new generator or locale, please review and follow the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md) first.
-->

This Pull Request has been created because the `Faker::Crypto` methods are generating extraordinarily long random strings to run through each hashing algorithm. The performance of each method within `Faker::Crypto` can be improved by balancing the complexity of the random strings for each hash algorithm.

### Additional Information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

The MD5 hash algorithm returns a string of 32 characters within the range of "a - f" and "0 - 9", which is a range of 16 characters. The total number of possible combinations with this setup is 16^32.

The method `Faker::Crypto.md5` computes the MD5 hash of a random string like this:
```ruby
OpenSSL::Digest::MD5.hexdigest(Lorem.characters)
```
Digging a little deeper we see that `Lorem.characters` returns a default number of 255 `Alphanumeric` characters:
```ruby
def characters(number: 255, min_alpha: 0, min_numeric: 0)
  Alphanumeric.alphanumeric(number: number, min_alpha: min_alpha, min_numeric: min_numeric)
end
```
Going further we find out that `Faker::Alphanumeric.alphanumeric` returns random characters within the range of "a - z" and "0 -9", which is a range of 36 characters. The total number of possible combinations with this setup is 36^255, which is mind-bogglingly larger than 16^32 (the total number of possible combinations for the MD5 hash algorithm).

### Optimization

The total number of random characters passed through the MD5 hashing algorithm within `Faker::Crypto` can be safely reduced from 255 down to a specific number. You can find that number by solving for the minimum value of `x` within: `36^x > 16^32`. This allows MD5 collisions to occur before (non-unique) collisions within `Faker::Lorem.characters`.

We can find that perfect number for each hash algorithm by running this ruby solver:
```ruby
algorithms = {MD5: 32, SHA1: 40, SHA256: 64, SHA512: 128}
algorithms.each do |algorithm, hash_length|
  puts "Algorithm: #{algorithm} - Hash Length: #{hash_length}"
  number = nil
  (1..100).each do |i|
    greater_than = ((36 ** i) > (16 ** hash_length))
    difference = (36 ** i) - (16 ** hash_length)
    number = i if greater_than && number == nil
    puts "36^#{i} #{greater_than ? ">" : "<"} 16^#{hash_length} by #{difference}"
  end
  output = "OpenSSL::Digest::#{algorithm}.hexdigest(Lorem.characters(number: #{number})) SUGGESTED"
  puts output, "*" * output.length
end
```

Which provides this output:
```
Algorithm: MD5 - Hash Length: 32
36^1 < 16^32 by -340282366920938463463374607431768211420
36^2 < 16^32 by -340282366920938463463374607431768210160
36^3 < 16^32 by -340282366920938463463374607431768164800
36^4 < 16^32 by -340282366920938463463374607431766531840
36^5 < 16^32 by -340282366920938463463374607431707745280
36^6 < 16^32 by -340282366920938463463374607429591429120
36^7 < 16^32 by -340282366920938463463374607353404047360
36^8 < 16^32 by -340282366920938463463374604610658304000
...
36^24 < 16^32 by -317830109213583906223287396307975536640
36^25 > 16^32 by 467998910543825597179764993024768081920
...
OpenSSL::Digest::MD5.hexdigest(Lorem.characters(number: 25)) SUGGESTED
...
```

From this output we can see the point at which `36^x > 16^32`:
```
36^24 < 16^32 by -317830109213583906223287396307975536640
36^25 > 16^32 by 467998910543825597179764993024768081920
```
This shows that `Faker::Lorem.characters(number: 24)` has `317830109213583906223287396307975536640` less possible combinations than the MD5 hash algorithm, while `Faker::Lorem.characters(number: 25)` has `467998910543825597179764993024768081920` more possible combinations than the MD5 hash algorithm.

We can safely reduce the number of random characters to `25` for the `Faker::Crypto.md5` algorithm while still returning deterministically unique hashes. Here are the other optimal values for each algorithm:

```ruby
OpenSSL::Digest::MD5.hexdigest(Lorem.characters(number: 25))
OpenSSL::Digest::SHA1.hexdigest(Lorem.characters(number: 31))
OpenSSL::Digest::SHA256.hexdigest(Lorem.characters(number: 50))
OpenSSL::Digest::SHA512.hexdigest(Lorem.characters(number: 100))
```

### Performance Benchmark

You can see from the benchmark below that after reducing library complexity the `Faker::Crypto` methods are much faster, while the `Faker::Omniauth` methods enjoy performance gains depending upon how heavily they rely upon the `Faker::Crypto` methods.

![Performance Benchmark - Faker Gem (Apil 18, 2024)](https://github.com/faker-ruby/faker/assets/521443/92c83604-8570-44b0-869c-b48efe9e5838)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
* [x] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [x] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
