### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
 
       - name: Install dependencies
         run: bundle install
@@ -38,7 +38,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rake
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
 
 # Suppress noise for obvious operator precedence.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -13,7 +13,7 @@ If you're reviewing a PR, ask yourself:
 ## Managing libraries dependencies EOL
 
 As a guideline for Ruby's End of Life (EOL) versions, a good heuristic (that's not too hard on maintainers) is to keep support for 1 EOL version.
-In other words, once Ruby 3.0 is EOL, drop support for 2.7.
+In other words, once Ruby 3.1 is EOL, drop support for 3.0.
 
 ## Security
 

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = ['faker']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/main/CHANGELOG.md'
   spec.metadata['source_code_uri'] = 'https://github.com/faker-ruby/faker'

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -5,7 +5,7 @@ mydir = __dir__
 require 'psych'
 require 'i18n'
 
-Dir.glob(File.join(mydir, 'helpers', '*.rb')).sort.each { |file| require file }
+Dir.glob(File.join(mydir, 'helpers', '*.rb')).each { |file| require file }
 
 I18n.load_path += Dir[File.join(mydir, 'locales', '**/*.yml')]
 
@@ -275,4 +275,4 @@ module Faker
 end
 
 # require faker objects
-Dir.glob(File.join(mydir, 'faker', '/**/*.rb')).sort.each { |file| require file }
+Dir.glob(File.join(mydir, 'faker', '/**/*.rb')).each { |file| require file }

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -12,7 +12,7 @@ module Faker
     ].freeze
     ZA_RACE_DIGIT = '8'
     ZA_CITIZENSHIP_DIGITS = %w[0 1].freeze
-    BRAZILIAN_ID_FORMAT = /(\d{1,2})(\d{3})(\d{3})([\dX])/.freeze
+    BRAZILIAN_ID_FORMAT = /(\d{1,2})(\d{3})(\d{3})([\dX])/
     BRAZILIAN_ID_FROM = 10_000_000
     BRAZILIAN_ID_TO = 99_999_999
 

--- a/test/faker/default/test_faker_crypto_coin.rb
+++ b/test/faker/default/test_faker_crypto_coin.rb
@@ -7,9 +7,9 @@ class TestFakerCryptoCoin < Test::Unit::TestCase
   ACRONYM = 1
   URL_LOGO = 2
 
-  REGEX_COIN_NAME = /[a-zA-Z .]{3,}/.freeze
-  REGEX_ACRONYM = /\w+{3,}/.freeze
-  REGEX_URL_LOGO = /^https:\/\/i.imgur.com\/.......\./.freeze
+  REGEX_COIN_NAME = /[a-zA-Z .]{3,}/
+  REGEX_ACRONYM = /\w+{3,}/
+  REGEX_URL_LOGO = /^https:\/\/i.imgur.com\/.......\./
 
   def setup
     @tester = Faker::CryptoCoin

--- a/test/faker/default/test_faker_vehicle.rb
+++ b/test/faker/default/test_faker_vehicle.rb
@@ -3,8 +3,8 @@
 require_relative '../../test_helper'
 
 class TestFakerVehicle < Test::Unit::TestCase
-  WORD_MATCH = /\w+\.?/.freeze
-  VIN_REGEX = /\A[A-HJ-NPR-Z0-9]{17}\z/.freeze
+  WORD_MATCH = /\w+\.?/
+  VIN_REGEX = /\A[A-HJ-NPR-Z0-9]{17}\z/
 
   def setup
     @tester = Faker::Vehicle


### PR DESCRIPTION
Co-authored by: @ayana-s
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Fixes https://github.com/faker-ruby/faker/issues/2885
This Pull Request has been created because Ruby 3.0 is now EOL and the Faker team aims to only maintain support for one EOL version at a time. This means that support for Ruby 2.7 can be dropped.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
