### PR TITLE
fix: `Faker::Config.lazy_loading` configuration must be respected (WIP)

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'faker/loader'
+
 mydir = __dir__
 
 require 'psych'
@@ -14,9 +16,10 @@ I18n.load_path += Dir[File.join(mydir, 'locales', '**/*.yml')]
 module Faker
   module Config
     @default_locale = nil
+    @lazy_loading = false
 
     class << self
-      attr_writer :default_locale
+      attr_writer :default_locale, :lazy_loading
 
       def locale=(new_locale)
         Thread.current[:faker_config_locale] = new_locale
@@ -43,15 +46,11 @@ module Faker
       end
 
       def lazy_loading?
-        if ENV.key?('FAKER_LAZY_LOAD') && !ENV['FAKER_LAZY_LOAD'].nil?
-          %w[true TRUE 1].include?(ENV.fetch('FAKER_LAZY_LOAD', nil))
+        if ENV.key?('FAKER_LAZY_LOAD')
+          %w[true TRUE 1].include?(ENV['FAKER_LAZY_LOAD'])
         else
-          Thread.current[:faker_lazy_loading] == true
+          @lazy_loading
         end
-      end
-
-      def lazy_loading=(value)
-        Thread.current[:faker_lazy_loading] = value
       end
     end
   end
@@ -291,60 +290,20 @@ module Faker
     end
   end
 
-  def self.load_path(*constants)
-    constants.map do |class_name|
-      class_name
-        .to_s
-        .gsub('::', '/')
-        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-        .tr('-', '_')
-        .downcase
-    end.join('/')
-  end
+  @loader = Loader.new(__dir__, Config)
 
-  # TODO: refactor this
-
-  def self.resolve_const(context_name, class_name)
-    load_path = case class_name
-                when :DnD
-                  load_path('faker/games/dnd')
-                else
-                  load_path(context_name, class_name)
-                end
-
-    begin
-      require(load_path)
-    rescue LoadError
-      require(load_path.gsub('faker/', 'faker/default/'))
-    end
-  end
-
-  EAGER_LOAD_MUTEX = Mutex.new
-  private_constant :EAGER_LOAD_MUTEX
-
-  # initial usage determines lazy loading or eager loading
-  # TODO: this can be a bit surprising and error-prone
+  # Resolves missing constants by either lazy or eager loading generator files,
+  # depending on +Config.lazy_loading?+ at the time of first use.
+  #
+  # The loading strategy is determined on the first access. Setting
+  # +Config.lazy_loading+ after any generator has been referenced has no effect.
   def self.const_missing(class_name)
-    EAGER_LOAD_MUTEX.synchronize do
-      if Config.lazy_loading?
-        resolve_const(name, class_name)
-      elsif !@eager_load
-        @eager_load = true
-        Dir.glob(["#{__dir__}/faker/*.rb", "#{__dir__}/faker/**/*.rb"]).each { |f| require f }
-      end
-    end
+    @loader.load_const(name, class_name)
 
     const_get(class_name)
   end
 
   def self.lazy_load(klass)
-    mutex = Mutex.new
-
-    klass.define_singleton_method(:const_missing) do |class_name|
-      mutex.synchronize { Faker.resolve_const(name, class_name) }
-
-      const_get(class_name)
-    end
+    @loader.install_on(klass)
   end
 end

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -320,8 +320,6 @@ module Faker
     end
   end
 
-  private_class_method :resolve_const
-
   EAGER_LOAD_MUTEX = Mutex.new
   private_constant :EAGER_LOAD_MUTEX
 

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -291,46 +291,62 @@ module Faker
     end
   end
 
-  if Faker::Config.lazy_loading?
-    def self.load_path(*constants)
-      constants.map do |class_name|
-        class_name
-          .to_s
-          .gsub('::', '/')
-          .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-          .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-          .tr('-', '_')
-          .downcase
-      end.join('/')
+  def self.load_path(*constants)
+    constants.map do |class_name|
+      class_name
+        .to_s
+        .gsub('::', '/')
+        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+        .tr('-', '_')
+        .downcase
+    end.join('/')
+  end
+
+  # TODO: refactor this
+
+  def self.resolve_const(context_name, class_name)
+    load_path = case class_name
+                when :DnD
+                  load_path('faker/games/dnd')
+                else
+                  load_path(context_name, class_name)
+                end
+
+    begin
+      require(load_path)
+    rescue LoadError
+      require(load_path.gsub('faker/', 'faker/default/'))
     end
