### PR TITLE
feat(lazy-loading): add `Faker::Config.lazy_loading?`

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -38,6 +38,14 @@ module Faker
       def random
         Thread.current[:faker_config_random] || Random
       end
+
+      def lazy_loading?
+        Thread.current[:faker_lazy_loading] == true
+      end
+
+      def lazy_loading=(value)
+        Thread.current[:faker_lazy_loading] = value
+      end
     end
   end
 

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -80,6 +80,14 @@ class TestFaker < Test::Unit::TestCase
     assert_equal v, Faker::Base.rand_in_range(0, 1000)
   end
 
+  def test_config_lazy_loading
+    refute_predicate Faker::Config, :lazy_loading?
+
+    Faker::Config.lazy_loading = true
+
+    assert_predicate Faker::Config, :lazy_loading?
+  end
+
   def test_parse
     data = {
       faker: {


### PR DESCRIPTION
(Fixes https://github.com/faker-ruby/faker/issues/3225)

Adds configuration option to enable/disable lazy loading so it can be explicitly enabled during beta testing.

This flag will be used to enable lazy loading generators.
