### PR TITLE
Add test range param to NHS numbers

### DIFF
--- a/doc/default/national_health_service.md
+++ b/doc/default/national_health_service.md
@@ -1,8 +1,9 @@
 # Faker::NationalHealthService
 
-```ruby
-Faker::NationalHealthService.british_number #=> "403 958 5577"
+The NHS sets aside a range of numbers from 999 000 0000 to 999 999 9999 for
+test purposes. For more details, see [NHS Digital documentation about
+synthetic data](https://digital.nhs.uk/services/e-referral-service/document-library/synthetic-data-in-live-environments#synthetic-data-naming-convention).
 
-# Keyword arguments: number
-Faker::NationalHealthService.check_digit(number: 400_012_114) #=> 6
+```ruby
+Faker::NationalHealthService.british_number #=> "999 464 0232"
 ```

--- a/lib/faker/default/national_health_service.rb
+++ b/lib/faker/default/national_health_service.rb
@@ -6,14 +6,17 @@ module Faker
       ##
       # Produces a random British NHS number.
       #
+      # The NHS sets aside a range of numbers from 999 000 0000 to 999 999 9999
+      # for test purposes.
+      #
       # @return [String]
       #
       # @example
-      #   Faker::NationalHealthService.british_number #=> "403 958 5577"
+      #   Faker::NationalHealthService.british_number #=> "999 464 0232"
       #
       # @faker.version 1.9.2
       def british_number
-        base_number = rand(400_000_001...499_999_999)
+        base_number = rand(999_000_001...999_999_999)
         # If the check digit is equivalent to 10, the number is invalid.
         # See https://en.wikipedia.org/wiki/NHS_number
         base_number -= 1 if check_digit(number: base_number) == 10
@@ -23,6 +26,8 @@ module Faker
                                                            .insert(7, ' ')
                                                            .join
       end
+
+      private
 
       ##
       # Produces a random British NHS number's check digit.

--- a/test/faker/default/test_faker_national_health_service.rb
+++ b/test/faker/default/test_faker_national_health_service.rb
@@ -8,20 +8,12 @@ class TestFakerNationalHealthService < Test::Unit::TestCase
   end
 
   def test_nhs_british_number
-    assert_match(/\A\d{3}\s\d{3}\s\d{4}\z/, @tester.british_number)
+    assert_match(/\A9{3}\s\d{3}\s\d{4}\z/, @tester.british_number)
   end
 
   def test_check_digit_equals_10
-    Faker::NationalHealthService.stub(:rand, 458_617_434) do
-      assert_match('458 617 4331', @tester.british_number)
+    Faker::NationalHealthService.stub(:rand, 999_464_033) do
+      assert_match('999 464 0321', @tester.british_number)
     end
-  end
-
-  def test_check_digit
-    assert_equal 6, @tester.check_digit(number: 400_012_114)
-  end
-
-  def test_check_digit_11
-    assert_equal 0, @tester.check_digit(number: 418_513_625)
   end
 end


### PR DESCRIPTION
The NHS sets aside a range of numbers for test purposes (999 000 0000 to 999 999 9999). By default, this generator creates valid NHS numbers that may be in use by actual people in the UK health services. This param will switch to using the test range which aren't in use anywhere.

### Motivation / Background

This Pull Request has been created because the NHS sets aside a range of numbers for test purposes (999 000 0000 to 999 999 9999). By default, this generator creates valid NHS numbers that may be in use by actual people in the UK health services. This param will switch to using the test range which aren't in use anywhere.

### Additional information

[NHS Digital documentation about "synthetic" data](https://digital.nhs.uk/services/e-referral-service/document-library/synthetic-data-in-live-environments#synthetic-data-naming-convention)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
