### PR TITLE
Fix bug on phone number generator for `nl` locale caused by incorrect .yml file structure

### DIFF
--- a/lib/locales/nl.yml
+++ b/lib/locales/nl.yml
@@ -33538,10 +33538,10 @@ nl:
       formats:
         - "(####) ######"
         - "##########"
-      cell_phone:
-        formats:
-          - '06########'
-          - '06 #### ####'
+    cell_phone:
+      formats:
+        - '06########'
+        - '06 #### ####'
     university:
       prefix:
         - Universiteit


### PR DESCRIPTION
Similar to https://github.com/faker-ruby/faker/pull/2924

Because the `cell_phone` entry in the `nl` locale was indented incorrectly, it could not be found when generating cell phone numbers using the dutch locale, causing it use the formats in `locales/en/phone_number` instead.