### PR TITLE
Refactor: Improve UK Phone number false failure hit-rate

### DIFF
--- a/lib/locales/en-GB.yml
+++ b/lib/locales/en-GB.yml
@@ -111,7 +111,7 @@ en-GB:
         - '0500 ######'
     cell_phone:
       formats:
-        - '07000 900###' # Ofcom suggestion for "drama -> unused"
+        - '07000 900###'
         - '071## ######'
         - '073## ######'
         - '074## ######'


### PR DESCRIPTION
This PR aims to improve the false failure hit-rate for UK Phone numbers. Partially alleviates https://github.com/faker-ruby/faker/issues/3135

### Additional information

Reference from Ofcom drama list: https://www.ofcom.org.uk/phones-and-broadband/phone-numbers/numbers-for-drama

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [ ] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [x] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [x] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
