### PR TITLE
Remove duplicate 'Recalled to Life' book title

### DIFF
--- a/lib/locales/en/book.yml
+++ b/lib/locales/en/book.yml
@@ -139,7 +139,6 @@ en:
         - The Proper Study
         - Quo Vadis
         - Recalled to Life
-        - Recalled to Life
         - Ring of Bright Water
         - The Road Less Traveled
         - A Scanner Darkly


### PR DESCRIPTION
## Motivation / Background

`Faker::Book.title` can return `"Recalled to Life"` with twice the expected probability because it appears twice in the title list (lines 141–142 of `lib/locales/en/book.yml`).

The duplicate has been present since #484 (Dec 2015), when the book title list was bulk-replaced with titles sourced from Wikipedia. Both [Reginald Hill's novel ](https://en.wikipedia.org/wiki/Recalled_to_Life_(novel)) and [Book 1 of Dickens' *A Tale of Two Cities*](https://www.amazon.com/Recalled-Life-Tale-Cities-Book/dp/B0FC33F3NP) share the name, so the source list had two entries that were pasted without deduplication.

This PR removes one of the two identical entries.

## Checklist

- [x] One change per PR
- [x] Detailed commit message
- [x] No CHANGELOG.md changes