### PR TITLE
feat(dependabot): add 7-day dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,13 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: weekly
-  
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
(Fixes #3262)


Adds a 7-day cooldown for dependency updates on dependabot:
- https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates

This could help us mitigate some supply chain attacks.

