### PR TITLE
Localize Faker::Job for de, de-CH, fr, fr-CH and it

### DIFF
--- a/lib/locales/de-CH.yml
+++ b/lib/locales/de-CH.yml
@@ -383,6 +383,93 @@ de-CH:
         - Lugano
       city:
         - "#{city_name}"
+    job:
+      field:
+        - Marketing
+        - IT
+        - Buchhaltung
+        - Verwaltung
+        - Werbung
+        - Bankwesen
+        - Soziales
+        - Bauwesen
+        - Beratung
+        - Design
+        - Bildung
+        - Landwirtschaft
+        - Behörde
+        - Gesundheitswesen
+        - Gastgewerbe
+        - Recht
+        - Produktion
+        - Bergbau
+        - Immobilien
+        - Einzelhandel
+        - Vertrieb
+        - Technologie
+      seniority:
+        - Senior
+        - Junior
+        - Leitender
+        - Stellvertretender
+        - Regionaler
+        - Nationaler
+        - Globaler
+        - Internationaler
+        - Strategischer
+        - Technischer
+        - Kaufmännischer
+        - Erfahrener
+        - Operativer
+        - Digitaler
+        - Zentraler
+        - Externer
+        - Interner
+        - Verantwortlicher
+        - Führender
+        - Erster
+      position:
+        - Leiter
+        - Mitarbeiter
+        - Manager
+        - Referent
+        - Sachbearbeiter
+        - Ingenieur
+        - Spezialist
+        - Direktor
+        - Koordinator
+        - Administrator
+        - Architekt
+        - Analyst
+        - Designer
+        - Planer
+        - Techniker
+        - Entwickler
+        - Produzent
+        - Berater
+        - Assistent
+        - Agent
+        - Vertreter
+        - Stratege
+      key_skills:
+        - Teamfähigkeit
+        - Kommunikation
+        - Problemlösung
+        - Führung
+        - Organisation
+        - Belastbarkeit
+        - Selbstvertrauen
+        - Eigenmotivation
+        - Netzwerkfähigkeit
+        - Proaktivität
+        - Schnelle Auffassungsgabe
+        - Technisches Verständnis
+      title:
+        - "#{seniority} #{field} #{position}"
+        - "#{seniority} #{field} #{position}"
+        - "#{field} #{position}"
+        - "#{field} #{position}"
+        - "#{seniority} #{position}"
     name:
       male_first_name:
         - Aaron

--- a/lib/locales/de.yml
+++ b/lib/locales/de.yml
@@ -1861,6 +1861,93 @@ de:
         - vintage
         - viral
         - vlog
+    job:
+      field:
+        - Marketing
+        - IT
+        - Buchhaltung
+        - Verwaltung
+        - Werbung
+        - Bankwesen
+        - Soziales
+        - Bauwesen
+        - Beratung
+        - Design
+        - Bildung
+        - Landwirtschaft
+        - Behörde
+        - Gesundheitswesen
+        - Gastgewerbe
+        - Recht
+        - Produktion
+        - Bergbau
+        - Immobilien
+        - Einzelhandel
+        - Vertrieb
+        - Technologie
+      seniority:
+        - Senior
+        - Junior
+        - Leitender
+        - Stellvertretender
+        - Regionaler
+        - Nationaler
+        - Globaler
+        - Internationaler
+        - Strategischer
+        - Technischer
+        - Kaufmännischer
+        - Erfahrener
+        - Operativer
+        - Digitaler
+        - Zentraler
+        - Externer
+        - Interner
+        - Verantwortlicher
+        - Führender
+        - Erster
+      position:
+        - Leiter
+        - Mitarbeiter
+        - Manager
+        - Referent
+        - Sachbearbeiter
+        - Ingenieur
+        - Spezialist
+        - Direktor
+        - Koordinator
+        - Administrator
+        - Architekt
+        - Analyst
+        - Designer
+        - Planer
+        - Techniker
+        - Entwickler
+        - Produzent
+        - Berater
+        - Assistent
+        - Agent
+        - Vertreter
+        - Stratege
+      key_skills:
+        - Teamfähigkeit
+        - Kommunikation
+        - Problemlösung
+        - Führung
+        - Organisation
+        - Belastbarkeit
+        - Selbstvertrauen
+        - Eigenmotivation
+        - Netzwerkfähigkeit
+        - Proaktivität
+        - Schnelle Auffassungsgabe
+        - Technisches Verständnis
+      title:
+        - "#{seniority} #{field} #{position}"
+        - "#{seniority} #{field} #{position}"
+        - "#{field} #{position}"
+        - "#{field} #{position}"
+        - "#{seniority} #{position}"
     name:
       male_first_name:
         - Aaron

