### PR TITLE
chore: removing gender and name mismatch

### DIFF
--- a/lib/locales/en/name.yml
+++ b/lib/locales/en/name.yml
@@ -917,7 +917,6 @@ en:
         - Parker
         - Pasquale
         - Pat
-        - Patricia
         - Patrick
         - Paul
         - Pedro
@@ -1246,13 +1245,11 @@ en:
         - Adriane
         - Adrianna
         - Adrianne
-        - Adrien
         - Adriene
         - Adrienne
         - Afton
         - Agatha
         - Agnes
-        - Agnus
         - Agripina
         - Agueda
         - Agustina
@@ -1326,7 +1323,6 @@ en:
         - Alla
         - Alleen
         - Allegra
-        - Allen
         - Allena
         - Allene
         - Allie
@@ -1381,7 +1377,6 @@ en:
         - Anastasia
         - Andera
         - Andra
-        - Andre
         - Andrea
         - Andree
         - Andria
@@ -1400,7 +1395,6 @@ en:
         - Angelique
         - Angelita
         - Angella
-        - Angelo
         - Angelyn
         - Angie
         - Angila
@@ -1622,7 +1616,6 @@ en:
         - Bibi
         - Billi
         - Billie
-        - Billy
         - Billye
         - Birdie
         - Birgit
@@ -1649,7 +1642,6 @@ en:
         - Brandee
         - Brandi
         - Brandie
-        - Brandon
         - Brandy
         - Breana
         - Breann
@@ -1975,7 +1967,6 @@ en:
         - Clora
         - Clorinda
         - Clotilde
-        - Clyde
         - Codi
         - Cody
         - Colby
@@ -2070,7 +2061,6 @@ en:
         - Dani
         - Dania
         - Danica
-        - Daniel
         - Daniela
         - Daniele
         - Daniell
@@ -2079,7 +2069,6 @@ en:
         - Danika
         - Danille
         - Danita
-        - Dann
         - Danna
         - Dannette
         - Dannie
@@ -2103,7 +2092,6 @@ en:
         - Darlena
         - Darlene
         - Darline
-        - Darnell
         - Daryl
         - Davida
         - Davina
@@ -2114,7 +2102,6 @@ en:
         - Dayna
         - Daysi
         - Deadra
-        - Dean
         - Deana
         - Deandra
         - Deandrea
@@ -2177,7 +2164,6 @@ en:
         - Demetra
         - Demetria
         - Demetrice
-        - Demetrius
         - Dena
         - Denae
         - Deneen
@@ -2375,11 +2361,9 @@ en:
         - Ellena
         - Elli
         - Ellie
-        - Ellis
         - Elly
         - Ellyn
         - Elma
-        - Elmer
         - Elmira
         - Elna
         - Elnora
@@ -2478,7 +2462,6 @@ en:
         - Eustolia
         - Eva
         - Evalyn
-        - Evan
         - Evangelina
         - Evangeline
         - Eve
@@ -2563,14 +2546,11 @@ en:
         - Francine
         - Francis
         - Francisca
-        - Francisco
         - Francoise
         - Frankie
         - Fransisca
-        - Fred
         - Freda
         - Fredda
-        - Freddie
         - Frederica
         - Fredericka
         - Fredia
@@ -2627,7 +2607,6 @@ en:
         - Georgie
         - Georgina
         - Georgine
-        - Gerald
         - Geraldine
         - Geralyn
         - Gerda
@@ -2666,7 +2645,6 @@ en:
         - Glayds
         - Glenda
         - Glendora
-        - Glenn
         - Glenna
         - Glennie
         - Glennis
@@ -3019,7 +2997,6 @@ en:
         - Jill
         - Jillian
         - Jimmie
-        - Jimmy
         - Jin
         - Jina
         - Jinny
@@ -3038,9 +3015,7 @@ en:
         - Jodi
         - Jodie
         - Jody
-        - Joe
         - Joeann
-        - Joel
         - Joella
         - Joelle
         - Joellen
@@ -3067,7 +3042,6 @@ en:
         - Joline
         - Jolyn
         - Jolynn
