### PR TITLE
Fix non-localized company suffixes in CH and it locales

### DIFF
--- a/lib/locales/de-CH.yml
+++ b/lib/locales/de-CH.yml
@@ -3251,8 +3251,6 @@ de-CH:
         - und Partner
         - "& Co."
         - Gruppe
-        - LLC
-        - Inc.
       legal_form:
         - GmbH
         - AG

--- a/lib/locales/fr-CH.yml
+++ b/lib/locales/fr-CH.yml
@@ -141,13 +141,13 @@ fr-CH:
         - CH
     company:
       suffix:
+        - SA
+        - Sàrl
         - AG
         - GmbH
         - et associés
         - "& Co."
         - Groupe
-        - LLC
-        - Inc.
       name:
         - "#{Name.last_name} #{suffix}"
         - "#{Name.last_name}-#{Name.last_name}"

--- a/lib/locales/it.yml
+++ b/lib/locales/it.yml
@@ -520,7 +520,7 @@ it:
       suffix:
         - SPA
         - e figli
-        - Group
+        - Gruppo
         - s.r.l.
       buzzwords:
         -

--- a/test/test_de_ch_locale.rb
+++ b/test/test_de_ch_locale.rb
@@ -23,6 +23,13 @@ class TestDeChLocale < Test::Unit::TestCase
     assert_kind_of String, Faker::Company.name
   end
 
+  def test_de_ch_company_suffix_has_no_english_forms
+    suffixes = I18n.translate('faker.company.suffix', locale: :'de-CH')
+
+    assert_not_includes suffixes, 'LLC'
+    assert_not_includes suffixes, 'Inc.'
+  end
+
   def test_de_ch_internet_methods
     assert_kind_of String, Faker::Internet.domain_suffix
   end

--- a/test/test_fr_ch_locale.rb
+++ b/test/test_fr_ch_locale.rb
@@ -44,6 +44,15 @@ class TestFrChLocale < Test::Unit::TestCase
     assert_kind_of String, Faker::Company.name
   end
 
+  def test_fr_ch_company_suffix_uses_swiss_forms
+    suffixes = I18n.translate('faker.company.suffix', locale: :'fr-CH')
+
+    assert_includes suffixes, 'SA'
+    assert_includes suffixes, 'Sàrl'
+    assert_not_includes suffixes, 'LLC'
+    assert_not_includes suffixes, 'Inc.'
+  end
+
   def test_fr_ch_internet_methods
     assert_kind_of String, Faker::Internet.email
     assert_kind_of String, Faker::Internet.domain_suffix

--- a/test/test_it_locale.rb
+++ b/test/test_it_locale.rb
@@ -34,6 +34,13 @@ class TestItLocale < Test::Unit::TestCase
     assert_kind_of String, Faker::Company.name
   end
 
+  def test_it_company_suffix_has_no_english_forms
+    suffixes = I18n.translate('faker.company.suffix', locale: :it)
+
+    assert_includes suffixes, 'Gruppo'
+    assert_not_includes suffixes, 'Group'
+  end
+
   def test_it_internet_methods
     assert_kind_of String, Faker::Internet.email
     assert_kind_of String, Faker::Internet.domain_suffix


### PR DESCRIPTION
### Motivation / Background

`Faker::Company.name` produced anglophone legal forms that do not exist in
these locales:

```ruby
Faker::Config.locale = 'de-CH'
Faker::Company.name  #=> "Klimczak LLC"

Faker::Config.locale = 'fr-CH'
Faker::Company.name  #=> "Adam LLC"

Faker::Config.locale = 'it'
Faker::Company.name  #=> "Russo-Russo Group"
```

`LLC` and `Inc.` are US forms and are not used in Switzerland; `Group` is
English. This Pull Request fixes the company `suffix` lists:

- **de-CH**: drop the English `LLC` and `Inc.` suffixes.
- **fr-CH**: drop `LLC`/`Inc.` and add the Swiss-French forms `SA` and `Sàrl`.
- **it**: replace English `Group` with the Italian `Gruppo`.

### Additional information

Output after the change:

```ruby
Faker::Config.locale = 'de-CH'
Faker::Company.name  #=> "Slotta AG"

Faker::Config.locale = 'fr-CH'
Faker::Company.name  #=> "Dumas, Bénoit et Duval"   # also: "Morin SA", "Brun Sàrl"

Faker::Config.locale = 'it'
Faker::Company.name  #=> "Monti, Cattaneo e Costantin Gruppo"
```

Tests assert the English forms are gone (and the localized forms present)
so the lists don't regress.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
