### PR TITLE
Enhance lazy load tests, CI configuration for better isolation and fixes for current lazy problems

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,12 +12,10 @@ on:
     branches:
       - main
       - 'lazy-loading-beta'
-      - 'lazy-load-test-and-fixes'
   pull_request:
     branches:
       - main
       - 'lazy-loading-beta'
-      - 'lazy-load-test-and-fixes'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - main
       - 'lazy-loading-beta'
+      - 'lazy-load-test-and-fixes'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -75,5 +75,5 @@ jobs:
         bundler-cache: true
 
     - name: Run tests with lazy load enabled
-      run: FAKER_LAZY_LOAD=1 bundle exec rake test
+      run: bundle exec rake test:lazy_load
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - 'lazy-loading-beta'
+      - 'lazy-load-test-and-fixes'
   pull_request:
     branches:
       - main

--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -67,7 +67,7 @@ module Faker
       #
       # @faker.version 1.9.4
       def rut
-        value = Number.number(digits: 8).to_s
+        value = Faker::Number.number(digits: 8).to_s
         vd = rut_verificator_digit(value)
         value << "-#{vd}"
       end
@@ -92,7 +92,7 @@ module Faker
       #
       # @faker.version 2.2.0
       def nric(min_age: 18, max_age: 65)
-        birthyear = Date.birthday(min_age: min_age, max_age: max_age).year
+        birthyear = Faker::Date.birthday(min_age: min_age, max_age: max_age).year
 
         generate(:string) do |g|
           g.computed(name: :prefix) do

