### PR TITLE
Faker::Alphanumeric.alphanumeric determinism fix

### DIFF
--- a/lib/faker/default/alphanumeric.rb
+++ b/lib/faker/default/alphanumeric.rb
@@ -60,7 +60,7 @@ module Faker
         randoms = Array.new(random_count) { sample(ALPHANUMS) }
 
         combined = alphas + numbers + randoms
-        combined.shuffle.join
+        shuffle(combined).join
       end
     end
   end

--- a/test/faker/default/test_alphanum.rb
+++ b/test/faker/default/test_alphanum.rb
@@ -48,4 +48,20 @@ class TestFakerAlphanum < Test::Unit::TestCase
 
     assert_operator numbers.compact.size, :>=, 4
   end
+
+  def test_alphanumeric_with_seed
+    seed = Faker::Config.random.seed
+    Faker::Config.random = Random.new(seed)
+
+    expected = @tester.alphanumeric(number: 10, min_alpha: 5, min_numeric: 5)
+
+    10.times do
+      # Reset the PRNG to ensure the same value is returned on every generation.
+      Faker::Config.random = Random.new(seed)
+
+      actual = @tester.alphanumeric(number: 10, min_alpha: 5, min_numeric: 5)
+
+      assert_equal expected, actual
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to faker-ruby!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the faker-ruby repo.

Create a pull request when it is ready for review and feedback
from the faker-ruby team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.

If you're proposing a new generator or locale, please review and follow the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md) first.
-->

This Pull Request has been created because the `Faker::Alphanumeric.alphanumeric` generator is not deterministic when using `min_alpha` and/or `min_numeric`.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

The generator is not currently deterministic when setting a custom `Faker::Config.random` due to the [usage of the standard `shuffle` array method.](https://github.com/faker-ruby/faker/blob/main/lib/faker/default/alphanumeric.rb#L63)

Unfortunately, this can't be caught by the tests in [test/test_determinism.rb](https://github.com/faker-ruby/faker/blob/main/test/test_determinism.rb) because the default keyword arguments do not trigger the non-determinism due to the [early return when both `min_alpha` and `min_numeric` are `0`](https://github.com/faker-ruby/faker/blob/main/lib/faker/default/alphanumeric.rb#L52).

I have added a test to the `Faker::Alphanumeric` test file for this case, but I'm happy to [re]move it if preferred.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [x] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [x] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