--- a/lib/locales/fr-CH.yml
+++ b/lib/locales/fr-CH.yml
@@ -1736,6 +1736,93 @@ fr-CH:
         - vulticulus
         - vultuosus
         - xiphias
+    job:
+      field:
+        - Marketing
+        - Informatique
+        - Comptabilité
+        - Administration
+        - Publicité
+        - Banque
+        - Services sociaux
+        - Construction
+        - Conseil
+        - Design
+        - Éducation
+        - Agriculture
+        - Gouvernement
+        - Santé
+        - Hôtellerie
+        - Juridique
+        - Industrie
+        - Mines
+        - Immobilier
+        - Commerce de détail
+        - Ventes
+        - Technologie
+      seniority:
+        - Senior
+        - Junior
+        - Principal
+        - Régional
+        - National
+        - Mondial
+        - International
+        - Stratégique
+        - Technique
+        - Commercial
+        - Adjoint
+        - Délégué
+        - Exécutif
+        - Opérationnel
+        - Numérique
+        - Central
+        - Externe
+        - Interne
+        - Associé
+        - Référent
+      position:
+        - Superviseur
+        - Associé
+        - Cadre
+        - Responsable
+        - Gestionnaire
+        - Ingénieur
+        - Spécialiste
+        - Directeur
+        - Coordinateur
+        - Administrateur
+        - Architecte
+        - Analyste
+        - Concepteur
+        - Planificateur
+        - Technicien
+        - Développeur
+        - Producteur
+        - Consultant
+        - Assistant
+        - Agent
+        - Représentant
+        - Stratège
+      key_skills:
+        - Travail d'équipe
+        - Communication
+        - Résolution de problèmes
+        - Leadership
+        - Organisation
+        - Gestion du stress
+        - Confiance
+        - Autonomie
+        - Réseautage
+        - Proactivité
+        - Apprentissage rapide
+        - Aisance technique
+      title:
+        - "#{position} #{field} #{seniority}"
+        - "#{position} #{field}"
+        - "#{position} #{field}"
+        - "#{position} #{seniority}"
+        - "#{position} #{field}"
     name:
       first_name:
         - Enzo

--- a/lib/locales/fr/job.yml
+++ b/lib/locales/fr/job.yml
@@ -1,0 +1,89 @@
+fr:
+  faker:
+    job:
+      field:
+        - Marketing
+        - Informatique
+        - Comptabilité
+        - Administration
+        - Publicité
+        - Banque
+        - Services sociaux
+        - Construction
+        - Conseil
+        - Design
+        - Éducation
+        - Agriculture
+        - Gouvernement
+        - Santé
+        - Hôtellerie
+        - Juridique
+        - Industrie
+        - Mines
+        - Immobilier
+        - Commerce de détail
+        - Ventes
+        - Technologie
+      seniority:
+        - Senior
+        - Junior
+        - Principal
+        - Régional
+        - National
+        - Mondial
+        - International
+        - Stratégique
+        - Technique
+        - Commercial
+        - Adjoint
+        - Délégué
+        - Exécutif
+        - Opérationnel
+        - Numérique
+        - Central
+        - Externe
+        - Interne
+        - Associé
+        - Référent
+      position:
+        - Superviseur
+        - Associé
+        - Cadre
+        - Responsable
+        - Gestionnaire
+        - Ingénieur
+        - Spécialiste
+        - Directeur
+        - Coordinateur
+        - Administrateur
+        - Architecte
+        - Analyste
+        - Concepteur
+        - Planificateur
+        - Technicien
+        - Développeur
+        - Producteur
+        - Consultant
+        - Assistant
+        - Agent
+        - Représentant
+        - Stratège
+      key_skills:
+        - Travail d'équipe
+        - Communication
+        - Résolution de problèmes
+        - Leadership
+        - Organisation
+        - Gestion du stress
+        - Confiance
+        - Autonomie
+        - Réseautage
+        - Proactivité
+        - Apprentissage rapide
+        - Aisance technique
+      title:
+        - "#{position} #{field} #{seniority}"
+        - "#{position} #{field}"
+        - "#{position} #{field}"
+        - "#{position} #{seniority}"
+        - "#{position} #{field}"

