### PR TITLE
Fix benchmark:all_methods task by excluding Faker::Deprecator module from benchmark target

### DIFF
--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -48,7 +48,7 @@ class BenchmarkHelper
 
     def subclasses
       Faker.constants.delete_if do |subclass|
-        %i[Base Bank Books Cat Char Base58 ChileRut CLI Config Creature Date Dog DragonBall Dota ElderScrolls Fallout Games GamesHalfLife HeroesOfTheStorm Internet JapaneseMedia LeagueOfLegends Movies Myst Overwatch OnePiece Pokemon Religion Sports SwordArtOnline TvShows Time VERSION Witcher WorldOfWarcraft Zelda].include?(subclass)
+        %i[Base Bank Books Cat Char Base58 ChileRut CLI Config Creature Date Deprecator Dog DragonBall Dota ElderScrolls Fallout Games GamesHalfLife HeroesOfTheStorm Internet JapaneseMedia LeagueOfLegends Movies Myst Overwatch OnePiece Pokemon Religion Sports SwordArtOnline TvShows Time VERSION Witcher WorldOfWarcraft Zelda].include?(subclass)
       end.sort
     end
 


### PR DESCRIPTION
### Motivation / Background

I found that the benchmark task `rake benchmark:all_methods` is not working on current main branch.

So here's a patch that makes the task runnable again.

### Additional information

The task has been broken since f586da74ebbf2eda105d3be5d22ccf2e4e031903 that added a new module named `Faker::Deprecator`. And this patch just adds it to the ignore module list.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature. => Actually, no. But the tasks that used not to work are now working.
* [x] Tests and Rubocop are passing before submitting your proposed changes.