### PR TITLE
Fix polynomial ReDoS in `regexify` alternation matching

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -110,7 +110,7 @@ module Faker
           .gsub(/(\[[^\]]++\])\{(\d+),(\d+)\}/) { |_match| Regexp.last_match(1) * sample(Array(Range.new(Regexp.last_match(2).to_i, Regexp.last_match(3).to_i))) }                # [12]{1,2} becomes [12] or [12][12]
           .gsub(/(\([^)]++\))\{(\d+),(\d+)\}/) { |_match| Regexp.last_match(1) * sample(Array(Range.new(Regexp.last_match(2).to_i, Regexp.last_match(3).to_i))) }                 # (12|34){1,2} becomes (12|34) or (12|34)(12|34)
           .gsub(/(\\?.)\{(\d+),(\d+)\}/) { |_match| Regexp.last_match(1) * sample(Array(Range.new(Regexp.last_match(2).to_i, Regexp.last_match(3).to_i))) }                       # A{1,2} becomes A or AA or \d{3} becomes \d\d\d
-          .gsub(/\((.*?)\)/) { |match| sample(match.gsub(/[()]/, '').split('|')) }                                                                                                # (this|that) becomes 'this' or 'that'
+          .gsub(/\(([^()]*)\)/) { |match| sample(match.gsub(/[()]/, '').split('|')) }                                                                                             # (this|that) becomes 'this' or 'that'
           .gsub(/\[([^\]]++)\]/) { |match| match.gsub(/(\w-\w)/) { |range| sample(Array(Range.new(*range.split('-')))) } }                                                        # All A-Z inside of [] become C (or X, or whatever)
           .gsub(/\[([^\]]++)\]/) { |_match| sample(Regexp.last_match(1).chars) }                                                                                                  # All [ABC] become B (or A or C)
           .gsub('\d') { |_match| sample(Numbers) }

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -27,7 +27,8 @@ class TestFaker < Test::Unit::TestCase
   def test_regexify
     {
       'uk post code' => /^([A-PR-UWYZ0-9][A-HK-Y0-9][AEHMNPRTVXY0-9]?[ABEHMNPRVWXY0-9]? {1,2}[0-9][ABD-HJLN-UW-Z]{2}|GIR 0AA)$/,
-      'us phone' => /^(1-?)[2-8][0-1][0-9]-\d{3}-\d{4}$/
+      'us phone' => /^(1-?)[2-8][0-1][0-9]-\d{3}-\d{4}$/,
+      'alternation group' => /^(foo|bar|baz)$/
     }.each do |label, re|
       deterministically_verify -> { Faker::Base.regexify(re) } do |result|
         assert_match re, result, "#{result} is not a match for #{label}"


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes the remaining **"Polynomial regular expression used on uncontrolled data"** code-scanning alert. Fixes #3183.

In `Faker::Base#regexify` (`lib/faker.rb`), the pattern that expands alternation groups such as `(this|that)` was:

```ruby
.gsub(/\((.*?)\)/) { |match| sample(match.gsub(/[()]/, '').split('|')) }
```

`\(.*?\)` runs in polynomial time on uncontrolled (locale) input: because the `.*?` content can itself match `(`, an input like `(a(a(a…` forces super-linear backtracking. #3196 hardened every sibling regex in this method (possessive quantifiers) but this one was left unchanged, so the alert remained.

### Solution

Restrict the captured group content to non-parenthesis characters:

```ruby
.gsub(/\(([^()]*)\)/) { |match| sample(match.gsub(/[()]/, '').split('|')) }
```

`[^()]*` cannot backtrack across a `(` or `)` delimiter, so matching is linear. This is the standard remedy for this CodeQL pattern and mirrors the backtracking-elimination approach already taken in #3196 for the neighbouring regexes. It is also consistent with `regexify`'s own documented contract — its header comment states it *"does not handle … nested parentheses"* — so behaviour is unchanged for every supported pattern.

I confirmed the fix with the same CodeQL query GitHub runs (`rb/polynomial-redos`, bundle 2.25.6): the alert on this regex is present before the change and gone after it, while the unrelated alerts elsewhere are unaffected.

Behaviour is byte-for-byte identical on all supported inputs (alternations, empty `()`, no-group strings, multiple/quantified groups); only nested parentheses — which `regexify` explicitly does not support and no locale data uses — match differently.

### Additional information

- Determinism preserved: `sample` / `split` logic is untouched, output under a fixed seed is unchanged.
- Backward compatibility: no observable change for supported patterns; no public API change.
- A regression case (`(foo|bar|baz)`) was added to `test_regexify` to guard the alternation path.
- `bundle exec rake` is green: 2179 tests, 0 failures, 0 errors; RuboCop clean.

### Checklist

* [x] This Pull Request is related to one change only.
* [x] Commit message describes what changed and why, and references the issue (`[Fix #3183]`).
* [x] Tests are added or updated.
* [x] `bundle exec rake` (tests + RuboCop) passes locally.
* [x] No new generator/locale/feature; no CHANGELOG edits; determinism preserved.