+  end
 
-    def self.lazy_load(klass)
-      def klass.const_missing(class_name)
-        load_path = case class_name
-                    when :DnD
-                      Faker.load_path('faker/games/dnd')
-                    else
-                      Faker.load_path(name, class_name)
-                    end
+  private_class_method :resolve_const
 
-        begin
-          require(load_path)
-        rescue LoadError
-          require(load_path.gsub('faker/', 'faker/default/'))
-        end
+  EAGER_LOAD_MUTEX = Mutex.new
+  private_constant :EAGER_LOAD_MUTEX
 
-        const_get(class_name)
+  # initial usage determines lazy loading or eager loading
+  # TODO: this can be a bit surprising and error-prone
+  def self.const_missing(class_name)
+    EAGER_LOAD_MUTEX.synchronize do
+      if Config.lazy_loading?
+        resolve_const(name, class_name)
+      elsif !@eager_load
+        @eager_load = true
+        Dir.glob(["#{__dir__}/faker/*.rb", "#{__dir__}/faker/**/*.rb"]).each { |f| require f }
       end
     end
 
-    lazy_load(self)
+    const_get(class_name)
   end
-end
 
-unless Faker::Config.lazy_loading?
-  rb_files = []
-  rb_files << File.join(mydir, 'faker', '*.rb')
-  rb_files << File.join(mydir, 'faker', '/**/*.rb')
+  def self.lazy_load(klass)
+    mutex = Mutex.new
 
-  Dir.glob(rb_files).each { |file| require file }
+    klass.define_singleton_method(:const_missing) do |class_name|
+      mutex.synchronize { Faker.resolve_const(name, class_name) }
+
+      const_get(class_name)
+    end
+  end
 end

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -299,8 +299,7 @@ module Faker
   # +Config.lazy_loading+ after any generator has been referenced has no effect.
   def self.const_missing(class_name)
     @loader.load_const(name, class_name)
-
-    const_get(class_name)
+    @loader.fetch_const(self, name, class_name)
   end
 
   def self.lazy_load(klass)

--- a/lib/faker/loader.rb
+++ b/lib/faker/loader.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Faker
+  class Loader
+    INFLECTIONS = { 'DnD' => 'dnd' }.freeze
+
+    def initialize(base_dir, config)
+      @base_dir = base_dir
+      @config = config
+      @eager_loaded = false
+      @mutex = Mutex.new
+    end
+
+    def load_const(context_name, class_name)
+      @mutex.synchronize do
+        if lazy_loading?
+          resolve_const(context_name, class_name)
+        else
+          eager_load!
+        end
+      end
+    end
+
+    def install_on(klass)
+      loader = self
+
+      klass.define_singleton_method(:const_missing) do |class_name|
+        loader.resolve_const(name, class_name)
+
+        const_get(class_name)
+      end
+    end
+
+    def resolve_const(context_name, class_name)
+      load_path = build_path(context_name, class_name)
+
+      require(load_path)
+    rescue LoadError
+      # try to load default generators
+      require(load_path.gsub('faker/', 'faker/default/'))
+    end
+
+    private
+
+    def eager_load!
+      return if @eager_loaded
+
+      @eager_loaded = true
+
+      Dir.glob(["#{@base_dir}/faker/*.rb", "#{@base_dir}/faker/**/*.rb"])
+         .each { |f| require f }
+    end
+
+    def build_path(*constants)
+      constants.map do |c|
+        INFLECTIONS
+          .reduce(c.to_s) { |s, (word, replacement)| s.gsub(word, replacement) }
+          .gsub('::', '/')
+          .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+          .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+          .tr('-', '_')
+          .downcase
+      end.join('/')
+    end
+
+    def lazy_loading?
+      @lazy_loading ||= @config.lazy_loading?
+    end
+  end
+end