-        - Jon
         - Jona
         - Jone
         - Jonell
@@ -3088,14 +3062,12 @@ en:
         - Josie
         - Joslyn
         - Josphine
-        - Jovan
         - Jovita
         - Joy
         - Joya
         - Joyce
         - Joycelyn
         - Joye
-        - Juan
         - Juana
         - Juanita
         - Jude
@@ -3120,7 +3092,6 @@ en:
         - Julieta
         - Julietta
         - Juliette
-        - Julio
         - Julissa
         - June
         - Jung
@@ -3172,7 +3143,6 @@ en:
         - Karine
         - Karisa
         - Karissa
-        - Karl
         - Karla
         - Karleen
         - Karlene
@@ -3357,7 +3327,6 @@ en:
         - Krystyna
         - Kum
         - Kyla
-        - Kyle
         - Kylee
         - Kylie
         - Kym
@@ -3417,7 +3386,6 @@ en:
         - Larita
         - Laronda
         - Larraine
-        - Larry
         - Larue
         - Lasandra
         - Lashanda
@@ -3535,7 +3503,6 @@ en:
         - Lenore
         - Leola
         - Leoma
-        - Leon
         - Leona
         - Leonarda
         - Leone
@@ -3932,7 +3899,6 @@ en:
         - Marquitta
         - Marry
         - Marsha
-        - Marshall
         - Marta
         - Marth
         - Martha
@@ -4121,7 +4087,6 @@ en:
         - Misti
         - Mistie
         - Misty
-        - Mitchell
         - Mitsue
         - Mitsuko
         - Mittie

--- a/lib/locales/en/name.yml
+++ b/lib/locales/en/name.yml
@@ -61,7 +61,6 @@ en:
         - Antoine
         - Anton
         - Antone
-        - Antonia
         - Antonio
         - Antony
         - Antwan
@@ -1276,7 +1275,6 @@ en:
         - Alanna
         - Alayna
         - Alba
-        - Albert
         - Alberta
         - Albertha
         - Albertina
@@ -2080,7 +2078,6 @@ en:
         - Dalila
         - Dallas
         - Damaris
-        - Dan
         - Dana
         - Danae
         - Danelle
@@ -2616,7 +2613,6 @@ en:
         - Galina
         - Garnet
         - Garnett
-        - Gary
         - Gay
         - Gaye
         - Gayla
@@ -2745,7 +2741,6 @@ en:
         - Hannah
         - Hannelore
         - Harmony
-        - Harold
         - Harriet
         - Harriett
         - Harriette
@@ -3120,7 +3115,6 @@ en:
         - Josefina
         - Josefine
         - Joselyn
-        - Joseph
         - Josephina
         - Josephine
         - Josette
@@ -3605,7 +3599,6 @@ en:
         - Lesli
         - Leslie
         - Lessie
-        - Lester
         - Leta
         - Letha
         - Leticia
@@ -3730,7 +3723,6 @@ en:
         - Louella
         - Louetta
         - Louie
-        - Louis
         - Louisa
         - Louise
         - Loura
@@ -3767,7 +3759,6 @@ en:
         - Lue
         - Luella
         - Luetta
-        - Luis
         - Luisa
         - Luise
         - Lula
@@ -4026,7 +4017,6 @@ en:
         - Mathilde
         - Matilda
         - Matilde
-        - Matthew
         - Mattie
         - Maud
         - Maude
@@ -4374,7 +4364,6 @@ en:
         - Oralia
         - Oretha
         - Orpha
-        - Oscar
         - Ossie
         - Otelia
         - Otha
@@ -4940,7 +4929,6 @@ en:
         - Soledad
         - Somer
         - Sommer
-        - Son
         - Sona
         - Sondra
         - Song
@@ -4982,7 +4970,6 @@ en:
         - Stephenie
         - Stephine
         - Stephnie
-        - Steven
         - Stevie
         - Stormy
         - Su
@@ -5244,7 +5231,6 @@ en:
         - Trisha
         - Trista
         - Tristan
-        - Troy
         - Trudi
         - Trudie
         - Trudy