--- a/lib/locales/it.yml
+++ b/lib/locales/it.yml
@@ -860,6 +860,94 @@ it:
         - it
         - it
         - it
+    job:
+      field:
+        - Marketing
+        - Informatica
+        - Contabilità
+        - Amministrazione
+        - Pubblicità
+        - Banca
+        - Servizi sociali
+        - Edilizia
+        - Consulenza
+        - Design
+        - Istruzione
+        - Agricoltura
+        - Pubblica amministrazione
+        - Sanità
+        - Ospitalità
+        - Legale
+        - Produzione
+        - Estrazione mineraria
+        - Immobiliare
+        - Vendita al dettaglio
+        - Vendite
+        - Tecnologia
+      seniority:
+        - Senior
+        - Junior
+        - Principale
+        - Regionale
+        - Nazionale
+        - Globale
+        - Internazionale
+        - Strategico
+        - Tecnico
+        - Commerciale
+        - Esecutivo
+        - Operativo
+        - Digitale
+        - Centrale
+        - Esterno
+        - Interno
+        - Associato
+        - Anziano
+        - Esperto
+        - Delegato
+      position:
+        - Supervisore
+        - Associato
+        - Dirigente
+        - Referente
+        - Responsabile
+        - Manager
+        - Ingegnere
+        - Specialista
+        - Direttore
+        - Coordinatore
+        - Amministratore
+        - Architetto
+        - Analista
+        - Designer
+        - Pianificatore
+        - Tecnico
+        - Sviluppatore
+        - Produttore
+        - Consulente
+        - Assistente
+        - Agente
+        - Rappresentante
+        - Stratega
+      key_skills:
+        - Lavoro di squadra
+        - Comunicazione
+        - Risoluzione dei problemi
+        - Leadership
+        - Organizzazione
+        - Gestione dello stress
+        - Fiducia
+        - Automotivazione
+        - Capacità di networking
+        - Proattività
+        - Apprendimento rapido
+        - Competenza tecnica
+      title:
+        - "#{position} #{field} #{seniority}"
+        - "#{position} #{field}"
+        - "#{position} #{field}"
+        - "#{position} #{seniority}"
+        - "#{position} #{field}"
     name:
       first_name:
         - Alberto

--- a/test/test_de_ch_locale.rb
+++ b/test/test_de_ch_locale.rb
@@ -30,4 +30,16 @@ class TestDeChLocale < Test::Unit::TestCase
   def test_de_ch_mountain_methods
     assert_kind_of String, Faker::Mountain.name
   end
+
+  def test_de_ch_job_methods
+    assert_kind_of String, Faker::Job.title
+    assert_kind_of String, Faker::Job.field
+    assert_kind_of String, Faker::Job.position
+    assert_kind_of String, Faker::Job.key_skill
+
+    # Guard against Faker::Job silently falling back to the English data.
+    fields = I18n.translate('faker.job.field', locale: :'de-CH')
+
+    assert_includes fields, Faker::Job.field
+  end
 end

--- a/test/test_de_locale.rb
+++ b/test/test_de_locale.rb
@@ -133,4 +133,16 @@ class TestDeLocale < Test::Unit::TestCase
 
     assert_match(/^(0|49)/, mobile)
   end
+
+  def test_de_job_methods
+    assert_kind_of String, Faker::Job.title
+    assert_kind_of String, Faker::Job.field
+    assert_kind_of String, Faker::Job.position
+    assert_kind_of String, Faker::Job.key_skill
+
+    # Guard against Faker::Job silently falling back to the English data.
+    fields = I18n.translate('faker.job.field', locale: :de)
+
+    assert_includes fields, Faker::Job.field
+  end
 end

