### PR TITLE
Fix: `Faker::Number.hexadecimal` should include characters within the range of `[0-9a-f]`

### DIFF
--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -114,7 +114,7 @@ module Faker
       # @faker.version 1.0.0
       def hexadecimal(digits: 6)
         hex = ''
-        digits.times { hex += rand(15).to_s(16) }
+        digits.times { hex += rand(16).to_s(16) }
         hex
       end
 

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -131,7 +131,7 @@ class TestFakerNumber < Test::Unit::TestCase
   end
 
   def test_hexadecimal_range
-    random_hex = @tester.hexadecimal(digits: 1024)
+    random_hex = @tester.hexadecimal(digits: 1000)
     expected_range = Array('0'..'9') + Array('a'..'f')
 
     expected_range.each { |char| assert_include(random_hex, char) }

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -130,6 +130,13 @@ class TestFakerNumber < Test::Unit::TestCase
     assert_match(/[0-9a-f]{7}/, @tester.hexadecimal(digits: 7))
   end
 
+  def test_hexadecimal_range
+    random_hex = @tester.hexadecimal(digits: 1024)
+    expected_range = Array('0'..'9') + Array('a'..'f')
+
+    expected_range.each { |char| assert_include(random_hex, char) }
+  end
+
   def test_binary
     assert_match(/^[0-1]{4}$/, @tester.binary(digits: 4))
     assert_match(/^[0-1]{8}$/, @tester.binary(digits: 8))


### PR DESCRIPTION
<!--
Thanks for contributing to faker-ruby!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the faker-ruby repo.

Create a pull request when it is ready for review and feedback
from the faker-ruby team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.

If you're proposing a new generator or locale, please review and follow the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md) first.
-->

This Pull Request has been created because `Faker::Number.hexadecimal` returns characters within the range of [0-9a-e], when it should return characters within the range of [0-9a-f]. The method is not producing the `f` character within the generated hexadecimal strings.

### Additional Information

```ruby
def hexadecimal(digits: 6)
  hex = ''
  digits.times { hex += rand(15).to_s(16) }
  hex
end
```
The current implementation (above) includes `rand(15)`, which is not inclusive and only returns the range [0-14], when the implementation requires [0-15] in order to return the `f` character. Adjusting the current implementation to return `rand(16).to_s(16)` allows the `Faker::Number.hexadecimal` method to return strings within the full character range (including the letter `f`, which is equal to `15.to_s(16)`).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
* [x] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [x] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
