### PR TITLE
en-GB: Fix erroneous too strict rule for `id_number` (NI number)

### DIFF
--- a/lib/locales/en-GB.yml
+++ b/lib/locales/en-GB.yml
@@ -86,7 +86,7 @@ en-GB:
       default_country_code:
         - GB
     id_number:
-      valid: '/[A-CEGHJ-NOPR-TW-Z][ACEHJLMOPRSW][0-9]{6}[ABCD]/'
+      valid: '/[A-CEGHJ-NOPR-TW-Z][A-CEGHJ-NOPR-TW-Z][0-9]{6}[ABCD]/'
       invalid: '/(BG|GB|NK|KN|TN|NT|ZZ)[0-9]{6}[E-Z]{1}/'
     internet:
       domain_suffix:


### PR DESCRIPTION
I found this out by investigation that actually this would fail for a specific valid NI number (One that is known to be valid, but this system would detect it as invalid)

Original work / motivation from #3032 

### Motivation / Background

Fixed a bug whereby you cannot generate a valid NI number

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug, refactor something, or add a feature.
* [ ] Tests and Rubocop are passing before submitting your proposed changes.

If you're proposing a new generator or locale:

* [ ] Double-check the existing generators documentation to make sure the new generator you want to add doesn't already exist.
* [ ] You've reviewed and followed the [Contributing guidelines](https://github.com/faker-ruby/faker/blob/main/CONTRIBUTING.md).
