### PR TITLE
Drop support for Ruby 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,7 +42,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ plugins:
   - rubocop-rake
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   NewCops: enable
 
 # Suppress noise for obvious operator precedence.

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,6 @@ gem 'test-unit', '3.7.7'
 gem 'timecop', '0.9.11'
 gem 'yard', '0.9.40'
 
-# TODO: remove when Ruby 3.1 is no longer supported
-gem 'erb', '~> 4.0.4'
-
 group :benchmark do
   gem 'benchmark'
   gem 'benchmark-ips'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,6 @@ PLATFORMS
 DEPENDENCIES
   benchmark
   benchmark-ips
-  erb (~> 4.0.4)
   faker!
   irb
   minitest (= 5.27.0)

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = ['faker']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.metadata['changelog_uri'] = 'https://github.com/faker-ruby/faker/blob/main/CHANGELOG.md'
   spec.metadata['source_code_uri'] = 'https://github.com/faker-ruby/faker'

--- a/lib/faker/default/driving_licence.rb
+++ b/lib/faker/default/driving_licence.rb
@@ -61,11 +61,11 @@ module Faker
       #   Faker::DrivingLicence.uk_driving_licence             #=> "70702548"
       #
       # @faker.version 1.9.2
-      def uk_driving_licence(*args)
+      def uk_driving_licence(*)
         if Faker::Config.random.rand < NI_CHANCE
           northern_irish_driving_licence
         else
-          british_driving_licence(*args)
+          british_driving_licence(*)
         end
       end
 

--- a/lib/helpers/positional_generator.rb
+++ b/lib/helpers/positional_generator.rb
@@ -278,8 +278,6 @@ class PositionalGenerator
     #       [2]
     #     ]
     def build_stack(graph)
-      require 'set'
-
       terminals = graph.filter_map { |(from, to)| to.nil? && from }
       stack = [terminals]
       seen = Set.new(terminals)


### PR DESCRIPTION
Ruby 3.1 is not maintained anymore. Following our Maintaining guidelines, we aim to support only one EOL version at a time.

The minimum Ruby version is now 3.2.

Close https://github.com/faker-ruby/faker/issues/3239
