### PR TITLE
deps: bump Minitest version to `v5.26.1` and fix issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'benchmark'
-gem 'minitest', '5.25.5'
+gem 'minitest', '5.26.1'
 gem 'pry', '0.15.2'
 gem 'rake', '13.3.1'
 gem 'rubocop', '1.81.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     method_source (1.1.0)
-    minitest (5.25.5)
+    minitest (5.26.1)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -75,7 +75,7 @@ PLATFORMS
 DEPENDENCIES
   benchmark
   faker!
-  minitest (= 5.25.5)
+  minitest (= 5.26.1)
   pry (= 0.15.2)
   rake (= 13.3.1)
   rubocop (= 1.81.7)

--- a/test/test_i18n_reload.rb
+++ b/test/test_i18n_reload.rb
@@ -12,7 +12,7 @@ class TestI18nLoad < Test::Unit::TestCase
 
       gemfile do
         source 'https://rubygems.org'
-        gem 'minitest', '5.25.5'
+        gem 'minitest'
         gem 'i18n'
       end
 


### PR DESCRIPTION
[minitest 5.26.0] introduced this change
https://github.com/minitest/minitest/commit/68b3d0c149a8773812d874b7cd3359930bf622fc, and when dependabot tried to bump faker's version to 5.26.0 and we started getting this error:

```
Failure: test_faker_i18n(TestI18nLoad)
/home/runner/work/faker/faker/test/test_i18n_reload.rb:40:in `test_faker_i18n'
     37:     cmd = %( ruby -e "#{code}" )
     38:     output, status = Open3.capture2e(cmd)
     39:
  => 40:     assert_equal 0, status, output
     41:   end
     42: end
/opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated minitest 5.26.1, but your Gemfile requires minitest 5.25.5. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/runtime.rb:25:in `block in setup'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/spec_set.rb:165:in `each'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/spec_set.rb:165:in `each'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/runtime.rb:24:in `map'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/runtime.rb:24:in `setup'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/inline.rb:66:in `block (2 levels) in gemfile'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/settings.rb:142:in `temporary'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/inline.rb:51:in `block in gemfile'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler.rb:403:in `block in with_unbundled_env'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler.rb:649:in `with_env'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler.rb:403:in `with_unbundled_env'
	from /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/inline.rb:42:in `gemfile'
	from -e:3:in `<main>'

<0> expected but was
<#<Process::Status: pid 2343 exit 1>>
Error: /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.4.22/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated minitest 5.26.1, but your Gemfile requires minitest 5.25.5. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```

I can't quite say why removing the version definition fixes this but it seems to reuse the version we have set in the Gemfile, and the tests pass.
