### PR TITLE
Fix: qualify bare Faker constant references to support lazy loading

### DIFF
--- a/lib/faker/default/code.rb
+++ b/lib/faker/default/code.rb
@@ -67,7 +67,7 @@ module Faker
       #
       # @faker.version 1.9.4
       def rut
-        value = Number.number(digits: 8).to_s
+        value = Faker::Number.number(digits: 8).to_s
         vd = rut_verificator_digit(value)
         value << "-#{vd}"
       end
@@ -92,7 +92,7 @@ module Faker
       #
       # @faker.version 2.2.0
       def nric(min_age: 18, max_age: 65)
-        birthyear = Date.birthday(min_age: min_age, max_age: max_age).year
+        birthyear = Faker::Date.birthday(min_age: min_age, max_age: max_age).year
 
         generate(:string) do |g|
           g.computed(name: :prefix) do

--- a/lib/faker/default/crypto.rb
+++ b/lib/faker/default/crypto.rb
@@ -22,7 +22,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def md5
-        OpenSSL::Digest::MD5.hexdigest(Lorem.characters(number: MD5_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::MD5.hexdigest(Faker::Lorem.characters(number: MD5_MIN_NUMBER_OF_CHARACTERS))
       end
 
       ##
@@ -35,7 +35,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha1
-        OpenSSL::Digest::SHA1.hexdigest(Lorem.characters(number: SHA1_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::SHA1.hexdigest(Faker::Lorem.characters(number: SHA1_MIN_NUMBER_OF_CHARACTERS))
       end
 
       ##
@@ -48,7 +48,7 @@ module Faker
       #
       # @faker.version 1.6.4
       def sha256
-        OpenSSL::Digest::SHA256.hexdigest(Lorem.characters(number: SHA256_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::SHA256.hexdigest(Faker::Lorem.characters(number: SHA256_MIN_NUMBER_OF_CHARACTERS))
       end
 
       ##
@@ -61,7 +61,7 @@ module Faker
       #
       # @faker.version next
       def sha512
-        OpenSSL::Digest::SHA512.hexdigest(Lorem.characters(number: SHA512_MIN_NUMBER_OF_CHARACTERS))
+        OpenSSL::Digest::SHA512.hexdigest(Faker::Lorem.characters(number: SHA512_MIN_NUMBER_OF_CHARACTERS))
       end
     end
   end

--- a/lib/faker/default/omniauth.rb
+++ b/lib/faker/default/omniauth.rb
@@ -103,7 +103,7 @@ module Faker
           },
           credentials: {
             token: Faker::Crypto.md5,
-            expires_at: Time.forward.to_i,
+            expires_at: Faker::Time.forward.to_i,
             expires: true
           },
           extra: {
@@ -263,8 +263,8 @@ module Faker
               params: {
                 oauth_token: token,
                 oauth_token_secret: secret,
-                oauth_expires_in: Time.forward.to_i,
-                oauth_authorization_expires_in: Time.forward.to_i
+                oauth_expires_in: Faker::Time.forward.to_i,
+                oauth_authorization_expires_in: Faker::Time.forward.to_i
               },
               response: nil
             },
@@ -420,7 +420,7 @@ module Faker
             image: image
           },
           credentials: {
-            expires_at: Time.forward.to_i,
+            expires_at: Faker::Time.forward.to_i,
             expires: true,
             token_type: 'Bearer',
             id_token: Faker::Crypto.sha256,

--- a/lib/faker/default/types.rb
+++ b/lib/faker/default/types.rb
@@ -63,7 +63,7 @@ module Faker
       # @faker.version 1.8.6
       def rb_hash(number: 1, type: -> { random_type })
         {}.tap do |hsh|
-          Lorem.words(number: number * 2).uniq.first(number).each do |s|
+          Faker::Lorem.words(number: number * 2).uniq.first(number).each do |s|
             value = type.is_a?(Proc) ? type.call : type
             hsh.merge!(s.to_sym => value)
           end


### PR DESCRIPTION
### Motivation / Background

Prefix unresolved calls to Number, Date, Lorem, and Time with Faker:: in Code, Crypto, Omniauth, and Types so they resolve correctly when FAKER_LAZY_LOAD=1 defers autoloading

**Generators failing with lazy enabled**
```
Faker::Code.nric
Faker::Code.rut
Faker::Crypto.md5
Faker::Crypto.sha1
Faker::Crypto.sha256
Faker::Omniauth.apple
Faker::Omniauth.auth0
Faker::Omniauth.facebook
Faker::Omniauth.github
Faker::Omniauth.google
Faker::Omniauth.linkedin
```
**Example to reproduce**

```
FAKER_LAZY_LOAD=1 bundle exec irb
irb(main):001> require 'faker'
=> true
irb(main):002> Faker::Code.nric
/home/user/faker/lib/faker/default/code.rb:95:in 'Faker::Code.nric': undefined method 'birthday' for class Date (NoMethodError)
```