--- a/lib/faker/loader.rb
+++ b/lib/faker/loader.rb
@@ -13,7 +13,7 @@ module Faker
 
     def load_const(context_name, class_name)
       @mutex.synchronize do
-        if lazy_loading?
+        if loading_strategy == :lazy
           resolve_const(context_name, class_name)
         else
           eager_load!
@@ -31,24 +31,36 @@ module Faker
       end
     end
 
-    def resolve_const(context_name, class_name)
-      load_path = build_path(context_name, class_name)
-
-      require(load_path)
-    rescue LoadError
-      # try to load default generators
-      require(load_path.gsub('faker/', 'faker/default/'))
+    def loading_strategy
+      @loading_strategy ||= if @config.lazy_loading?
+                              :lazy
+                            else
+                              :eager
+                            end
     end
 
     private
+
+    def resolve_const(context_name, class_name)
+      load_path = build_path(context_name, class_name)
+
+      require load_path
+    rescue LoadError
+      # try to load default generators
+      require load_path.gsub('faker/', 'faker/default/')
+    end
 
     def eager_load!
       return if @eager_loaded
 
       @eager_loaded = true
 
-      Dir.glob(["#{@base_dir}/faker/*.rb", "#{@base_dir}/faker/**/*.rb"])
-         .each { |f| require f }
+      paths = [
+        "#{@base_dir}/faker/*.rb",
+        "#{@base_dir}/faker/**/*.rb"
+      ]
+
+      Dir.glob(paths).uniq.each { |f| require f }
     end
 
     def build_path(*constants)
@@ -61,10 +73,6 @@ module Faker
           .tr('-', '_')
           .downcase
       end.join('/')
-    end
-
-    def lazy_loading?
-      @lazy_loading ||= @config.lazy_loading?
     end
   end
 end

--- a/lib/faker/loader.rb
+++ b/lib/faker/loader.rb
@@ -4,11 +4,12 @@ module Faker
   class Loader
     INFLECTIONS = { 'DnD' => 'dnd' }.freeze
 
-    def initialize(base_dir, config)
+    def initialize(base_dir, config, requirer: method(:require))
       @base_dir = base_dir
       @config = config
       @eager_loaded = false
       @mutex = Mutex.new
+      @requirer = requirer
     end
 
     def load_const(context_name, class_name)
@@ -39,16 +40,16 @@ module Faker
                             end
     end
 
-    private
-
     def resolve_const(context_name, class_name)
       load_path = build_path(context_name, class_name)
 
-      require load_path
+      @requirer.call(load_path)
     rescue LoadError
       # try to load default generators
-      require load_path.gsub('faker/', 'faker/default/')
+      @requirer.call load_path.gsub('faker/', 'faker/default/')
     end
+
+    private
 
     def eager_load!
       return if @eager_loaded
@@ -60,7 +61,7 @@ module Faker
         "#{@base_dir}/faker/**/*.rb"
       ]
 
-      Dir.glob(paths).uniq.each { |f| require f }
+      Dir.glob(paths).uniq.each { |f| @requirer.call(f) }
     end
 
     def build_path(*constants)

--- a/lib/faker/loader.rb
+++ b/lib/faker/loader.rb
@@ -63,12 +63,10 @@ module Faker
 
       @eager_loaded = true
 
-      paths = [
-        "#{@base_dir}/faker/*.rb",
-        "#{@base_dir}/faker/**/*.rb"
-      ]
+      parents = Dir.glob("#{@base_dir}/faker/*.rb")
+      nested = Dir.glob("#{@base_dir}/faker/**/*.rb") - parents
 
-      Dir.glob(paths).uniq.each { |f| @requirer.call(f) }
+      (parents + nested).each { |f| @requirer.call(f) }
     end
 
     def build_path(*constants)

--- a/lib/faker/loader.rb
+++ b/lib/faker/loader.rb
@@ -27,9 +27,16 @@ module Faker
 
       klass.define_singleton_method(:const_missing) do |class_name|
         loader.resolve_const(name, class_name)
