### PR TITLE
Bump bundler version to `2.4.22`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,4 +83,4 @@ DEPENDENCIES
   yard (= 0.9.36)
 
 BUNDLED WITH
-   2.2.33
+   2.4.22


### PR DESCRIPTION
### Motivation / Background

This PR will bump bundler version to 2.4.22 (the latest version compatible with Ruby 2.7.8).

This will remove the following deprecation warning from thor when running tests:
```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/bundler-2.2.33/lib/bundler/vendor/thor/lib/thor/error.rb:105: warning: constant DidYouMean::SPELL_CHECKERS is deprecated
```

### Additional information

See this issue https://github.com/rails/rails/issues/44037

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
