### PR TITLE
Add phone_number.country_code and address.full_address in locale sv

### DIFF
--- a/lib/locales/sv.yml
+++ b/lib/locales/sv.yml
@@ -24,6 +24,8 @@ sv:
       secondary_address: ['Lgh. ###', 'Hus ###']
       street_address:
         - "#{street_name} #{building_number}"
+      full_address:
+        - "#{street_address}, #{postcode} #{city}"
       default_country: [Sverige]
       default_country_code: ["SE"]
 

--- a/lib/locales/sv.yml
+++ b/lib/locales/sv.yml
@@ -61,6 +61,8 @@ sv:
         - "#{prefix} #{first_name} #{last_name}"
 
     phone_number:
+      country_code:
+        - '46'
       formats: ['####-#####', '####-######']
     cell_phone:
       formats:


### PR DESCRIPTION
### Motivation / Background

I'm Swedish and noticed error when tested it to generate Swedish phone_number and addresses.
This Pull Request has been created to correct phone_number.country_code and address.full_address in locale sv.

### Additional information

locale sv phone_number.country_code should be +46, reference https://countrycode.org/sweden

sv do not have #{state_abbr} as in default locale, the format is described here https://en.wikipedia.org/wiki/Postal_codes_in_Sweden#Format

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
