### PR TITLE
test: fix flaky test on `Faker::IdNumber`

### DIFF
--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -66,7 +66,7 @@ class TestFakerIdNumber < Test::Unit::TestCase
     sample = @tester.invalid_south_african_id_number
 
     assert_raises Date::Error do
-      Date.parse(south_african_id_number_to_date_of_birth_string(sample))
+      Date.parse(sample[0..5])
     end
   end
 
@@ -276,15 +276,12 @@ class TestFakerIdNumber < Test::Unit::TestCase
 
   private
 
-  def south_african_id_number_to_date_of_birth_string(sample)
-    "19#{sample[0..1]}/#{sample[2..3]}/#{sample[4..5]}}"
-  end
-
   def assert_valid_south_african_id_number(sample)
     assert_equal 13, sample.length
     assert_match(/^\d{13}$/, sample)
     assert_include Faker::IdNumber::ZA_CITIZENSHIP_DIGITS, sample[10]
     assert_equal Faker::IdNumber::ZA_RACE_DIGIT, sample[11]
-    assert Date.parse(south_african_id_number_to_date_of_birth_string(sample))
+
+    assert Date.parse(sample[0..5])
   end
 end


### PR DESCRIPTION
Fixes a flaky spec on `faker/default/test_faker_id_number.rb`.

The assertion expected a prefix date with year in the `1900-1999` range, but some birthdays in year >2000 would fail. They would be converted incorrectly, for example:
```
Date.parse("19002902")
#=> invalid date (Date::Error)
```

Failed run example: [link](https://github.com/faker-ruby/faker/actions/runs/19003592070/job/54273715783).