### PR TITLE
perf: Avoid unnecessary word-list copies in `Lorem.words`

### DIFF
--- a/lib/faker/default/lorem.rb
+++ b/lib/faker/default/lorem.rb
@@ -36,15 +36,16 @@ module Faker
       # @faker.version 2.1.3
       def words(number: 3, supplemental: false, exclude_words: nil)
         resolved_num = resolve(number)
-        word_list = (
-          translate('faker.lorem.words') +
-          (supplemental ? translate('faker.lorem.supplemental') : [])
-        )
+        word_list = translate('faker.lorem.words')
+        word_list += translate('faker.lorem.supplemental') if supplemental
         if exclude_words
           exclude_words = exclude_words.split(', ') if exclude_words.instance_of?(::String)
           word_list -= exclude_words
         end
-        word_list *= ((resolved_num / word_list.length) + 1)
+        # Duplicate the word list only when more words are requested than the
+        # list contains. Never mutate word_list itself: it may be the array
+        # cached by the I18n backend.
+        word_list *= ((resolved_num / word_list.length) + 1) if resolved_num > word_list.length
         sample(word_list, resolved_num)
       end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I want to make Faker more performant and use less memory when generating DB seeds and running automated tests.

This PR was generated using Claude Code with Fable 5. The change has been reviewed by me and tested by me.

Only concatenate the supplemental list when requested, and only duplicate the word list when more words are asked for than the list contains. The list returned by translate is never mutated, since it may be the array cached by the I18n backend.

### Additional information

Benchmark (Ruby 3.4.9, arm64-darwin25, benchmark-ips):

```rb
require 'benchmark/ips'
require 'faker'

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)
  x.report('words(number: 4)') { Faker::Lorem.words(number: 4) }
  x.report('sentence') { Faker::Lorem.sentence }
  x.report('paragraph') { Faker::Lorem.paragraph }
end
```

Results:

    main:        words(number: 4)  126.489k (+/- 2.2%) i/s
                 sentence           40.797k (+/- 4.4%) i/s
                 paragraph          12.455k (+/- 0.7%) i/s
    this commit: words(number: 4)  132.863k (+/- 1.0%) i/s  (~1.05x)
                 sentence           43.273k (+/- 0.4%) i/s  (~1.06x)
                 paragraph          12.733k (+/- 1.4%) i/s  (~1.02x)

These are only barely faster, but they are definitively faster. The main benefit of this PR is that it saves a lot of memory allocations/bytes.

- Ruby 3.4.9 (arm64-darwin25)
- memory_profiler 1.1.0
- Comparison is against `main` at `9b078038`, with only this change applied.

```ruby
require 'memory_profiler'
require 'faker'

BENCHES = {
  'words(number: 4)' => -> { Faker::Lorem.words(number: 4) },
  'words(number: 300)' => -> { Faker::Lorem.words(number: 300) },
  'sentence' => -> { Faker::Lorem.sentence },
  'paragraph' => -> { Faker::Lorem.paragraph }
}.freeze

# Warm up I18n translation caches so they don't count against the first bench
BENCHES.each_value(&:call)

N = 1000
BENCHES.each do |name, blk|
  report = MemoryProfiler.report { N.times { blk.call } }
  puts format('%-20s per call: %8.1f objects / %10.1f bytes',
              name,
              report.total_allocated.fdiv(N),
              report.total_allocated_memsize.fdiv(N))
end
```

## Results (per call, averaged over 1000 calls)

| Benchmark | main | this change | Bytes saved |
|---|---|---|---|
| `words(number: 4)` | 68 objects / 7,824 B | 65 objects / 3,720 B | **-52%** |
| `words(number: 300)` | 68 objects / 13,760 B | 66 objects / 11,688 B | -15% |
| `sentence` | 201 objects / 15,437 B | 198 objects / 11,335 B | -27% |
| `paragraph` | 672 objects / 50,204 B | 663 objects / 37,890 B | -25% |

Per Claude, confirmed by me: The object count barely moves (each eliminated array copy is a single object), but each copy carries a ~2KB buffer, so the small-`n` case drops ~4.1KB per call — over half its allocation footprint. For `words(number: 300)` the duplication is genuinely needed (300 words sampled from a 249-word list), so only the concatenation copy is saved.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