--- a/lib/locales/en/name.yml
+++ b/lib/locales/en/name.yml
@@ -1242,7 +1242,6 @@ en:
         - Adena
         - Adina
         - Adria
-        - Adrian
         - Adriana
         - Adriane
         - Adrianna
@@ -1300,7 +1299,6 @@ en:
         - Alethia
         - Alex
         - Alexa
-        - Alexander
         - Alexandra
         - Alexandria
         - Alexia
@@ -1386,7 +1384,6 @@ en:
         - Andre
         - Andrea
         - Andree
-        - Andrew
         - Andria
         - Anette
         - Angel
@@ -1443,7 +1440,6 @@ en:
         - Annis
         - Annita
         - Annmarie
-        - Anthony
         - Antionette
         - Antoinette
         - Antonetta
@@ -1451,7 +1447,6 @@ en:
         - Antonia
         - Antonietta
         - Antonina
-        - Antonio
         - Anya
         - Apolonia
         - April
@@ -1497,7 +1492,6 @@ en:
         - Arnetta
         - Arnette
         - Arnita
-        - Arthur
         - Artie
         - Arvilla
         - Asha
@@ -1535,7 +1529,6 @@ en:
         - Aurelia
         - Aurora
         - Aurore
-        - Austin
         - Autumn
         - Ava
         - Avelina
@@ -1666,7 +1659,6 @@ en:
         - Brenda
         - Brenna
         - Brett
-        - Brian
         - Briana
         - Brianna
         - Brianne
@@ -1742,7 +1734,6 @@ en:
         - Carisa
         - Carissa
         - Carita
-        - Carl
         - Carla
         - Carlee
         - Carleen
@@ -1754,7 +1745,6 @@ en:
         - Carlie
         - Carline
         - Carlita
-        - Carlos
         - Carlota
         - Carlotta
         - Carly
@@ -1869,7 +1859,6 @@ en:
         - Charleen
         - Charlena
         - Charlene
-        - Charles
         - Charlesetta
         - Charlette
         - Charlie
@@ -1930,7 +1919,6 @@ en:
         - Christene
         - Christi
         - Christia
-        - Christian
         - Christiana
         - Christiane
         - Christie
@@ -1938,7 +1926,6 @@ en:
         - Christina
         - Christine
         - Christinia
-        - Christopher
         - Christy
         - Chrystal
         - Chu
@@ -1959,7 +1946,6 @@ en:
         - Claire
         - Clara
         - Clare
-        - Clarence
         - Claretha
         - Claretta
         - Claribel
@@ -2057,7 +2043,6 @@ en:
         - Crystal
         - Crystle
         - Cuc
-        - Curtis
         - Cyndi
         - Cyndy
         - Cynthia
@@ -2120,7 +2105,6 @@ en:
         - Darline
         - Darnell
         - Daryl
-        - David
         - Davida
         - Davina
         - Dawn
@@ -2204,7 +2188,6 @@ en:
         - Denisse
         - Denita
         - Denna
-        - Dennis
         - Dennise
         - Denny
         - Denyse
@@ -2257,7 +2240,6 @@ en:
         - Domitila
         - Domonique
         - Dona
-        - Donald
         - Donella
         - Donetta
         - Donette
@@ -2331,7 +2313,6 @@ en:
         - Edna
         - Edra
         - Edris
-        - Edward
         - Edwina
         - Edyth
         - Edythe
@@ -2447,7 +2428,6 @@ en:
         - Enriqueta
         - Epifania
         - Era
-        - Eric
         - Erica
         - Ericka
         - Erika
@@ -2485,7 +2465,6 @@ en:
         - Ettie
         - Eufemia
         - Eugena
-        - Eugene
         - Eugenia
         - Eugenie
         - Eula
@@ -2586,7 +2565,6 @@ en:
         - Francisca
         - Francisco
         - Francoise
-        - Frank
         - Frankie
         - Fransisca
         - Fred
@@ -2602,7 +2580,6 @@ en:
         - Frida
         - Frieda
         - Fumiko
-        - Gabriel
         - Gabriela
         - Gabriele
         - Gabriella