-
-        const_get(class_name)
+        loader.fetch_const(self, name, class_name)
       end
+    end
+
+    def fetch_const(klass, context_name, class_name)
+      unless klass.const_defined?(class_name, false)
+        raise NameError, "uninitialized constant #{context_name}::#{class_name}"
+      end
+
+      klass.const_get(class_name)
     end
 
     def loading_strategy

--- a/test/faker/test_loader.rb
+++ b/test/faker/test_loader.rb
@@ -4,6 +4,7 @@ require_relative '../test_helper'
 
 class TestLoader < Test::Unit::TestCase
   FIXTURES_DIR = File.expand_path('../fixtures', __dir__)
+  LIB_DIR = File.expand_path('../../lib', __dir__)
 
   class FakeRequirer
     attr_reader :loaded_files
@@ -93,6 +94,19 @@ class TestLoader < Test::Unit::TestCase
     expected_files.each do |file|
       assert_includes actual_files, file, "expected #{file} to be loaded"
     end
+  end
+
+  def test_requires_namespace_parents_before_nested_generators
+    requirer = FakeRequirer.new
+    loader = Faker::Loader.new(LIB_DIR, FakeConfig.new(false), requirer: requirer)
+
+    loader.load_const('Faker', :Name)
+
+    parents, nested = requirer.loaded_files.partition do |file|
+      File.dirname(file).end_with?('/faker')
+    end
+
+    assert_equal requirer.loaded_files, parents + nested
   end
 
   def test_eager_loads_only_once

--- a/test/faker/test_loader.rb
+++ b/test/faker/test_loader.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class TestLoader < Test::Unit::TestCase
+  FIXTURES_DIR = File.expand_path('../fixtures', __dir__)
+
+  FakeConfig = Struct.new(:lazy_loading?)
+
+  def eager_loader = Faker::Loader.new(FIXTURES_DIR, FakeConfig.new(false))
+  def lazy_loader = Faker::Loader.new(FIXTURES_DIR, FakeConfig.new(true))
+
+  def with_require_spy(fail_if: nil)
+    original = Kernel.instance_method(:require)
+    loaded_files = []
+    mutex = Mutex.new
+
+    Kernel.define_method(:require) do |f|
+      if fail_if&.call(f)
+        raise LoadError
+      end
+
+      mutex.synchronize { loaded_files << f }
+    end
+
+    yield loaded_files
+  ensure
+    Kernel.define_method(:require, original)
+  end
+
+  def test_strategy_does_not_change_after_first_use
+    config = FakeConfig.new(false)
+    loader = Faker::Loader.new(FIXTURES_DIR, config)
+
+    with_require_spy do
+      loader.load_const('Faker', :Gadget)
+
+      config[:lazy_loading?] = true
+
+      assert_equal :eager, loader.loading_strategy
+    end
+  end
+
+  def test_falls_back_to_default_path_on_load_error
+    loader = lazy_loader
+
+    fail_when_requiring_non_default_path = ->(f) { f.end_with?('faker/gadget') }
+
+    with_require_spy(fail_if: fail_when_requiring_non_default_path) do |loaded_files|
+      loader.load_const('Faker', :Gadget)
+
+      assert loaded_files.any? { |f| f.include?('faker/default/gadget') }
+    end
+  end
+
+  def test_inflection_resolves_correctly
+    loader = lazy_loader
+
+    with_require_spy do |loaded_files|
+      loader.load_const('Faker::Games', :DnD)
+
+      assert_includes loaded_files.first, 'faker/games/dnd'
+      refute_includes loaded_files.first, 'dn_d'
+    end
+  end
+
+  def test_install_on_installs_const_missing
+    loader = lazy_loader
+    klass = Class.new
+
+    loader.install_on(klass)
+
+    assert_equal klass.singleton_class, klass.method(:const_missing).owner
+  end
+
+  def test_eager_loads_all_files_on_first_const_access
+    loader = eager_loader
+
+    with_require_spy do |loaded_files|
+      loader.load_const('Faker', :Gadget)
+
+      actual_files = loaded_files.map do |loaded|
+        loaded.match(/fixtures\/(?<path>.*)/)[:path]
+      end.uniq
+
+      expected_files = %w[
+        faker/gadget.rb
+        faker/default/widget.rb
+        faker/games/dnd.rb
+      ]
+
+      expected_files.each do |file|
+        assert_includes actual_files, file, "expected #{file} to be loaded"
+      end
+    end
+  end
+
+  def test_eager_loads_only_once
+    loader = eager_loader
+
+    with_require_spy do |loaded_files|
+      loader.load_const('Faker', :Gadget)
+
+      count = loaded_files.size
+
+      loader.load_const('Faker', :Gadget)
+
+      assert_equal count, loaded_files.size
+    end
+  end
+
+  def test_lazy_loads_single_file_on_const_access
+    loader = lazy_loader
+
+    with_require_spy do |loaded_files|
+      loader.load_const('Faker', :Gadget)
+
+      assert_equal 1, loaded_files.size
+      assert_includes loaded_files.first, 'faker/gadget'
+    end
+  end
+
+  def test_eager_loads_only_once_across_threads
+    loader = eager_loader
+
+    with_require_spy do |loaded_files|
+      threads = 10.times.map do
+        Thread.new { loader.load_const('Faker', :Gadget) }
+      end
+
+      threads.each(&:join)
+
+      actual_files = loaded_files.map do |loaded|
+        loaded.match(/fixtures\/(?<path>.*)/)[:path]
+      end.compact
+
+      assert_equal actual_files.uniq, actual_files
+    end
+  end
+
+  def test_raises_on_unknown_const
+    loader = lazy_loader
+
+    assert_raises(LoadError) { loader.load_const('Faker', :NonExistent) }
+  end
+end

