### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ If for some reason you can't update to the latest version, please let us know yo
 
 The faker-ruby core contributors take security very seriously and investigate all reported vulnerabilities.
 
-If you would like to report a vulnerablity or have a security concern regarding faker-ruby, please report it by contacting the current security coordinators (Stefanni Brasil stefanni@hexdevs.com and Thiago Araujo thd@hexdevs.com).
+If you would like to report a vulnerablity or have a security concern regarding faker-ruby, please report it by contacting the current security coordinators (Stefanni Brasil stefanni@hexdevs.com and Thiago Araujo thiago@hexdevs.com).
 
 The information you share with the faker-ruby core contributors as part of this process will be kept confidential within the team, unless or until we need to share information upstream with our dependent libraries' core teams, at which point we will notify you.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,12 @@
-## Security and Vulnerability Reporting
+## Security Policy
+
+### Supported Versions
+
+Only the the latest version of this project is supported at a given time. If you find a security issue with an older version, please try updating to the latest version first.
+
+If for some reason you can't update to the latest version, please let us know your reasons so that we can have a better understanding of your situation.
+
+## Reporting a Vulnerability
 
 The faker-ruby core contributors take security very seriously and investigate all reported vulnerabilities.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+## Security and Vulnerability Reporting
+
+The faker-ruby core contributors take security very seriously and investigate all reported vulnerabilities.
+
+If you would like to report a vulnerablity or have a security concern regarding faker-ruby, please report it by contacting the current security coordinators (Stefanni Brasil stefanni@hexdevs.com and Thiago Araujo thd@hexdevs.com).
+
+The information you share with the faker-ruby core contributors as part of this process will be kept confidential within the team, unless or until we need to share information upstream with our dependent libraries' core teams, at which point we will notify you.
+
+If a vulnerability is first reported by you, we will credit you with the discovery in the public disclosure.


### PR DESCRIPTION
Following the template from Loofah: https://github.com/flavorjones/loofah/blob/main/SECURITY.md

Having a security policy document is a important document to have in any Open Source library. This is what we can support for now.