@@ -2637,7 +2614,6 @@ en:
         - Genny
         - Genoveva
         - Georgann
-        - George
         - Georgeann
         - Georgeanna
         - Georgene
@@ -2709,7 +2685,6 @@ en:
         - Grayce
         - Grazyna
         - Gregoria
-        - Gregory
         - Greta
         - Gretchen
         - Gretta
@@ -2765,7 +2740,6 @@ en:
         - Hellen
         - Henrietta
         - Henriette
-        - Henry
         - Herlinda
         - Herma
         - Hermelinda
@@ -2884,7 +2858,6 @@ en:
         - Jacelyn
         - Jacinda
         - Jacinta
-        - Jack
         - Jackeline
         - Jackelyn
         - Jacki
@@ -2917,7 +2890,6 @@ en:
         - Jama
         - Jame
         - Jamee
-        - James
         - Jamey
         - Jami
         - Jamie
@@ -2964,7 +2936,6 @@ en:
         - Jaquelyn
         - Jasmin
         - Jasmine
-        - Jason
         - Jaunita
         - Jay
         - Jaye
@@ -2993,7 +2964,6 @@ en:
         - Jeannie
         - Jeannine
         - Jeffie
-        - Jeffrey
         - Jen
         - Jena
         - Jenae
@@ -3020,7 +2990,6 @@ en:
         - Jennine
         - Jenny
         - Jeraldine
-        - Jeremy
         - Jeri
         - Jerica
         - Jerilyn
@@ -3081,7 +3050,6 @@ en:
         - Johana
         - Johanna
         - Johanne
-        - John
         - Johna
         - Johnetta
         - Johnette
@@ -3110,7 +3078,6 @@ en:
         - Jonna
         - Jonnie
         - Jordan
-        - Jose
         - Josefa
         - Josefina
         - Josefine
@@ -3118,7 +3085,6 @@ en:
         - Josephina
         - Josephine
         - Josette
-        - Joshua
         - Josie
         - Joslyn
         - Josphine
@@ -3142,7 +3108,6 @@ en:
         - Julene
         - Juli
         - Julia
-        - Julian
         - Juliana
         - Juliane
         - Juliann
@@ -3163,7 +3128,6 @@ en:
         - Junita
         - Junko
         - Justa
-        - Justin
         - Justina
         - Justine
         - Jutta
@@ -3292,7 +3256,6 @@ en:
         - Keila
         - Keira
         - Keisha
-        - Keith
         - Keitha
         - Keli
         - Kelle
@@ -3314,7 +3277,6 @@ en:
         - Kenia
         - Kenisha
         - Kenna
-        - Kenneth
         - Kenya
         - Kenyatta
         - Kenyetta
@@ -3329,7 +3291,6 @@ en:
         - Keshia
         - Keturah
         - Keva
-        - Kevin
         - Khadijah
         - Khalilah
         - Kia
@@ -3531,7 +3492,6 @@ en:
         - Lawana
         - Lawanda
         - Lawanna
-        - Lawrence
         - Layla
         - Layne
         - Le
@@ -3573,7 +3533,6 @@ en:
         - Lennie
         - Lenora
         - Lenore
-        - Leo
         - Leola
         - Leoma
         - Leon
@@ -3606,7 +3565,6 @@ en:
         - Letitia
         - Lettie
         - Letty
-        - Lewis
         - Lexie
         - Lezlie
         - Li
@@ -3952,7 +3910,6 @@ en:
         - Marivel
         - Marjorie
         - Marjory
-        - Mark
         - Marketta
         - Markita
         - Marla
@@ -3980,7 +3937,6 @@ en:
         - Marth
         - Martha
         - Marti
-        - Martin
         - Martina
         - Martine
         - Marty
@@ -4023,7 +3979,6 @@ en:
         - Maudie
         - Maura
         - Maureen
-        - Maurice
         - Maurine
         - Maurita
         - Mavis
@@ -4108,11 +4063,9 @@ en:
         - Micaela
         - Micah
         - Micha
-        - Michael
         - Michaela
         - Michaele
         - Michal
