### PR TITLE
perf: Use memoized `I18n.locale_available?` in `Config.locale`

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -24,7 +24,10 @@ module Faker
 
       def locale
         # Because I18n.locale defaults to :en, if we don't have :en in our available_locales, errors will happen
-        Thread.current[:faker_config_locale] || @default_locale || (I18n.available_locales.include?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
+        # I18n.locale_available? is used here because it relies on a memoized
+        # set of locales, unlike I18n.available_locales which is recomputed
+        # on every call.
+        Thread.current[:faker_config_locale] || @default_locale || (I18n.locale_available?(I18n.locale) ? I18n.locale : I18n.available_locales.first)
       end
 
       def own_locale


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I want to improve the performance of the Faker gem.

This PR was generated using Claude Code with Fable 5. The change has been reviewed by me and tested by me.

`I18n.locale_available?` checks a memoized set of locales, unlike `I18n.available_locales` which rebuilds its array on every call, so the common case (the current I18n locale is available) no longer allocates.

### Additional information

Benchmark (Ruby 3.4.9, arm64-darwin25, benchmark-ips):

```rb
require 'benchmark/ips'
require 'faker'

Benchmark.ips do |x|
  x.config(warmup: 1, time: 2)
  x.report('Config.locale') { Faker::Config.locale }
end
```

Results:

    main:        Config.locale  178.877k (+/-16.1%) i/s
    this commit: Config.locale  992.950k (+/- 2.5%) i/s  (~5.5x)


Because `Config.locale` sits under `Base.translate`, the change speeds up essentially every generator:

```ruby
require 'benchmark/ips'
require 'faker'

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)
  x.report('Name.first_name') { Faker::Name.first_name }
  x.report('Name.name') { Faker::Name.name }
  x.report('Address.city') { Faker::Address.city }
  x.report('Lorem.word') { Faker::Lorem.word }
end
```

| Benchmark | main | this change | Speedup |
|---|---|---|---|
| `Name.first_name` | 30.534k (±1.1%) i/s | 90.615k (±3.0%) i/s | ~3.0x |
| `Name.name` | 18.497k (±3.4%) i/s | 55.295k (±2.1%) i/s | ~3.0x |
| `Address.city` | 21.859k (±1.2%) i/s | 60.335k (±5.1%) i/s | ~2.8x |
| `Lorem.word` | 126.049k (±0.6%) i/s | 383.438k (±1.2%) i/s | ~3.0x |

Note: These gains are independent of (and compound with) the other performance PRs I've opened, whose benchmarks were also measured against `main` without this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
