### PR TITLE
Ensure `Faker::Internet.password` method behavior is consistent with length parameters

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -106,7 +106,7 @@ module Faker
       #
       # @param min_length [Integer] The minimum length of the password
       # @param max_length [Integer] The maximum length of the password
-      # @param mix_case [Boolean] Toggles if uppercased letters are allowed. If true, at least one will be added.
+      # @param mix_case [Boolean] Toggles if uppercased and lowercased letters are allowed. If true, at least one of each will be added. Otherwise, only lowercased letters will be used.
       # @param special_characters [Boolean] Toggles if special characters are allowed. If true, at least one will be added.
       #
       # @return [String]
@@ -144,21 +144,16 @@ module Faker
 
         target_length = rand(min_length..max_length)
 
-        password = []
-        character_bag = []
-
-        # use lower_chars by default and add upper_chars if mix_case
         lower_chars = self::LLetters
-        password << sample(lower_chars)
-        character_bag += lower_chars
-
         digits = ('0'..'9').to_a
-        password << sample(digits)
-        character_bag += digits
+
+        password = []
+        character_bag = lower_chars + digits
 
         if mix_case
           upper_chars = self::ULetters
           password << sample(upper_chars)
+          password << sample(lower_chars)
           character_bag += upper_chars
         end
 

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -194,6 +194,12 @@ class TestFakerInternet < Test::Unit::TestCase
     end
   end
 
+  def test_password_with_specific_integer_arg
+    (1..32).each do |length|
+      assert_equal length, @tester.password(min_length: length, max_length: length, mix_case: false).length
+    end
+  end
+
   def test_password_max_with_integer_arg
     (1..32).each do |min_length|
       max_length = min_length + 4
@@ -241,10 +247,12 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_password_with_same_min_max_length
-    password = @tester.password(min_length: 5, max_length: 5)
+    (2..32).each do |length|
+      password = @tester.password(min_length: length, max_length: length)
 
-    assert_match(/\w+/, password)
-    assert_equal(5, password.length)
+      assert_match(/\w+/, password)
+      assert_equal(length, password.length)
+    end
   end
 
   def test_password_with_max_length_less_than_min_length


### PR DESCRIPTION
<!--
Thanks for contributing to faker-ruby!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the faker-ruby repo.

Create a pull request when it is ready for review and feedback
from the faker-ruby team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#documentation).

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.

If you're proposing a new generator or locale, please review and follow the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md) first.
-->

When using `Faker::Interner.password`, the `min_length` and `max_length` options are not **always** respected.

For instance, running the following snippet will give password out of the desired length range:

```ruby
Faker::Internet.password(min_length: 2, max_length: 2) # => "Pa1" => 3 characters while I was expecting 2
Faker::Internet.password(min_length: 1, max_length: 1, mix_case: false) # => "9n" => 2 characters while I was expecting 1
Faker::Internet.password(min_length: 1, max_length: 1, mix_case: false, special_characters: true) # => "!5u" => 3 characters while I was expecting 1
Faker::Internet.password(min_length: 3, max_length: 3, mix_case: true, special_characters: true) # => "Y2#h" => 4 characters while I was expecting 3
```

This can lead to unexpected behavior when using the `Faker::Internet.password` method.


#### Changes proposed in this pull request

This PR fixes the issue by ensuring that the password generated respects the `min_length` and `max_length` options.

- This is done so by specifying the behavior of the `mix_case` option from the `Faker::Internet.password` method, which is to either force-include an uppercase letter **AND** a lowercase letter if set to `true`, or to only use lowercase letters if set to `false` (without enforcing the presence of a letter).
- This also removes the "force-addition" of digit, which lead to the password being one character longer than expected. I've opened a separate PR to enable or not the force-addition and the use of digits https://github.com/faker-ruby/faker/pull/3033

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* ~[ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.~
* ~[ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).~

### Closing notes

I'm open to any feedback or suggestions on how to improve this PR if this solution makes sense.

Thanks!
