### PR TITLE
Add option to trigger GH workflows manually

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,7 @@ name: "CodeQL"
 on:
   schedule:
     - cron: '56 11 * * 5'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
It would be helpful to have the option to manually trigger a GitHub workflow via the UI. That can be done by adding the `workflow_dispatch:` key.

