### PR TITLE
fix: `Faker::Internet.username` should not generate duplicated punctuation

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -65,7 +65,7 @@ module Faker
         with_locale(:en) do
           case specifier
           when ::String
-            names = specifier&.gsub("'", '')&.split
+            names = specifier.gsub("'", '').scan(/[[:word:]]+/)
             shuffled_names = shuffle(names)
 
             return shuffled_names.join(sample(separators)).downcase

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -44,6 +44,22 @@ class TestFakerInternet < Test::Unit::TestCase
     end
   end
 
+  def test_email_with_abbreviations
+    name = 'Mr. Faker'
+
+    deterministically_verify -> { @tester.email(name: name) } do |email|
+      assert_email_regex 'Mr', 'Faker', email
+    end
+  end
+
+  def test_email_against_name_generator
+    deterministically_verify -> { @tester.email(name: Faker::Name.unique.name) } do |email|
+      # reject emails with duplicated punctuation
+      # e.g.: "mr._faker.jr.@example.com"
+      refute_match(/[\p{Punct}]{2,}/, email)
+    end
+  end
+
   def test_email_with_separators
     deterministically_verify -> { @tester.email(name: 'jane doe', separators: '+') } do |result|
       name, domain = result.split('@')


### PR DESCRIPTION
[fixes #2967]

In https://github.com/faker-ruby/faker/pull/2950 there was a change on how email usernames were generated. This caused usernames to be generated with duplicate punctuation - for example:
```
Faker::Internet.email(name: 'Mr. Faker')
#=> faker.mr.@test.example
#=> mr._faker@test.example  
```

This PR restores the previous behavior when dealing with punctuation.

While we can't guarantee that any of these generated emails will be valid, we can restore the previous behaviour.