--- a/test/faker/test_loader.rb
+++ b/test/faker/test_loader.rb
@@ -5,67 +5,68 @@ require_relative '../test_helper'
 class TestLoader < Test::Unit::TestCase
   FIXTURES_DIR = File.expand_path('../fixtures', __dir__)
 
-  FakeConfig = Struct.new(:lazy_loading?)
+  class FakeRequirer
+    attr_reader :loaded_files
 
-  def eager_loader = Faker::Loader.new(FIXTURES_DIR, FakeConfig.new(false))
-  def lazy_loader = Faker::Loader.new(FIXTURES_DIR, FakeConfig.new(true))
-
-  def with_require_spy(fail_if: nil)
-    original = Kernel.instance_method(:require)
-    loaded_files = []
-    mutex = Mutex.new
-
-    Kernel.define_method(:require) do |f|
-      if fail_if&.call(f)
-        raise LoadError
-      end
-
-      mutex.synchronize { loaded_files << f }
+    def initialize(failing_paths: [])
+      @failing_paths = failing_paths
+      @loaded_files = []
+      @mutex = Mutex.new
     end
 
-    yield loaded_files
-  ensure
-    Kernel.define_method(:require, original)
+    def call(path)
+      raise LoadError if @failing_paths.any? do |suffix|
+        path.end_with?(suffix)
+      end
+
+      @mutex.synchronize { @loaded_files << path }
+    end
+  end
+
+  FakeConfig = Struct.new(:lazy_loading?)
+
+  def eager_loader(requirer:)
+    Faker::Loader.new(FIXTURES_DIR, FakeConfig.new(false), requirer: requirer)
+  end
+
+  def lazy_loader(requirer:)
+    Faker::Loader.new(FIXTURES_DIR, FakeConfig.new(true), requirer: requirer)
   end
 
   def test_strategy_does_not_change_after_first_use
     config = FakeConfig.new(false)
-    loader = Faker::Loader.new(FIXTURES_DIR, config)
+    loader = Faker::Loader.new(FIXTURES_DIR, config, requirer: FakeRequirer.new)
 
-    with_require_spy do
-      loader.load_const('Faker', :Gadget)
+    loader.load_const('Faker', :Gadget)
+    config[:lazy_loading?] = true
 