-        - Micheal
         - Michel
         - Michele
         - Michelina
@@ -4397,13 +4350,11 @@ en:
         - Patrica
         - Patrice
         - Patricia
-        - Patrick
         - Patrina
         - Patsy
         - Patti
         - Pattie
         - Patty
-        - Paul
         - Paula
         - Paulene
         - Pauletta
@@ -4429,7 +4380,6 @@ en:
         - Penny
         - Perla
         - Perry
-        - Peter
         - Petra
         - Petrina
         - Petronila
@@ -4499,7 +4449,6 @@ en:
         - Ray
         - Raye
         - Raylene
-        - Raymond
         - Raymonde
         - Rayna
         - Rea
@@ -5360,7 +5309,6 @@ en:
         - Vonda
         - Vonnie
         - Wai
-        - Walter
         - Waltraud
         - Wan
         - Wanda
@@ -5632,7 +5580,6 @@ en:
         - Cummings
         - Dach
         - D'Amore
-        - Daniel
         - Dare
         - Daugherty
         - Davis

--- a/lib/locales/en/name.yml
+++ b/lib/locales/en/name.yml
@@ -2203,7 +2203,6 @@ en:
         - Dina
         - Dinah
         - Dinorah
-        - Dion
         - Dione
         - Dionna
         - Dionne
@@ -3641,7 +3640,6 @@ en:
         - Louanne
         - Louella
         - Louetta
-        - Louie
         - Louisa
         - Louise
         - Loura
@@ -4398,7 +4396,6 @@ en:
         - Rasheeda
         - Rashida
         - Raven
-        - Ray
         - Raye
         - Raylene
         - Raymonde
@@ -5016,7 +5013,6 @@ en:
         - Thea
         - Theda
         - Thelma
-        - Theo
         - Theodora
         - Theola
         - Theresa

--- a/lib/locales/en/name.yml
+++ b/lib/locales/en/name.yml
@@ -436,7 +436,6 @@ en:
         - Forest
         - Forrest
         - Foster
-        - Frances
         - Francesco
         - Francis
         - Francisco
@@ -791,7 +790,6 @@ en:
         - Marcos
         - Marcus
         - Margarito
-        - Maria
         - Mariano
         - Mario
         - Marion
@@ -804,7 +802,6 @@ en:
         - Martin
         - Marty
         - Marvin
-        - Mary
         - Mason
         - Mathew
         - Matt
@@ -1629,7 +1626,6 @@ en:
         - Blythe
         - Bobbi
         - Bobbie
-        - Bobby
         - Bobbye
         - Bobette
         - Bok
@@ -2986,7 +2982,6 @@ en:
         - Jessie
         - Jessika
         - Jestine
-        - Jesus
         - Jesusa
         - Jesusita
         - Jetta
@@ -3031,7 +3026,6 @@ en:
         - Johnie
         - Johnna
         - Johnnie
-        - Johnny
         - Johnsie
         - Joi
         - Joie
@@ -3864,7 +3858,6 @@ en:
         - Marina
         - Marinda
         - Marine
-        - Mario
         - Marion
         - Maris
         - Marisa
@@ -3885,7 +3878,6 @@ en:
         - Marlen
         - Marlena
         - Marlene
-        - Marlin
         - Marline
         - Marlo
         - Marlyn
@@ -3998,7 +3990,6 @@ en:
         - Melonie
         - Melony
         - Melva
-        - Melvin
         - Melvina
         - Melynda
         - Mendy
@@ -4032,7 +4023,6 @@ en:
         - Michaela
         - Michaele
         - Michal
-        - Michel
         - Michele
         - Michelina
         - Micheline
@@ -4048,7 +4038,6 @@ en:
         - Miguelina
         - Mika
         - Mikaela
-        - Mike
         - Miki
         - Mikki
         - Mila
@@ -4238,7 +4227,6 @@ en:
         - Noriko
         - Norine
         - Norma
-        - Norman
         - Nova
         - Novella
         - Nu
@@ -4405,7 +4393,6 @@ en:
         - Randa
         - Randee
         - Randi
