### PR TITLE
Fix city address with number in `locales/fr/address.yml`

### DIFF
--- a/lib/locales/fr/address.yml
+++ b/lib/locales/fr/address.yml
@@ -268,7 +268,7 @@ fr:
         - Nogent-sur-Marne
         - Noisy-le-Grand
         - Noisy-le-Sec
-        - Nouméa11
+        - Nouméa
         - Orléans
         - Palaiseau
         - Pantin


### PR DESCRIPTION
fr locale Address.yml
invalid city_name with numbers

Nouméa11 --> Nouméa

