### PR TITLE
Autoload OpenSSL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
-  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -5,9 +5,7 @@ mydir = __dir__
 require 'psych'
 require 'i18n'
 
-if ENV['AUTOLOAD'] == '1'
-  autoload(:OpenSSL, 'openssl')
-end
+autoload(:OpenSSL, 'openssl')
 
 Dir.glob(File.join(mydir, 'helpers', '*.rb')).each { |file| require file }
 

--- a/lib/faker/blockchain/bitcoin.rb
+++ b/lib/faker/blockchain/bitcoin.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-if ENV['AUTOLOAD'] != '1'
-  require 'openssl'
-end
 require 'securerandom'
 
 module Faker

--- a/lib/faker/blockchain/tezos.rb
+++ b/lib/faker/blockchain/tezos.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-if ENV['AUTOLOAD'] != '1'
-  require 'openssl'
-end
 require 'securerandom'
 
 module Faker

--- a/lib/faker/default/crypto.rb
+++ b/lib/faker/default/crypto.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-if ENV['AUTOLOAD'] != '1'
-  require 'openssl'
-end
-
 module Faker
   class Crypto < Base
     class << self


### PR DESCRIPTION
Closes #3186

This work has been co-authored with @thdaraujo 

The following generators require OpenSSL:

- [Crypto](https://github.com/faker-ruby/faker/blob/main/lib/faker/default/crypto.rb)
- [Blockchain::Tezos](https://github.com/faker-ruby/faker/blob/main/lib/faker/blockchain/tezos.rb)
- [Blockchain::Bitcoin](https://github.com/faker-ruby/faker/blob/main/lib/faker/blockchain/bitcoin.rb)

The profiler screenshots show that loading faker spent about 9% of the samples doing that:

`vernier run -- ruby -e 'load("/Users/stefannibrasil/projects/faker/lib/faker.rb")'`

Call tree:
<img width="1066" height="249" alt="Profiler Call tree, inverted stack" src="https://github.com/user-attachments/assets/f3032990-43cd-46d3-a38b-808a034f17d3" />

Stack chart:
<img width="1736" height="602" alt="Profiler Stack chart" src="https://github.com/user-attachments/assets/6f485409-50b7-4144-a3fd-08938a75cb08" />

## benchmark

CI: `took 125.20560900000532ms to load`

We tried requiring 'openssl/digest' only but we still needed to require 'openssl' somewhere else.

The next step was testing autoloading OpenSSL.

## Autoload OpenSSL

CI: `took 80.12221799998542ms to load`

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('autoload openssl') { system('AUTOLOAD=1 ruby load_faker.rb') }
  x.report('require openssl') { system('ruby load_faker.rb') }

  x.compare!(order: :baseline)
end
```

results

```sh
ruby load.rb
ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [arm64-darwin24]
Warming up --------------------------------------
     require openssl     1.000 i/100ms
    autoload openssl     1.000 i/100ms
Calculating -------------------------------------
     require openssl     10.485 (± 0.0%) i/s   (95.37 ms/i) -     53.000 in   5.057875s
    autoload openssl     12.429 (± 0.0%) i/s   (80.46 ms/i) -     63.000 in   5.072235s

Comparison:
     require openssl:       10.5 i/s
    autoload openssl:       12.4 i/s - 1.19x  faster
```

Autoloading OpenSSL is ~19% faster 🚀 

Call tree:
<img width="1153" height="318" alt="Profiler Call tree, inverted stack" src="https://github.com/user-attachments/assets/11aac974-5f3b-4ad5-bc82-621d1ff9916e" />

Stack Chart:
<img width="1729" height="552" alt="Profiler Stack Chart" src="https://github.com/user-attachments/assets/7fbc2064-bb0b-499a-9d62-baa4d514da14" />