-        - Randy
         - Ranee
         - Raquel
         - Rasheeda
@@ -4470,7 +4457,6 @@ en:
         - Rhonda
         - Ria
         - Ricarda
-        - Richard
         - Richelle
         - Ricki
         - Rickie
@@ -4486,9 +4472,7 @@ en:
         - Robbin
         - Robbyn
         - Robena
-        - Robert
         - Roberta
-        - Roberto
         - Robin
         - Robyn
         - Rochel
@@ -4503,7 +4487,6 @@ en:
         - Romelia
         - Romona
         - Rona
-        - Ronald
         - Ronda
         - Roni
         - Ronna
@@ -4563,7 +4546,6 @@ en:
         - Roxanne
         - Roxie
         - Roxy
-        - Roy
         - Royce
         - Rozanne
         - Rozella
@@ -4573,7 +4555,6 @@ en:
         - Rubye
         - Rudy
         - Rufina
-        - Russell
         - Ruth
         - Rutha
         - Ruthann
@@ -4606,7 +4587,6 @@ en:
         - Samira
         - Sammie
         - Sammy
-        - Samuel
         - Sana
         - Sanda
         - Sandee
@@ -4621,7 +4601,6 @@ en:
         - Santa
         - Santana
         - Santina
-        - Santos
         - Sara
         - Sarah
         - Sarai
@@ -4637,9 +4616,6 @@ en:
         - Savannah
         - Scarlet
         - Scarlett
-        - Scott
-        - Scottie
-        - Sean
         - Season
         - Sebrina
         - See
@@ -4722,7 +4698,6 @@ en:
         - Sharyl
         - Sharyn
         - Shasta
-        - Shaun
         - Shauna
         - Shaunda
         - Shaunna
@@ -4880,7 +4855,6 @@ en:
         - Stephania
         - Stephanie
         - Stephany
-        - Stephen
         - Stephenie
         - Stephine
         - Stephnie
@@ -5027,7 +5001,6 @@ en:
         - Terina
         - Terisa
         - Terra
-        - Terrell
         - Terresa
         - Terri
         - Terrie
@@ -5077,7 +5050,6 @@ en:
         - Tilda
         - Tillie
         - Timika
-        - Timothy
         - Tina
         - Tinisha
         - Tiny
@@ -5086,7 +5058,6 @@ en:
         - Tisha
         - Tobi
         - Tobie
-        - Toby
         - Toccara
         - Toi
         - Tomasa
@@ -5095,7 +5066,6 @@ en:
         - Tomika
         - Tomiko
         - Tommie
-        - Tommy
         - Tommye
         - Tomoko
         - Tona
@@ -5128,7 +5098,6 @@ en:
         - Tracy
         - Tran
         - Trang
-        - Travis
         - Treasa
         - Treena
         - Trena
@@ -5144,7 +5113,6 @@ en:
         - Trish
         - Trisha
         - Trista
-        - Tristan
         - Trudi
         - Trudie
         - Trudy
@@ -5228,7 +5196,6 @@ en:
         - Vernice
         - Vernie
         - Vernita
-        - Vernon
         - Verona
         - Veronica
         - Veronika
@@ -5243,7 +5210,6 @@ en:
         - Vicki
         - Vickie
         - Vicky
-        - Victor
         - Victoria
         - Victorina
         - Vida
@@ -5260,7 +5226,6 @@ en:
         - Violette
         - Virgen
         - Virgie
-        - Virgil
         - Virgina
         - Virginia
         - Vita
@@ -5288,7 +5253,6 @@ en:
         - Wendolyn
         - Wendy
         - Wenona
-        - Wesley
         - Whitley
         - Whitney
         - Wilda
@@ -5300,7 +5264,6 @@ en:
         - Willetta
         - Willette
         - Willia
-        - William
         - Willie
         - Williemae
         - Willodean


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because first name and gender mismatch creates a scenario in which names seems to be generated randomly, not by gender (as coded).

### Additional information

Checked with [ChatGPT](https://chatgpt.com/share/6a4cfb9c-6918-83e9-8d10-13273e17d535) and Claude.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [x] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
