### PR TITLE
Bump minitest to 6.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'irb'
-gem 'minitest', '5.27.0'
+gem 'minitest', '6.0.5'
+gem 'minitest-mock'
 gem 'pry', '0.16.0'
 gem 'rake', '13.4.2'
 gem 'rdoc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     concurrent-ruby (1.3.6)
     date (3.5.1)
     docile (1.4.1)
+    drb (2.2.3)
     erb (6.0.4)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
@@ -27,7 +28,10 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     method_source (1.1.0)
-    minitest (5.27.0)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    minitest-mock (5.27.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -101,7 +105,8 @@ DEPENDENCIES
   benchmark-ips
   faker!
   irb
-  minitest (= 5.27.0)
+  minitest (= 6.0.5)
+  minitest-mock
   pry (= 0.16.0)
   rake (= 13.4.2)
   rdoc

--- a/test/faker/default/test_faker_boolean.rb
+++ b/test/faker/default/test_faker_boolean.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../../test_helper'
-require 'minitest/mock'
 
 class TestFakerBoolean < Test::Unit::TestCase
   def setup

--- a/test/faker/default/test_faker_number.rb
+++ b/test/faker/default/test_faker_number.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../../test_helper'
-require 'minitest/mock'
 
 class TestFakerNumber < Test::Unit::TestCase
   def setup

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require 'minitest/mock'
 require_relative 'test_helper'
+
 # rubocop:disable Security/Eval,Style/EvalWithLocation
 class TestDeterminism < Test::Unit::TestCase
   def setup


### PR DESCRIPTION
Close https://github.com/faker-ruby/faker/issues/3254

`minitest-mock` is now a separate gem. Adding it to the Gemfile and requiring it
fixes the load error after bumping minitest. I also removed requiring the mock gem in files that didn't use it.