### PR TITLE
Change default scheme in url method to 'https'

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -417,11 +417,11 @@ module Faker
       # @param scheme [String]
       #
       # @example
-      #   Faker::Internet.url                                                           #=> "http://treutel.test/demarcus"
-      #   Faker::Internet.url(host: 'faker')                                            #=> "http://faker/shad"
-      #   Faker::Internet.url(host: 'faker', path: '/docs')                             #=> "http://faker/docs"
-      #   Faker::Internet.url(host: 'faker', path: '/docs', scheme: 'https')            #=> "https://faker/docs"
-      def url(host: domain_name, path: "/#{username}", scheme: 'http')
+      #   Faker::Internet.url                                                           #=> "https://treutel.test/demarcus"
+      #   Faker::Internet.url(host: 'faker')                                            #=> "https://faker/shad"
+      #   Faker::Internet.url(host: 'faker', path: '/docs')                             #=> "https://faker/docs"
+      #   Faker::Internet.url(host: 'faker', path: '/docs', scheme: 'http')            #=> "http://faker/docs"
+      def url(host: domain_name, path: "/#{username}", scheme: 'https')
         "#{scheme}://#{host}#{path}"
       end
 


### PR DESCRIPTION
### Motivation / Background

It's quite surprising that default schema is `http` in 2025. I believe it's time to change this to `https`. I am aware this might be considered a breaking change, but I think is worth it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [ ] Tests and Rubocop are passing before submitting your proposed changes.
