### PR TITLE
Add GitHub actions to dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,11 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: "Etc/UTC"
   


### PR DESCRIPTION
I realized in https://github.com/faker-ruby/faker/pull/3167 that we we're running an older `actions/checkout@v6` version. Then I remembered we can have dependabot keeping these actions up to date for us.