### PR TITLE
Fix usage docs header indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ and it was the original impetus for the creation of this gem.
     - [Notes](#notes)
   - [Getting Started](#getting-started)
   - [Usage](#usage)
-      - [A note about the Generators versions](#a-note-about-the-generators-versions)
+    - [A note about the Generators versions](#a-note-about-the-generators-versions)
     - [Ensuring unique values](#ensuring-unique-values)
     - [Deterministic Random](#deterministic-random)
     - [Customization](#customization)
@@ -89,7 +89,7 @@ Faker::ProgrammingLanguage.name #=> "Ruby"
 
 For a complete list of the generators, see [Generators](#generators).
 
-#### A note about the Generators versions
+### A note about the Generators versions
 
 If you get a `uninitialized constant Faker::[some_class]` error, your version of
 the gem is behind main.


### PR DESCRIPTION
### Motivation / Background

I noticed reading the rubydocs that the indentation for the menu was off for the table of contents. Looking at the README, the indentation for the menu and headers were not consistent. GitHub gracefully handled it, but rdoc did not. You'll see the double indentation (right-most image) has "1.   1. A note about the Generators versions"

### Additional information
| GH Generated ToC | GH Render | RDoc |
|--------|--------|--------|
| <img width="253" alt="image" src="https://github.com/user-attachments/assets/676e9af0-88e8-4a5e-b3fb-d5af63a10c7d" /> | <img width="401" alt="image" src="https://github.com/user-attachments/assets/e662f4ea-25b3-4814-bcfa-a53544498cd4" /> | <img width="347" alt="image" src="https://github.com/user-attachments/assets/c77105ca-079b-4e13-9c8c-829c9a54419a" /> |