-      config[:lazy_loading?] = true
-
-      assert_equal :eager, loader.loading_strategy
-    end
+    assert_equal :eager, loader.loading_strategy
   end
 
   def test_falls_back_to_default_path_on_load_error
-    loader = lazy_loader
+    non_default_path = ['faker/gadget']
+    requirer = FakeRequirer.new(failing_paths: non_default_path)
 
-    fail_when_requiring_non_default_path = ->(f) { f.end_with?('faker/gadget') }
+    loader = lazy_loader(requirer: requirer)
 
-    with_require_spy(fail_if: fail_when_requiring_non_default_path) do |loaded_files|
-      loader.load_const('Faker', :Gadget)
+    loader.load_const('Faker', :Gadget)
 
-      assert loaded_files.any? { |f| f.include?('faker/default/gadget') }
-    end
+    assert requirer.loaded_files.any? { |f| f.include?('faker/default/gadget') }
   end
 
   def test_inflection_resolves_correctly
-    loader = lazy_loader
+    requirer = FakeRequirer.new
+    loader = lazy_loader(requirer: requirer)
 
-    with_require_spy do |loaded_files|
-      loader.load_const('Faker::Games', :DnD)
+    loader.load_const('Faker::Games', :DnD)
 
-      assert_includes loaded_files.first, 'faker/games/dnd'
-      refute_includes loaded_files.first, 'dn_d'
-    end
+    assert_includes requirer.loaded_files.first, 'faker/games/dnd'
+    refute_includes requirer.loaded_files.first, 'dn_d'
   end
 
   def test_install_on_installs_const_missing
-    loader = lazy_loader
+    requirer = FakeRequirer.new
+    loader = lazy_loader(requirer: requirer)
     klass = Class.new
 
     loader.install_on(klass)
@@ -74,72 +75,71 @@ class TestLoader < Test::Unit::TestCase
   end
 
   def test_eager_loads_all_files_on_first_const_access
-    loader = eager_loader
+    requirer = FakeRequirer.new
+    loader = eager_loader(requirer: requirer)
 
-    with_require_spy do |loaded_files|
-      loader.load_const('Faker', :Gadget)
+    loader.load_const('Faker', :Gadget)
 
-      actual_files = loaded_files.map do |loaded|
-        loaded.match(/fixtures\/(?<path>.*)/)[:path]
-      end.uniq
+    actual_files = requirer.loaded_files.map do |loaded|
+      loaded.match(/fixtures\/(?<path>.*)/)[:path]
+    end.uniq
 
-      expected_files = %w[
-        faker/gadget.rb
-        faker/default/widget.rb
-        faker/games/dnd.rb
-      ]
+    expected_files = %w[
+      faker/gadget.rb
+      faker/default/widget.rb
+      faker/games/dnd.rb
+    ]
 
-      expected_files.each do |file|
-        assert_includes actual_files, file, "expected #{file} to be loaded"
-      end
+    expected_files.each do |file|
+      assert_includes actual_files, file, "expected #{file} to be loaded"
     end
   end
 
   def test_eager_loads_only_once
-    loader = eager_loader
+    requirer = FakeRequirer.new
+    loader = eager_loader(requirer: requirer)
 
-    with_require_spy do |loaded_files|
-      loader.load_const('Faker', :Gadget)
+    loader.load_const('Faker', :Gadget)
 
-      count = loaded_files.size
+    count = requirer.loaded_files.size
 
-      loader.load_const('Faker', :Gadget)
+    loader.load_const('Faker', :Gadget)
 
-      assert_equal count, loaded_files.size
-    end
+    assert_equal count, requirer.loaded_files.size
   end
 
   def test_lazy_loads_single_file_on_const_access
-    loader = lazy_loader
+    requirer = FakeRequirer.new
+    loader = lazy_loader(requirer: requirer)
 
-    with_require_spy do |loaded_files|
-      loader.load_const('Faker', :Gadget)
+    loader.load_const('Faker', :Gadget)
 
-      assert_equal 1, loaded_files.size
-      assert_includes loaded_files.first, 'faker/gadget'
-    end
+    assert_equal 1, requirer.loaded_files.size
+    assert_includes requirer.loaded_files.first, 'faker/gadget'
   end
 
   def test_eager_loads_only_once_across_threads
