### PR TITLE
Replace broken via.placeholder.com with placehold.co

### DIFF
--- a/doc/default/omniauth.md
+++ b/doc/default/omniauth.md
@@ -215,7 +215,7 @@ Faker::Omniauth.github #=>
     :nickname => "jackson-keeling",
     :email => "jackson.keeling@example.com",
     :name => "Jackson Keeling",
-    :image => "https://via.placeholder.com/300x300.png",
+    :image => "https://placehold.co/300x300.png",
     :urls => {
       :GitHub => "https://github.com/jackson-keeling"
     }
@@ -228,7 +228,7 @@ Faker::Omniauth.github #=>
     :raw_info => {
       :login => "jackson-keeling",
       :id => "95144751",
-      :avatar_url => "https://via.placeholder.com/300x300.png",
+      :avatar_url => "https://placehold.co/300x300.png",
       :gravatar_id => "",
       :url => "https://api.github.com/users/jackson-keeling",
       :html_url => "https://github.com/jackson-keeling",
@@ -299,7 +299,7 @@ Faker::Omniauth.auth0 #=>
     :name => "auth0|d0584e3ab2d3816be9518a56",
     :nickname => "Thurman DuBuque",
     :email => "dubuque_thurman@example.com",
-    :image => "https://via.placeholder.com/300x300.png"
+    :image => "https://placehold.co/300x300.png"
   },
   :credentials=> {
     :expires_at => 1654345109,

--- a/doc/default/placeholdit.md
+++ b/doc/default/placeholdit.md
@@ -2,13 +2,13 @@
 
 ```ruby
 # Keyword arguments: size, format, background_color, text_color, text
-Faker::Placeholdit.image #=> "https://via.placeholder.com/300x300.png"
-Faker::Placeholdit.image(size: '50x50') #=> "https://via.placeholder.com/50x50.png"
-Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://via.placeholder.com/50x50.jpg"
-Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://via.placeholder.com/50x50.gif/ffffff"
-Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://via.placeholder.com/50x50.jpeg/39eba7"
-Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://via.placeholder.com/50x50.jpeg/ffffff/000"
-Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://via.placeholder.com/50x50.jpg/ffffff/000?text=Some Custom Text"
+Faker::Placeholdit.image #=> "https://placehold.co/300x300.png"
+Faker::Placeholdit.image(size: '50x50') #=> "https://placehold.co/50x50.png"
+Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://placehold.co/50x50.jpg"
+Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://placehold.co/50x50/ffffff.gif"
+Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://placehold.co/50x50/39eba7.jpeg"
+Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://placehold.co/50x50/ffffff/000.jpeg"
+Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://placehold.co/50x50/ffffff/000.jpg?text=Some Custom Text"
 ```
 
 ## Tips

--- a/lib/faker/default/placeholdit.rb
+++ b/lib/faker/default/placeholdit.rb
@@ -6,7 +6,7 @@ module Faker
       SUPPORTED_FORMATS = %w[png jpg gif jpeg].freeze
 
       ##
-      # Produces a random placeholder image from https://via.placeholder.com.
+      # Produces a random placeholder image from https://placehold.co.
       #
       # @param size [String] Specifies the image's size, dimensions separated by 'x'.
       # @param format [String] Specifies the image's extension.
@@ -17,13 +17,13 @@ module Faker
       #
       # @example
       #     # Keyword arguments: size, format, background_color, text_color, text
-      #   Faker::Placeholdit.image #=> "https://via.placeholder.com/300x300.png"
-      #   Faker::Placeholdit.image(size: '50x50') #=> "https://via.placeholder.com/50x50.png"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://via.placeholder.com/50x50.jpg"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://via.placeholder.com/50x50.gif/ffffff"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://via.placeholder.com/50x50.jpeg/39eba7"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://via.placeholder.com/50x50.jpeg/ffffff/000"
-      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://via.placeholder.com/50x50.jpg/ffffff/000?text=Some Custom Text"
+      #   Faker::Placeholdit.image #=> "https://placehold.co/300x300.png"
+      #   Faker::Placeholdit.image(size: '50x50') #=> "https://placehold.co/50x50.png"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg') #=> "https://placehold.co/50x50.jpg"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'gif', background_color: 'ffffff') #=> "https://placehold.co/50x50/ffffff.gif"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: :random) #=> "https://placehold.co/50x50/39eba7.jpeg"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "https://placehold.co/50x50/ffffff/000.jpeg"
+      #   Faker::Placeholdit.image(size: '50x50', format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "https://placehold.co/50x50/ffffff/000.jpg?text=Some Custom Text"
       #
       # @faker.version 1.6.0
       def image(size: '300x300', format: 'png', background_color: nil, text_color: nil, text: nil)
@@ -35,9 +35,10 @@ module Faker
         raise ArgumentError, "background_color must be a hex value without '#'" unless background_color.nil? || background_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
         raise ArgumentError, "text_color must be a hex value without '#'" unless text_color.nil? || text_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
 
-        image_url = "https://via.placeholder.com/#{size}.#{format}"
+        image_url = "https://placehold.co/#{size}"
         image_url += "/#{background_color}" if background_color
         image_url += "/#{text_color}" if text_color
+        image_url += ".#{format}"
         image_url += "?text=#{text}" if text
         image_url
       end

--- a/test/faker/default/test_placeholdit.rb
+++ b/test/faker/default/test_placeholdit.rb
@@ -8,11 +8,11 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_placeholdit
-    refute_nil @tester.image.match(%r{https://via\.placeholder\.com/(.+)(png?)})[1]
+    refute_nil @tester.image.match(%r{https://placehold\.co/(.+)\.(png)})[1]
   end
 
   def test_avatar_with_custom_size
-    assert_equal('3x3', @tester.image(size: '3x3').match(%r{https://via\.placeholder\.com/+(\d+x\d+)})[1])
+    assert_equal('3x3', @tester.image(size: '3x3').match(%r{https://placehold\.co/(\d+x\d+)\.})[1])
   end
 
   def test_avatar_with_incorrect_size
@@ -22,7 +22,7 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_with_supported_format
-    assert_match %r{https://via\.placeholder\.com/(.+)(jpg?)}, @tester.image(size: '300x300', format: 'jpg')
+    assert_match %r{https://placehold\.co/(.+)\.(jpg)}, @tester.image(size: '300x300', format: 'jpg')
   end
 
   def test_avatar_with_incorrect_format
@@ -32,15 +32,15 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_background_with_correct_six_char_hex
-    assert_match %r{https://via\.placeholder\.com/(.+)(jpg?)/ffffff}, @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff')
+    assert_match %r{https://placehold\.co/(.+)/ffffff\.(jpg?)}, @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff')
   end
 
   def test_avatar_background_with_correct_three_char_hex
-    assert_match %r{https://via\.placeholder\.com/(.+)(jpg?)/fff}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff')
+    assert_match %r{https://placehold\.co/(.+)/fff\.(jpg?)}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff')
   end
 
   def test_avatar_background_with_random_color
-    assert_match %r{https://via\.placeholder\.com/(.+)(jpg?)/[a-f0-9]{6}}, @tester.image(size: '300x300', format: 'jpg', background_color: :random)
+    assert_match %r{https://placehold\.co/(.+)/[a-f0-9]{6}\.(jpg?)}, @tester.image(size: '300x300', format: 'jpg', background_color: :random)
   end
 
   def test_avatar_background_with_wrong_six_char_hex
@@ -62,15 +62,15 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_avatar_font_color_with_correct_six_char_hex
-    assert_match %r{https://via\.placeholder\.com/(.+)(jpg?)/ffffff/000000}, @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '000000')
+    assert_match %r{https://placehold\.co/(.+)/ffffff/000000\.(jpg?)}, @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '000000')
   end
 
   def test_avatar_font_color_with_correct_three_char_hex
-    assert_match %r{https://via\.placeholder\.com/(.+)(jpg?)/fff}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000')
+    assert_match %r{https://placehold\.co/(.+)/fff/000\.(jpg?)}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000')
   end
 
   def test_avatar_font_color_with_random_color
-    assert_match %r{https://via\.placeholder\.com/(.+)(jpg?)/fff/[a-f0-9]{6}}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: :random)
+    assert_match %r{https://placehold\.co/(.+)/fff/[a-f0-9]{6}\.(jpg?)}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: :random)
   end
 
   def test_avatar_font_color_with_wrong_six_char_hex
@@ -92,10 +92,10 @@ class TestPlaceholdit < Test::Unit::TestCase
   end
 
   def test_text_not_present
-    assert_match %r{https://via\.placeholder\.com/[^\\?]+$}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000')
+    assert_match %r{https://placehold\.co/[^\\?]+$}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000')
   end
 
   def test_text_present
-    assert_match %r{https://via\.placeholder\.com/(.+)\?text=hello}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000', text: 'hello')
+    assert_match %r{https://placehold\.co/(.+)\?text=hello}, @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000', text: 'hello')
   end
 end


### PR DESCRIPTION
## Summary

The `via.placeholder.com` domain is no longer resolving, causing `Faker::Placeholdit` to generate broken image URLs.

This PR replaces it with [placehold.co](https://placehold.co), a working placeholder image service with a similar API.

Fixes #3055

## Changes

- **`lib/faker/default/placeholdit.rb`**: Updated URL generation to use `placehold.co` with its URL format (`/{size}/{bg}/{text}.{format}` instead of `/{size}.{format}/{bg}/{text}`)
- **`test/faker/default/test_placeholdit.rb`**: Updated all regex assertions to match the new URL structure
- **`doc/default/placeholdit.md`**: Updated example output URLs
- **`doc/default/omniauth.md`**: Updated placeholder image URLs in OmniAuth examples

## URL Format Comparison

| Scenario | Old (via.placeholder.com) | New (placehold.co) |
|---|---|---|
| Basic | `/{size}.{format}` | `/{size}.{format}` |
| With bg color | `/{size}.{format}/{bg}` | `/{size}/{bg}.{format}` |
| With bg + text color | `/{size}.{format}/{bg}/{text}` | `/{size}/{bg}/{text}.{format}` |
| With custom text | `...?text=hello` | `...?text=hello` |

## Testing

All 19 existing tests pass with updated assertions.