### PR TITLE
Remove json_schema and public-suffix versions constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem 'yard', '0.9.38'
 
 # TODO: remove when Ruby 3.1 is no longer supported
 gem 'erb', '~> 4.0.4'
-gem 'json-schema', '~> 5.2.2'
-gem 'public_suffix', '~> 6.0.2'
 
 group :benchmark do
   gem 'benchmark'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,10 +114,8 @@ DEPENDENCIES
   erb (~> 4.0.4)
   faker!
   irb
-  json-schema (~> 5.2.2)
   minitest (= 5.27.0)
   pry (= 0.16.0)
-  public_suffix (~> 6.0.2)
   rake (= 13.3.1)
   rdoc
   rubocop


### PR DESCRIPTION
This was needed in https://github.com/faker-ruby/faker/pull/3220 but after https://github.com/faker-ruby/faker/pull/3222 it is not needed anymore.