### PR TITLE
Fix: load :en fallback translations if the I18n backend discarded them [Fix #2987]

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -186,6 +186,15 @@ module Faker
         # in en either, then it will raise again.
         disable_enforce_available_locales do
           I18n.translate(*args, **opts)
+        rescue I18n::MissingTranslationData
+          # I18n discards translations for locales that are not in
+          # I18n.available_locales when it initializes. If the :en
+          # translations were discarded, load them and try once more.
+          raise if I18n.exists?('faker', :en)
+
+          en_files = Dir[::File.join(__dir__, 'locales', 'en.yml'), ::File.join(__dir__, 'locales', 'en', '**/*.yml')]
+          I18n.backend.load_translations(en_files)
+          I18n.translate(*args, **opts)
         end
       end
 

--- a/test/test_locale.rb
+++ b/test/test_locale.rb
@@ -51,6 +51,19 @@ class TestLocale < Test::Unit::TestCase
     I18n.available_locales += [:en]
   end
 
+  # https://github.com/faker-ruby/faker/issues/2987
+  def test_translation_fallback_when_i18n_initialized_without_en_in_available_locales
+    old_available_locales = I18n.available_locales
+    I18n.available_locales = [:de]
+    I18n.reload! # force I18n to discard the :en translations
+    Faker::Config.locale = :de
+
+    assert_kind_of String, Faker::Company.catch_phrase
+  ensure
+    I18n.available_locales = old_available_locales
+    I18n.reload!
+  end
+
   def test_with_locale_does_not_fail_without_the_locale_in_available_locales
     I18n.available_locales -= [:en]
 


### PR DESCRIPTION
### Motivation / Background

Fixes #2987

When an application restricts `I18n.available_locales` to a list that does not include `:en` (e.g. `I18n.available_locales = [:de]`), calling a generator whose key is missing in the current locale raises:

```
I18n::MissingTranslationData: Translation missing: en.faker.company.buzzwords
```

**Root cause:** the i18n backend (`I18n::Backend::Simple#store_translations`) silently discards translations for locales that are not in `I18n.available_locales` when it initializes. So faker's `:en` data is never stored, and the `:en` fallback in `Faker::Base.translate` fails: wrapping the lookup in `disable_enforce_available_locales` cannot help, because it only affects the lookup — the data was already dropped at load time. This is the line @thdaraujo suspected wasn't working as expected in the issue discussion.

**Solution:** when the `:en` fallback lookup fails *and* the backend has no faker `:en` data (`I18n.exists?('faker', :en)` is false), load faker's `:en` locale files via `I18n.backend.load_translations` and retry. Properties of this approach:

- Loads **only** the `:en` files — it does not pull in all ~60 locales the way the `I18n.reload!` workarounds from the issue thread do.
- Purely additive — it does not clear or reload the host application's translations (unlike `I18n.reload!`, which would drop translations an app stored at runtime), and it does not touch `I18n.available_locales` or `enforce_available_locales`.
- Runs at most once — after loading, `I18n.exists?('faker', :en)` is true, so subsequent calls never hit this path again.
- No behavior change otherwise — in a normal setup the guard short-circuits immediately, and keys genuinely missing from `:en` still raise `I18n::MissingTranslationData` as before (existing tests cover this).

Both `I18n.exists?` and `load_translations` are part of the `I18n::Backend::Base` API and are available in i18n >= 1.8.11 (the gemspec minimum), including the `Chain` backend.

### Additional information

Console output running the reproduction script from the issue against this branch:

**Before:**
```
I18n.available_locales = [:de]
Faker::Company.catch_phrase
# => I18n::MissingTranslationData: Translation missing: en.faker.company.buzzwords
```

**After:**
```
I18n.available_locales = [:de]
Faker::Company.catch_phrase
# => "Public-key human-resource access"
I18n.enforce_available_locales  # => true (restored)
I18n.available_locales          # => [:de] (untouched)
I18n.backend.send(:translations).keys  # => [:de, :en] (only :en added, not all locales)
Faker::Base.translate("faker.nonexistent_key")  # => still raises I18n::MissingTranslationData
```

The regression test reproduces the issue scenario (it fails with `I18n::MissingTranslationData: Translation missing: en.faker.company.buzzwords` without the fix). Note the pre-existing `test_translation_fallback_without_en_in_available_locales` did not catch this because it removes `:en` *after* the backend has already initialized and stored the `:en` data; the bug only manifests when the backend initializes while `:en` is excluded, hence the `I18n.reload!` in the new test.

Full suite + RuboCop pass locally: `bundle exec rake` → 2180 tests, 0 failures, 0 errors; 576 files inspected, no offenses.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.
