### PR TITLE
Remove minitest dependency on i18n reload test

### DIFF
--- a/test/test_i18n_reload.rb
+++ b/test/test_i18n_reload.rb
@@ -9,23 +9,24 @@ class TestI18nLoad < Test::Unit::TestCase
     # and proper initialization of i18n.
     code = <<-RUBY
       require 'bundler/inline'
+      require 'test/unit'
 
       gemfile do
         source 'https://rubygems.org'
-        gem 'minitest'
         gem 'i18n'
       end
 
-      require 'minitest/autorun'
       require 'i18n'
 
-      class TestI18nLoad < Minitest::Test
+      class TestI18nLoad < Test::Unit::TestCase
         def test_faker_i18n
           I18n.available_locales = [:en]
-          refute_predicate I18n.backend, :initialized?
+
+          refute I18n.backend.initialized?
+
           I18n.translate('doesnt matter just triggering a lookup')
 
-          assert_predicate I18n.backend, :initialized?
+          assert I18n.backend.initialized?
 
           assert require File.expand_path('#{File.dirname(__FILE__)}/../lib/faker')
 
@@ -37,6 +38,6 @@ class TestI18nLoad < Test::Unit::TestCase
     cmd = %( ruby -e "#{code}" )
     output, status = Open3.capture2e(cmd)
 
-    assert_equal 0, status, output
+    assert_equal(0, status, output)
   end
 end


### PR DESCRIPTION
Closes #3147

This test has had a few failures regarding its minitest version:

https://github.com/faker-ruby/faker/pull/3073
https://github.com/faker-ruby/faker/pull/3144

To avoid having to change this every time we bump minitest, and there's a failure caused by dependencies mismatches, let's just use Ruby's test/unit instead. CI was failing because [ruby head](https://github.com/ruby/ruby/commit/ccdf83f17a115b53749ec22816467b2aa4f0ddc2) sets minitest version to `5.26.2` but why handle dependencies when we just can not have any 🤓 