--- a/test/test_fr_ch_locale.rb
+++ b/test/test_fr_ch_locale.rb
@@ -74,4 +74,16 @@ class TestFrChLocale < Test::Unit::TestCase
     assert_kind_of String, Faker::Games::Pokemon.location
     assert_kind_of String, Faker::Games::Pokemon.move
   end
+
+  def test_fr_ch_job_methods
+    assert_kind_of String, Faker::Job.title
+    assert_kind_of String, Faker::Job.field
+    assert_kind_of String, Faker::Job.position
+    assert_kind_of String, Faker::Job.key_skill
+
+    # Guard against Faker::Job silently falling back to the English data.
+    fields = I18n.translate('faker.job.field', locale: :'fr-CH')
+
+    assert_includes fields, Faker::Job.field
+  end
 end

--- a/test/test_fr_locale.rb
+++ b/test/test_fr_locale.rb
@@ -149,4 +149,16 @@ class TestFrLocale < Test::Unit::TestCase
     assert_kind_of String, Faker::Games::Pokemon.location
     assert_kind_of String, Faker::Games::Pokemon.move
   end
+
+  def test_fr_job_methods
+    assert_kind_of String, Faker::Job.title
+    assert_kind_of String, Faker::Job.field
+    assert_kind_of String, Faker::Job.position
+    assert_kind_of String, Faker::Job.key_skill
+
+    # Guard against Faker::Job silently falling back to the English data.
+    fields = I18n.translate('faker.job.field', locale: :fr)
+
+    assert_includes fields, Faker::Job.field
+  end
 end

--- a/test/test_it_locale.rb
+++ b/test/test_it_locale.rb
@@ -59,4 +59,16 @@ class TestItLocale < Test::Unit::TestCase
     assert_kind_of String, Faker::Subscription.subscription_term
     assert_kind_of String, Faker::Subscription.payment_term
   end
+
+  def test_it_job_methods
+    assert_kind_of String, Faker::Job.title
+    assert_kind_of String, Faker::Job.field
+    assert_kind_of String, Faker::Job.position
+    assert_kind_of String, Faker::Job.key_skill
+
+    # Guard against Faker::Job silently falling back to the English data.
+    fields = I18n.translate('faker.job.field', locale: :it)
+
+    assert_includes fields, Faker::Job.field
+  end
 end


### PR DESCRIPTION
### Motivation / Background

`Faker::Job` only had data for `en` (and `hy`, `pt-BR`), so every other
locale silently returned English job titles:

```ruby
Faker::Config.locale = 'it'
Faker::Job.title  #=> "Lead Banking Developer"

Faker::Config.locale = 'de'
Faker::Job.title  #=> "Design Administrator"
```

This Pull Request adds localized `job` data for the German, French and
Italian locales. Each provides the keys `Faker::Job` consumes — `field`,
`seniority`, `position`, `key_skills` — plus a `title` template reordered
to fit the language (adjective-after-noun for fr/it). As with the English
generator, titles are synthetic combinations.

### Additional information

Output after the change:

```ruby
Faker::Config.locale = 'de'
Faker::Job.title  #=> "Senior Produktion Planer"

Faker::Config.locale = 'fr'
Faker::Job.title  #=> "Directeur Régional"

Faker::Config.locale = 'fr-CH'
Faker::Job.title  #=> "Responsable Technologie"

Faker::Config.locale = 'it'
Faker::Job.title  #=> "Dirigente Contabilità"
```

Notes:
- `fr` follows the `lib/locales/fr/` subfolder convention (new
  `fr/job.yml`); the other locales get a top-level `job:` block.
- `de-CH` / `fr-CH` carry their own copies because they do not fall back to
  `de` / `fr`.
- Only the keys consumed by `Faker::Job` are included (`employment_type` /
  `education_level` are not read by any `Faker::Job` method).

Tests assert `Faker::Job.field` is a member of the locale's own field list,
guarding against a regression back to the English fallback.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
