### PR TITLE
Remove CodeClimate badges

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,18 +55,5 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
-    - name: Setup Code Climate test-reporter
-      run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-        ./cc-test-reporter before-build
-
     - name: Run tests
       run: bundle exec rake test
-
-    - name: Publish code coverage
-      env:
-        CC_TEST_REPORTER_ID: c9b8356df2031a5a72462555fe898245cf24d83c7bb82c40ddb5c6c6976c4319
-      run: |
-        export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-        ./cc-test-reporter after-build -r $CC_TEST_REPORTER_ID

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Tests](https://github.com/faker-ruby/faker/workflows/Tests/badge.svg)](https://github.com/faker-ruby/faker/actions?query=workflow%3ATests)
 [![Gem Version](https://badge.fury.io/rb/faker.svg)](https://badge.fury.io/rb/faker)
 [![Inline docs](https://inch-ci.org/github/faker-ruby/faker.svg?branch=main)](https://inch-ci.org/github/faker-ruby/faker)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/ef54c7f9df86e965d64b/test_coverage)](https://codeclimate.com/github/stympy/faker/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/ef54c7f9df86e965d64b/maintainability)](https://codeclimate.com/github/stympy/faker/maintainability)
 
 Faker is a port of [Perl's Data::Faker library](https://metacpan.org/pod/Data::Faker).
 It's a library for generating fake data such as names, addresses, and phone numbers.


### PR DESCRIPTION
Code Climate integration is removed due to access issues after the project moved to an organization. We will reassess the need for a static analysis tool in the future.

This commit removes the Code Climate configuration and badge from the repository and updates CI to remove related steps.

Close #2983
