### PR TITLE
ci: run against Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.4'
 
       - name: Install dependencies
         run: bundle install
@@ -42,6 +42,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - 'head'
           - truffleruby-head
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,9 +78,6 @@ Style/FormatStringToken:
 
 Style/FrozenStringLiteralComment:
   Description: Add the frozen_string_literal comment to the top of files to help transition from Ruby 2.3.0 to Ruby 3.0.
-  Exclude:
-    - 'lib/faker/default/json.rb'
-    - 'test/faker/default/test_faker_json.rb'
 
 Style/For:
   Description: Checks use of for or each in multiline loops.

--- a/lib/faker/default/json.rb
+++ b/lib/faker/default/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Faker
   class Json < Base
     require 'json'
@@ -104,17 +106,20 @@ module Faker
       end
 
       def add_hash(key_array, hash, width, options)
-        string_to_eval = 'hash'
+        string_to_eval = 'hash'.dup
+
         key_array.length.times do |index|
           string_to_eval << "['#{key_array[index]}']"
         end
         string_to_eval << " = #{build_shallow_hash(width, options)}"
         eval(string_to_eval)
+
         hash
       end
 
       def build_keys_from_array(key_array)
-        key_string = ''
+        key_string = ''.dup
+
         key_array.each do |value|
           key_string << "['#{value}']"
         end

--- a/test/faker/default/test_faker_json.rb
+++ b/test/faker/default/test_faker_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../test_helper'
 
 class TestFakerJson < Test::Unit::TestCase


### PR DESCRIPTION
### Motivation / Background

Add Ruby 3.4 to github workflow to run tests against that version.
Fixes frozen string warning in json generator.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [ ] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
