### PR TITLE
Add except method for excluding specific values from generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ manually set values).
 Faker::Lorem.unique.exclude :string, [number: 6], %w[azerty wxcvbn]
 ```
 
+### Excluding specific values
+
+To exclude specific values from being generated, use the `except` method:
+
+```ruby
+Faker::Name.except('John').first_name # This will return any first name except 'John'
+Faker::Name.except(['Jane', 'John']).first_name # Exclude multiple values
+```
+
 ### Deterministic Random
 
 Faker supports seeding of its pseudo-random number generator (PRNG)

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -233,6 +233,19 @@ module Faker
         @unique ||= UniqueGenerator.new(self, max_retries)
       end
 
+      # Returns any other value than the given excluded value(s).
+      #
+      # @param values [Object, Array] The value(s) to exclude from generation.
+      # @param max_retries [Integer] The max number of retries that should be done before giving up.
+      # @return [self]
+      #
+      # @example
+      #   Faker::Name.except('Jane').first_name #=> 'John' (or any name except 'Jane')
+      #   Faker::Name.except(['Jane', 'John']).first_name #=> 'Bob' (or any name except 'Jane' or 'John')
+      def except(values, max_retries = 10_000)
+        ExceptGenerator.new(self, values, max_retries)
+      end
+
       def sample(list, num = nil)
         if list.respond_to?(:sample)
           if num

--- a/lib/helpers/except_generator.rb
+++ b/lib/helpers/except_generator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Faker
+  class ExceptGenerator
+    def initialize(generator, values, max_retries)
+      @generator = generator
+      @excluded_values = Array(values)
+      @max_retries = max_retries
+    end
+
+    def method_missing(name, *arguments)
+      @max_retries.times do
+        result = @generator.public_send(name, *arguments)
+
+        return result unless @excluded_values.include?(result)
+      end
+
+      raise RetryLimitExceeded, "Retry limit exceeded for #{name} (excluded values: #{@excluded_values.inspect})"
+    end
+    # Have method_missing use ruby 2.x keywords if the method exists.
+    # This is necessary because the syntax for passing arguments (`...`)
+    # is invalid on versions before Ruby 2.7, so it can't be used.
+    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+
+    def respond_to_missing?(method_name, include_private = false)
+      @generator.respond_to?(method_name, include_private) || super
+    end
+
+    RetryLimitExceeded = Class.new(StandardError)
+  end
+end

--- a/test/faker/default/test_faker_except_generator.rb
+++ b/test/faker/default/test_faker_except_generator.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerExceptGenerator < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Name
+  end
+
+  def test_except_with_single_value
+    excluded_name = 'John'
+    100.times do
+      name = @tester.except(excluded_name).first_name
+
+      assert_not_equal excluded_name, name, "Generated name should not be '#{excluded_name}'"
+    end
+  end
+
+  def test_except_with_array_of_values
+    excluded_names = %w[John Jane Bob]
+    100.times do
+      name = @tester.except(excluded_names).first_name
+
+      assert_not_includes excluded_names, name, "Generated name should not be in #{excluded_names.inspect}"
+    end
+  end
+
+  def test_except_with_multiple_methods
+    excluded_name = 'Smith'
+    100.times do
+      last_name = @tester.except(excluded_name).last_name
+
+      assert_not_equal excluded_name, last_name, "Generated last name should not be '#{excluded_name}'"
+    end
+  end
+
+  def test_except_raises_error_when_retry_limit_exceeded
+    # Create a generator that only returns one value
+    generator = Class.new(Faker::Base) do
+      def self.single_value
+        'OnlyValue'
+      end
+    end
+
+    error = assert_raises(Faker::ExceptGenerator::RetryLimitExceeded) do
+      generator.except('OnlyValue', 10).single_value
+    end
+
+    assert_match(/Retry limit exceeded/, error.message)
+    assert_match(/single_value/, error.message)
+    assert_match(/OnlyValue/, error.message)
+  end
+
+  def test_except_with_low_retry_limit
+    # This should work even with a low retry limit if the excluded value is uncommon
+    name = @tester.except('VeryUncommonName', 10).first_name
+
+    assert_not_equal 'VeryUncommonName', name
+  end
+
+  def test_except_returns_different_values
+    excluded_names = %w[John Jane]
+    names = 50.times.map { @tester.except(excluded_names).first_name }
+
+    # Should generate multiple different names (not all the same)
+    assert_operator names.uniq.length, :>, 1, 'Should generate varied names'
+
+    # None should be excluded
+    names.each do |name|
+      assert_not_includes excluded_names, name
+    end
+  end
+
+  def test_except_with_method_arguments
+    # Test that except works with methods that take arguments
+    excluded_number = 5
+    100.times do
+      number = Faker::Number.except(excluded_number).between(from: 1, to: 10)
+
+      assert_not_equal excluded_number, number, "Generated number should not be #{excluded_number}"
+    end
+  end
+
+  def test_except_deterministic_with_seed
+    Faker::Config.random = Random.new(42)
+    result1 = @tester.except('John').first_name
+
+    Faker::Config.random = Random.new(42)
+    result2 = @tester.except('John').first_name
+
+    assert_equal result1, result2, 'Results should be deterministic with same seed'
+
+    Faker::Config.random = nil
+  end
+
+  def test_respond_to_missing
+    except_generator = @tester.except('John')
+
+    assert_respond_to except_generator, :first_name
+    assert_respond_to except_generator, :last_name
+    assert_false except_generator.respond_to?(:nonexistent_method)
+  end
+end

--- a/test/faker/default/test_faker_name.rb
+++ b/test/faker/default/test_faker_name.rb
@@ -51,4 +51,20 @@ class TestFakerName < Test::Unit::TestCase
     assert_match(/[A-Z]{3}/, @tester.initials)
     assert_match(/[A-Z]{2}/, @tester.initials(number: 2))
   end
+
+  def test_first_name_with_except
+    excluded_name = 'John'
+    20.times do
+      name = @tester.except(excluded_name).first_name
+      assert_not_equal excluded_name, name, "Should not generate excluded name '#{excluded_name}'"
+    end
+  end
+
+  def test_last_name_with_except_array
+    excluded_names = %w[Smith Jones]
+    20.times do
+      last_name = @tester.except(excluded_names).last_name
+      assert_not_includes excluded_names, last_name, "Should not generate names in #{excluded_names.inspect}"
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request adds a chainable `except` method that allows filtering out specific values during generation. This is useful when you need to generate fake data but want to avoid certain values, such as excluding existing records in tests or avoiding reserved values.

The implementation follows the same pattern as the existing `unique` method, making it intuitive for users already familiar with Faker's API.

### Additional information

**Usage examples:**
```ruby
# Exclude a single value
Faker::Name.except('John').first_name

# Exclude multiple values
Faker::Name.except(['John', 'Jane', 'Bob']).first_name

# Works with any generator
Faker::Internet.except('admin@example.com').email
Faker::Number.except(13).between(from: 1, to: 20)
```
  
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: [Fix #issue-number]
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

[N/A] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
[N/A] You've reviewed and followed the https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md.