--- a/lib/faker/default/crypto.rb
+++ b/lib/faker/default/crypto.rb
@@ -22,7 +22,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def md5
-        OpenSSL::Digest::MD5.hexdigest(Lorem.characters(number: MD5_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::MD5.hexdigest(Faker::Lorem.characters(number: MD5_MIN_NUMBER_OF_CHARACTERS))
       end
 
       ##
@@ -35,7 +35,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha1
-        OpenSSL::Digest::SHA1.hexdigest(Lorem.characters(number: SHA1_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::SHA1.hexdigest(Faker::Lorem.characters(number: SHA1_MIN_NUMBER_OF_CHARACTERS))
       end
 
       ##
@@ -48,7 +48,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha256
-        OpenSSL::Digest::SHA256.hexdigest(Lorem.characters(number: SHA256_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::SHA256.hexdigest(Faker::Lorem.characters(number: SHA256_MIN_NUMBER_OF_CHARACTERS))
       end
 
       ##
@@ -61,7 +61,7 @@ module Faker
       #
       # @faker.version next
       def sha512
-        OpenSSL::Digest::SHA512.hexdigest(Lorem.characters(number: SHA512_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::SHA512.hexdigest(Faker::Lorem.characters(number: SHA512_MIN_NUMBER_OF_CHARACTERS))
       end
     end
   end

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -103,7 +103,7 @@ module Faker
           },
           credentials: {
             token: Faker::Crypto.md5,
-            expires_at: Time.forward.to_i,
+            expires_at: Faker::Time.forward.to_i,
             expires: true
           },
           extra: {
@@ -263,8 +263,8 @@ module Faker
               params: {
                 oauth_token: token,
                 oauth_token_secret: secret,
-                oauth_expires_in: Time.forward.to_i,
-                oauth_authorization_expires_in: Time.forward.to_i
+                oauth_expires_in: Faker::Time.forward.to_i,
+                oauth_authorization_expires_in: Faker::Time.forward.to_i
               },
               response: nil
             },
@@ -420,7 +420,7 @@ module Faker
             image: image
           },
           credentials: {
-            expires_at: Time.forward.to_i,
+            expires_at: Faker::Time.forward.to_i,
             expires: true,
             token_type: 'Bearer',
             id_token: Faker::Crypto.sha256,

--- a/lib/faker/default/types.rb
+++ b/lib/faker/default/types.rb
@@ -63,7 +63,7 @@ module Faker
       # @faker.version 1.8.6
       def rb_hash(number: 1, type: -> { random_type })
         {}.tap do |hsh|
-          Lorem.words(number: number * 2).uniq.first(number).each do |s|
+          Faker::Lorem.words(number: number * 2).uniq.first(number).each do |s|
             value = type.is_a?(Proc) ? type.call : type
             hsh.merge!(s.to_sym => value)
           end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -36,33 +36,32 @@ namespace :test do
           )
 
           if status.success?
-            mutex.synchronize do
-              print '.'
-              $stdout.flush
-            end
+            mutex.synchronize { puts "PASS: #{file}" }
           else
             mutex.synchronize do
-              print 'F'
-              $stdout.flush
+              puts "FAIL: #{file}"
               failures << { file: file, stdout: stdout, stderr: stderr }
             end
           end
+        end
+      rescue StandardError => e
+        mutex.synchronize do
+          failures << { file: 'THREAD ERROR', stdout: e.message, stderr: e.backtrace&.join("\n") || '' }
         end
       end
     end
 
     threads.each(&:join)
-    puts # newline after progress dots
 
     unless failures.empty?
-      warn "\n#{'=' * 60}"
-      warn "LAZY LOAD FAILURES (#{failures.size} file(s)):"
+      puts "\n#{'=' * 60}"
+      puts "LAZY LOAD FAILURES (#{failures.size} file(s)):"
       failures.each do |f|
-        warn "\n--- #{f[:file]} ---"
-        warn f[:stdout] unless f[:stdout].empty?
-        warn f[:stderr] unless f[:stderr].empty?
+        puts "\n--- #{f[:file]} ---"
+        puts f[:stdout] unless f[:stdout].empty?
+        puts f[:stderr] unless f[:stderr].empty?
       end
-      warn '=' * 60
+      puts '=' * 60
       abort
     end
   end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rake/testtask'
+require 'open3'
+require 'etc'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
@@ -10,3 +12,58 @@ Rake::TestTask.new do |t|
 end
 
 task default: :test
+
+namespace :test do
+  desc 'Run each generator test file in isolation with FAKER_LAZY_LOAD=1 to catch lazy-loading cross-reference bugs'
+  task :lazy_load do
+    # Locale tests (test/test_*_locale.rb) only verify i18n data — they do not exercise
+    # generator constant cross-references and are irrelevant to lazy loading.
+    # Scoping to test/faker/ and test/helpers/ keeps the run fast and targeted.
+    files    = FileList['test/faker/**/**/test*.rb', 'test/helpers/**/**/test*.rb'].to_a
+    failures = []
+    mutex    = Mutex.new
+    workers  = [Etc.nprocessors, files.size].min
+
+    threads = workers.times.map do
+      Thread.new do
+        loop do
+          file = mutex.synchronize { files.shift }
+          break unless file
+
+          stdout, stderr, status = Open3.capture3(
+            { 'FAKER_LAZY_LOAD' => '1' },
+            RbConfig.ruby, '-Ilib', '-Itest', file
+          )
+
+          if status.success?
+            mutex.synchronize do
+              print '.'
+              $stdout.flush
+            end
+          else
+            mutex.synchronize do
+              print 'F'
+              $stdout.flush
+              failures << { file: file, stdout: stdout, stderr: stderr }
+            end
+          end
+        end
+      end
+    end
+
+    threads.each(&:join)
+    puts # newline after progress dots
+
+    unless failures.empty?
+      warn "\n#{'=' * 60}"
+      warn "LAZY LOAD FAILURES (#{failures.size} file(s)):"
+      failures.each do |f|
+        warn "\n--- #{f[:file]} ---"
+        warn f[:stdout] unless f[:stdout].empty?
+        warn f[:stderr] unless f[:stderr].empty?
+      end
+      warn '=' * 60
+      abort
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This pull request introduces a new parallelized Rake task to test for lazy-loading issues, updates the GitHub Actions workflow to use this new task, and standardizes internal references to the Faker module across several files. These changes improve test coverage for lazy loading, ensure consistency in code referencing, and enhance the reliability of the test suite.

The current `FAKER_LAZY_LOAD=1 bundle exec rake test`, all test files are loaded into the same Ruby process sequentially. A test file loaded early may accidentally trigger the loading of constants that a later test file depends on, silently masking cross-reference bugs. By the time the problematic file runs, the constants it needs are already in memory — not because it loaded them correctly, but because a previous test happened to do so first.
The new `rake test:lazy_load` task fixes this by spawning each test file as a separate subprocess with FAKER_LAZY_LOAD=1. Each file starts with a completely clean environment, so any missing or incorrectly ordered constant references will fail immediately and visibly — exactly as they would for a real user relying on lazy loading.

**Testing improvements:**

* Added a new `test:lazy_load` Rake task in `tasks/test.rake` that runs each generator test file in isolation with `FAKER_LAZY_LOAD=1`, using parallel threads to speed up execution and catch lazy-loading cross-reference bugs. The task reports failures in detail. (`[[1]](diffhunk://#diff-6f6c54f948fbcefb0bec48cb184b468692ff700d73f87c9d797e5bbccb467a46R4-R5)`, `[[2]](diffhunk://#diff-6f6c54f948fbcefb0bec48cb184b468692ff700d73f87c9d797e5bbccb467a46R15-R68)`)
* Updated the GitHub Actions workflow (`.github/workflows/ruby.yml`) to use the new `test:lazy_load` task instead of running all tests with `FAKER_LAZY_LOAD=1` in a single process. (`[.github/workflows/ruby.ymlL78-R78](diffhunk://#diff-ce0dee93a528f6c7648f4cd671a3ec7be6a80f976c88f3aa1c322b7a80828fbaL78-R78)`)

**Code consistency and internal referencing:**

* Standardized internal references to always use the `Faker` namespace instead of direct class references (e.g., replaced `Lorem` with `Faker::Lorem`, `Number` with `Faker::Number`, etc.) in files such as `lib/faker/default/code.rb`, `lib/faker/default/crypto.rb`, `lib/faker/default/types.rb`, and `lib/faker/default/omniauth.rb`. This change helps avoid cross-referencing issues and supports lazy loading. (`[[1]](diffhunk://#diff-009d3f12eca261a0240580a253675f30be5048cb65513d17bd28703343f83ab4L70-R70)`, `[[2]](diffhunk://#diff-009d3f12eca261a0240580a253675f30be5048cb65513d17bd28703343f83ab4L95-R95)`, `[[3]](diffhunk://#diff-f7ba0d722070400981162098a5127d27a858f745f7cac746bbdefedb38821af3L25-R25)`, `[[4]](diffhunk://#diff-f7ba0d722070400981162098a5127d27a858f745f7cac746bbdefedb38821af3L38-R38)`, `[[5]](diffhunk://#diff-f7ba0d722070400981162098a5127d27a858f745f7cac746bbdefedb38821af3L51-R51)`, `[[6]](diffhunk://#diff-f7ba0d722070400981162098a5127d27a858f745f7cac746bbdefedb38821af3L64-R64)`, `[[7]](diffhunk://#diff-304a6cb766ca8fa8b967986bcba28d10b498b4b4d7951c772599784f8e0e2f59L66-R66)`, `[[8]](diffhunk://#diff-1a5efd2ca4db6dee6f330e93ca231b604096cf391cd52d65b618e1dd5219e562L106-R106)`, `[[9]](diffhunk://#diff-1a5efd2ca4db6dee6f330e93ca231b604096cf391cd52d65b618e1dd5219e562L266-R267)`, `[[10]](diffhunk://#diff-1a5efd2ca4db6dee6f330e93ca231b604096cf391cd52d65b618e1dd5219e562L423-R423)`)

### Additional information

- Example of the GHA run before the changes to fix current problems: https://github.com/javier-menendez/faker/actions/runs/24780020390/job/72508311148