-    loader = eager_loader
+    requirer = FakeRequirer.new
+    loader = eager_loader(requirer: requirer)
 
-    with_require_spy do |loaded_files|
-      threads = 10.times.map do
-        Thread.new { loader.load_const('Faker', :Gadget) }
-      end
-
-      threads.each(&:join)
-
-      actual_files = loaded_files.map do |loaded|
-        loaded.match(/fixtures\/(?<path>.*)/)[:path]
-      end.compact
-
-      assert_equal actual_files.uniq, actual_files
+    threads = 10.times.map do
+      Thread.new { loader.load_const('Faker', :Gadget) }
     end
+
+    threads.each(&:join)
+
+    actual_files = requirer.loaded_files.map do |loaded|
+      loaded.match(/fixtures\/(?<path>.*)/)[:path]
+    end.compact
+
+    assert_equal actual_files.uniq, actual_files
   end
 
   def test_raises_on_unknown_const
-    loader = lazy_loader
+    non_existent_paths = ['faker/non_existent', 'faker/default/non_existent']
+    requirer = FakeRequirer.new(failing_paths: non_existent_paths)
+
+    loader = lazy_loader(requirer: requirer)
 
     assert_raises(LoadError) { loader.load_const('Faker', :NonExistent) }
   end

--- a/test/fixtures/faker/default/widget.rb
+++ b/test/fixtures/faker/default/widget.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Faker
+  class Default
+    # rubocop:disable Lint/EmptyClass
+    class Widget
+    end
+    # rubocop:enable Lint/EmptyClass
+  end
+end

--- a/test/fixtures/faker/gadget.rb
+++ b/test/fixtures/faker/gadget.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Faker
+  # rubocop:disable Lint/EmptyClass
+  class Gadget
+  end
+  # rubocop:enable Lint/EmptyClass
+end

--- a/test/fixtures/faker/games/dnd.rb
+++ b/test/fixtures/faker/games/dnd.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Faker
+  class Games
+    # rubocop:disable Lint/EmptyClass
+    class DnD
+    end
+    # rubocop:enable Lint/EmptyClass
+  end
+end

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -6,6 +6,9 @@ require_relative 'test_helper'
 # rubocop:disable Security/Eval,Style/EvalWithLocation
 class TestDeterminism < Test::Unit::TestCase
   def setup
+    # TODO: can we expose loader?
+    Faker.instance_variable_get(:@loader).send(:eager_load!)
+
     @all_methods = all_methods.freeze
     @first_run = []
   end
@@ -94,6 +97,7 @@ class TestDeterminism < Test::Unit::TestCase
       Time
       TvShows
       Music
+      Loader
       VERSION
     ]
   end


### PR DESCRIPTION
(fixes #3248 )

This fix initializes lazy loading or eager loading after the first constant access, which can be a bit surprising.

But this guarantees that the `Faker::Config.lazy_loading` setting is respected.

We introduce a new `Faker::Loader` class responsible for taking care of the loading process.

The loader has a method `Loader#install_on` that adds lazy loading to a generator. It defines `const_missing` on namespace classes (Faker::Games, Faker::Music etc.), delegating back to the Loader, which resolves the constant either by requiring the single corresponding file (lazy) or by loading all generator files at once (eager).

The loading strategy (lazy vs eager) is snapshotted on the first `const_missing` call. Changing config after first use has no effect.

The loader also has a list of inflections to handle cases such as `DnD -> dnd.rb`.

`Config.lazy_loading` is now process-wide rather than thread-local, so it cannot be confired per-thread anymore (which didn't seem very useful to begin with, so we're simplifying this).

--

The main source of the problem is due to Faker having configuration set directly, which makes it hard to defer evaluation of the configuration before requiring the Faker library.

Other possible alternative could be:
- forcing eager loading when the `lazy_loading` config is first set to true
- exposing a [configuration block](https://hanakai.org/learn/dry/dry-configurable/v1.4#configure-block-syntax) that only loads files after the block is executed.


