### PR TITLE
Amend `province` for `zh-CN`

### DIFF
--- a/doc/default/address.md
+++ b/doc/default/address.md
@@ -38,6 +38,11 @@ Faker::Address.state #=> "California"
 
 Faker::Address.state_abbr #=> "AP"
 
+#note: In some countries, "province" is used instead of "state".
+Faker::Address.province #=> "湖北省"
+
+Faker::Address.province_abbr #=> "鄂"
+
 Faker::Address.country #=> "French Guiana"
 
 # Keyword arguments: code

--- a/lib/locales/zh-CN.yml
+++ b/lib/locales/zh-CN.yml
@@ -209,7 +209,7 @@ zh-CN:
         - 栋
       postcode:
         - "######"
-      state:
+      province: &province
         - 北京市
         - 上海市
         - 天津市
@@ -217,13 +217,13 @@ zh-CN:
         - 黑龙江省
         - 吉林省
         - 辽宁省
-        - 内蒙古
+        - 内蒙古自治区
         - 河北省
-        - 新疆
+        - 新疆维吾尔自治区
         - 甘肃省
         - 青海省
         - 陕西省
-        - 宁夏
+        - 宁夏回族自治区
         - 河南省
         - 山东省
         - 山西省
@@ -234,16 +234,17 @@ zh-CN:
         - 四川省
         - 贵州省
         - 云南省
-        - 广西省
-        - 西藏
+        - 广西壮族自治区
+        - 西藏自治区
         - 浙江省
         - 江西省
         - 广东省
         - 福建省
         - 海南省
-        - 香港
-        - 澳门
-      state_abbr:
+        - 香港特别行政区
+        - 澳门特别行政区
+        - 台湾省
+      province_abbr: &province_abbr
         - 京
         - 沪
         - 津
@@ -277,6 +278,11 @@ zh-CN:
         - 琼
         - 港
         - 澳
+        - 台
+      state:
+        *province
+      state_abbr:
+        *province_abbr
       street_name:
         - "#{Name.last_name}#{street_suffix}"
       street_address:


### PR DESCRIPTION
### Motivation / Background

In China, we use `province` instead of `state`. In the original localization, the default term `state` was used.

To address this, I adjusted it to `province` and used the standard term of each province rather than an abbreviation.

However, there is an issue with this PR: to maintain backward compatibility, I used YAML's anchor syntax. What do you think — is this necessary?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [x] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [x] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
