### PR TITLE
Deprecate Faker::Placeholdit in favor of Faker::LoremFlickr.image

### DIFF
--- a/doc/default/placeholdit.md
+++ b/doc/default/placeholdit.md
@@ -1,5 +1,8 @@
 # Faker::Placeholdit
 
+> [!WARNING]
+> `Faker::Placeholdit` is deprecated and will be removed in a future version. The via.placeholder.com service is no longer available. Use [`Faker::LoremFlickr`](lorem_flickr.md) instead.
+
 ```ruby
 # Keyword arguments: size, format, background_color, text_color, text
 Faker::Placeholdit.image #=> "https://via.placeholder.com/300x300.png"

--- a/lib/faker/default/placeholdit.rb
+++ b/lib/faker/default/placeholdit.rb
@@ -3,6 +3,8 @@
 module Faker
   class Placeholdit < Base
     class << self
+      extend Gem::Deprecate
+
       SUPPORTED_FORMATS = %w[png jpg gif jpeg].freeze
 
       ##
@@ -41,6 +43,7 @@ module Faker
         image_url += "?text=#{text}" if text
         image_url
       end
+      deprecate :image, 'Faker::LoremFlickr.image', 2026, 12
 
       private
 

--- a/test/faker/default/test_placeholdit.rb
+++ b/test/faker/default/test_placeholdit.rb
@@ -5,6 +5,24 @@ require_relative '../../test_helper'
 class TestPlaceholdit < Test::Unit::TestCase
   def setup
     @tester = Faker::Placeholdit
+    @original_skip = Gem::Deprecate.skip
+    Gem::Deprecate.skip = true
+  end
+
+  def teardown
+    Gem::Deprecate.skip = @original_skip
+  end
+
+  def test_image_is_deprecated
+    Gem::Deprecate.skip = false
+    original_stderr = $stderr
+    $stderr = StringIO.new
+
+    @tester.image
+
+    assert_match(/Placeholdit\.image is deprecated; use Faker::LoremFlickr\.image instead/, $stderr.string)
+  ensure
+    $stderr = original_stderr
   end
 
   def test_placeholdit


### PR DESCRIPTION
### Motivation / Background

Fixes #3055

The `via.placeholder.com` service no longer resolves (`ERR_NAME_NOT_RESOLVED`), so every URL generated by `Faker::Placeholdit` is broken. In the issue discussion, @stefannibrasil asked for this generator to be deprecated — consistent with the project's decision to move away from generators that rely on external services (#2852) — rather than repointing it at another third-party host.

This PR deprecates `Faker::Placeholdit#image` using `Gem::Deprecate`, following the process documented in [CONTRIBUTING.md](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md#removing-generators) and the precedent from #2733 (`free_email`/`safe_email`). The generator keeps working and returns the same values, so this is fully backward compatible — it just warns and recommends `Faker::LoremFlickr.image`, the maintained replacement.

### Additional information

Console output after the change:

```console
$ bundle exec rake console
irb(main):001> Faker::Placeholdit.image(size: '50x50', format: 'jpg')
NOTE: Faker::Placeholdit.image is deprecated; use Faker::LoremFlickr.image instead. It will be removed on or after 2026-12.
Faker::Placeholdit.image called from (irb):1.
=> "https://via.placeholder.com/50x50.jpg"
```

Changes:
- `lib/faker/default/placeholdit.rb`: `extend Gem::Deprecate` + `deprecate :image, 'Faker::LoremFlickr.image', 2026, 12` (date mirrors the ~6-month horizon used in #2733; happy to adjust it to match your release plans)
- `test/faker/default/test_placeholdit.rb`: regression test asserting the deprecation warning is emitted (verified it fails without the `deprecate` call); existing tests silence the warning via `Gem::Deprecate.skip` in `setup`/`teardown` to keep test output clean
- `doc/default/placeholdit.md`: deprecation notice pointing to `Faker::LoremFlickr`

Test results: `bundle exec rake` → 2180 tests, 297308 assertions, 0 failures, 0 errors; RuboCop: 576 files inspected, no offenses detected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
